### PR TITLE
Move termsAccepted to its correct location

### DIFF
--- a/publoader/workers/uploader.py
+++ b/publoader/workers/uploader.py
@@ -241,9 +241,9 @@ class UploaderProcess:
                 "chapter": self.chapter.chapter_number,
                 "title": self.chapter.chapter_title,
                 "translatedLanguage": self.chapter.chapter_language,
-                "externalUrl": self.chapter.chapter_url,
-                "termsAccepted": True
+                "externalUrl": self.chapter.chapter_url
             },
+            "termsAccepted": True,
             "pageOrder": self.images_to_upload_ids
             if not self.failed_image_upload
             else [],


### PR DESCRIPTION
It should be in the root of the payload, not inside chapterDraft (whoops)