### PR TITLE
Revert the revert the revert the revert the revert the revert the revert

### DIFF
--- a/publoader/workers/uploader.py
+++ b/publoader/workers/uploader.py
@@ -246,6 +246,7 @@ class UploaderProcess:
             "pageOrder": (
                 self.images_to_upload_ids if not self.failed_image_upload else []
             ),
+            "termsAccepted": True
         }
 
         # if (


### PR DESCRIPTION
The API no longer bonks the bot due to the termsAccepted attribute (devs were lazy)