### PR TITLE
Allow indefinite pause (until /resume)

### DIFF
--- a/publoader/bot/server.py
+++ b/publoader/bot/server.py
@@ -353,10 +353,15 @@ class PubloaderBot(commands.Bot):
                 embed.add_field(name="Scheduled jobs", value=str(len(jobs)))
 
                 if status.get("paused"):
-                    mins = round((status.get("pause_remaining_seconds", 0) or 0) / 60, 1)
+                    remaining = status.get("pause_remaining_seconds")
+                    if status.get("pause_indefinite") or remaining is None:
+                        paused_value = ":pause_button: paused indefinitely (until `/resume`)"
+                    else:
+                        mins = round((remaining or 0) / 60, 1)
+                        paused_value = f":pause_button: resumes in ~{mins} min"
                     embed.add_field(
                         name="Paused",
-                        value=f":pause_button: resumes in ~{mins} min",
+                        value=paused_value,
                         inline=False,
                     )
 
@@ -1321,12 +1326,14 @@ def _register_commands(bot: PubloaderBot) -> None:
 
     @bot.tree.command(
         name="pause",
-        description="Pause scheduled runs, manual runs and workers for N minutes (admin-only).",
+        description="Pause scheduled runs, manual runs and workers (admin-only).",
     )
-    @app_commands.describe(minutes="How long to pause for (1-1440).")
+    @app_commands.describe(
+        minutes="How long to pause for (1-1440). Omit to pause indefinitely until /resume."
+    )
     async def _slash_pause(
         interaction: discord.Interaction,
-        minutes: app_commands.Range[int, 1, 1440],
+        minutes: Optional[app_commands.Range[int, 1, 1440]] = None,
     ):
         if not _is_admin(interaction.user):
             await interaction.response.send_message("Not allowed.", ephemeral=True)
@@ -1338,9 +1345,7 @@ def _register_commands(bot: PubloaderBot) -> None:
         if not _is_admin(ctx.author):
             await ctx.send("Not allowed.")
             return
-        if minutes is None:
-            await ctx.send("Usage: `!pause <minutes>` (1-1440).")
-            return
+        # No argument pauses indefinitely; pass minutes through when supplied.
         await bot._dispatch(ctx, "pause", minutes=minutes)
 
     @bot.tree.command(

--- a/publoader/dashboard/index.html
+++ b/publoader/dashboard/index.html
@@ -78,8 +78,9 @@
       <button onclick="run({force:true})">Force all</button>
       <button onclick="run({clean:true})">Clean run</button>
       <span style="width:14px"></span>
-      <input id="pauseMin" type="number" min="1" max="1440" value="60" style="width:80px">
+      <input id="pauseMin" type="number" min="0" max="1440" value="60" style="width:80px">
       <button onclick="pause()">Pause (min)</button>
+      <button onclick="pause(true)">Pause &#8734;</button>
       <button onclick="post('resume')">Resume</button>
       <span style="width:14px"></span>
       <button onclick="post('reload')">Reload</button>
@@ -186,7 +187,7 @@ function summarize(name, res){
 async function post(name, body){ const r = await apiPost(name, body); summarize(name, r); refreshAll(); return r; }
 async function confirmPost(name, msg, body){ if(!confirm(msg)) return {}; return post(name, body); }
 async function run(opts){ const r = await apiPost("run", opts); summarize("run", r); refreshAll(); }
-async function pause(){ const m = parseInt($("pauseMin").value,10)||60; const r = await apiPost("pause",{minutes:m}); summarize("pause", r); refreshStatus(); }
+async function pause(indefinite){ const m = indefinite ? 0 : (parseInt($("pauseMin").value,10)||60); const r = await apiPost("pause",{minutes:m}); summarize("pause", r); refreshStatus(); }
 
 // ---- renderers ----
 function kv(obj){
@@ -197,7 +198,8 @@ async function refreshStatus(){
   const s = await apiGet("status");
   if(s.ok===false){ $("status").textContent = s.error; return; }
   const paused = s.paused;
-  $("schedState").textContent = paused ? "paused "+Math.ceil((s.pause_remaining_seconds||0)/60)+"m" : "running";
+  const pauseLabel = (s.pause_indefinite || s.pause_remaining_seconds==null) ? "paused ∞" : "paused "+Math.ceil((s.pause_remaining_seconds||0)/60)+"m";
+  $("schedState").textContent = paused ? pauseLabel : "running";
   $("schedState").className = "pill "+(paused?"warn":"ok");
   let html = `<div class="muted">pid ${s.pid} · ${(s.jobs||[]).length} scheduled jobs</div>`;
   if(s.workers && s.workers.length){

--- a/run.py
+++ b/run.py
@@ -12,6 +12,7 @@ import time
 from datetime import time as dtTime, timezone
 from importlib import reload
 from pathlib import Path
+from typing import Optional
 
 from scheduler import Scheduler
 
@@ -68,10 +69,14 @@ _inflight_lock = threading.Lock()
 
 # Pause gate. While `time.time() < _pause_until` the scheduler skips its due
 # jobs and manual /run requests are rejected. Mirrored to the state DB setting
-# `pause_until` so a restart mid-pause still honours it. 0 = not paused.
+# `pause_until` so a restart mid-pause still honours it. 0 = not paused;
+# `float("inf")` = paused indefinitely (until an explicit /resume).
 _PAUSE_SETTING_KEY = "pause_until"
 _pause_lock = threading.Lock()
 _pause_until = 0.0
+# Sentinel deadline for an indefinite pause. Persists to the DB as the string
+# "inf" and round-trips cleanly through float().
+_INDEFINITE_PAUSE = float("inf")
 
 
 def _set_pause_until(epoch: float) -> None:
@@ -112,6 +117,20 @@ def _is_paused() -> bool:
 def _pause_remaining() -> float:
     with _pause_lock:
         return max(0.0, _pause_until - time.time())
+
+
+def _is_paused_indefinitely() -> bool:
+    with _pause_lock:
+        return _pause_until == _INDEFINITE_PAUSE
+
+
+def _pause_remaining_report() -> Optional[int]:
+    """Whole seconds until auto-resume for status payloads. None when paused
+    indefinitely (no deadline), 0 when not paused."""
+    remaining = _pause_remaining()
+    if remaining == _INDEFINITE_PAUSE:
+        return None
+    return int(remaining)
 
 
 def _claim_extensions(names):
@@ -564,7 +583,7 @@ def _setup_ipc_server(database_connection) -> IPCServer:
                 "queued": False,
                 "paused": True,
                 "error": "bot is paused",
-                "resumes_in_seconds": int(_pause_remaining()),
+                "resumes_in_seconds": _pause_remaining_report(),
             }
 
         extensions = req.get("extensions")
@@ -626,7 +645,8 @@ def _setup_ipc_server(database_connection) -> IPCServer:
             "jobs": [str(j) for j in getattr(sched, "jobs", [])] if sched else [],
             "workers": _worker_queue_lengths(database_connection),
             "paused": _is_paused(),
-            "pause_remaining_seconds": int(_pause_remaining()),
+            "pause_remaining_seconds": _pause_remaining_report(),
+            "pause_indefinite": _is_paused_indefinitely(),
         }
 
     def cmd_pull(req):
@@ -1070,6 +1090,18 @@ def _setup_ipc_server(database_connection) -> IPCServer:
 
     def cmd_pause(req):
         minutes = req.get("minutes")
+        # Omitting minutes (or passing 0/null) pauses indefinitely until /resume.
+        if minutes is None or minutes == 0:
+            _set_pause_until(_INDEFINITE_PAUSE)
+            return {
+                "ok": True,
+                "paused": True,
+                "minutes": None,
+                "indefinite": True,
+                "resumes_in_seconds": None,
+                "note": "paused indefinitely; scheduled runs, manual runs and worker "
+                "queue processing stay suspended until /resume.",
+            }
         try:
             minutes = int(minutes)
         except (TypeError, ValueError):
@@ -1082,7 +1114,8 @@ def _setup_ipc_server(database_connection) -> IPCServer:
             "ok": True,
             "paused": True,
             "minutes": minutes,
-            "resumes_in_seconds": int(_pause_remaining()),
+            "indefinite": False,
+            "resumes_in_seconds": _pause_remaining_report(),
             "note": "scheduled runs, manual runs and worker queue processing are all suspended.",
         }
 

--- a/tests/test_bot_control.py
+++ b/tests/test_bot_control.py
@@ -285,9 +285,49 @@ def test_pause_sets_deadline(paused_handlers):
 
 def test_pause_rejects_out_of_range(paused_handlers):
     h, _db = paused_handlers
-    assert h["pause"]({"minutes": 0})["ok"] is False
+    assert h["pause"]({"minutes": -5})["ok"] is False
     assert h["pause"]({"minutes": 5000})["ok"] is False
     assert h["pause"]({"minutes": "abc"})["ok"] is False
+
+
+def test_pause_indefinite_with_no_minutes(paused_handlers):
+    h, _db = paused_handlers
+    result = h["pause"]({})
+    assert result["ok"] is True
+    assert result["paused"] is True
+    assert result["indefinite"] is True
+    assert result["resumes_in_seconds"] is None
+    assert run_module._is_paused() is True
+    assert run_module._is_paused_indefinitely() is True
+
+
+def test_pause_indefinite_with_zero_minutes(paused_handlers):
+    h, _db = paused_handlers
+    result = h["pause"]({"minutes": 0})
+    assert result["ok"] is True
+    assert result["indefinite"] is True
+    assert run_module._is_paused_indefinitely() is True
+
+
+def test_status_reports_indefinite_pause(paused_handlers):
+    h, _db = paused_handlers
+    h["pause"]({})
+    status = h["status"]({})
+    assert status["paused"] is True
+    assert status["pause_indefinite"] is True
+    assert status["pause_remaining_seconds"] is None
+
+
+def test_indefinite_pause_persists_and_reloads(paused_handlers, monkeypatch):
+    h, _db = paused_handlers
+    # Reuse one store so the persisted deadline survives the reload.
+    store = _FakeStore()
+    monkeypatch.setattr(run_module, "get_state_store", lambda: store)
+    h["pause"]({})
+    assert store.settings["pause_until"] == "inf"
+    run_module._pause_until = 0.0
+    run_module._load_pause_until()
+    assert run_module._is_paused_indefinitely() is True
 
 
 def test_resume_clears_pause(paused_handlers):

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -92,6 +92,14 @@ def test_pause_flag_ignores_garbage(store):
     assert store.is_paused() is False
 
 
+def test_indefinite_pause_flag(store):
+    # The scheduler persists an indefinite pause as the string "inf"; workers
+    # must read that as "stay paused" rather than falling back to not-paused.
+    store.set_setting("pause_until", "inf")
+    assert store.get_pause_until() == float("inf")
+    assert store.is_paused() is True
+
+
 def test_exists_on_disk(tmp_path):
     db_path = tmp_path / "state.db"
     s = StateStore(db_path)


### PR DESCRIPTION
## What
Lets the bot be paused with **no time limit** — it stays paused until an explicit `/resume`. Previously `/pause` required 1–1440 minutes.

## How
- **Sentinel**: an indefinite pause sets the deadline to `float("inf")`, persisted to the state DB as the string `"inf"` so it survives a restart mid-pause. `/resume` clears it as before.
- **`run.py`** — `cmd_pause` treats missing/`0` minutes as indefinite; finite path still validates 1–1440. Status payloads now report `pause_remaining_seconds: null` + `pause_indefinite: true` for indefinite pauses (avoids `int(inf)` overflow).
- **`bot/server.py`** — `/pause` and `!pause` make `minutes` optional (omit → indefinite); status embed shows "paused indefinitely (until `/resume`)".
- **Dashboard** — new **Pause ∞** button; status pill renders `paused ∞`.
- **Workers** — no change needed; `state/store.is_paused()` round-trips `"inf"` as still-paused.

## Tests
Added coverage for indefinite pause (no/zero minutes, status reporting, DB persist+reload, and the `"inf"` store round-trip); updated the out-of-range test since `0` now means indefinite. Full suite: **165 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)