### PR TITLE
Proxy aiohttp-based extensions (SOCKS via aiohttp_socks)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -78,16 +78,30 @@ pool. `http(s)://` works out of the box; `socks5://` needs `requests[socks]`
 (add `PySocks` to `requirements.txt`). When `PROXIES` is set it takes precedence
 over the source-IP options below.
 
-An extension that sets its own `session.proxies`, or uses a non-`requests`
-client (`httpx`, `urllib`, raw sockets), is left alone. To force *everything* in
-the container through one proxy regardless of library, set standard proxy env
-vars on the `publoader` service instead (single proxy, no rotation):
+**aiohttp extensions** are covered too, but differently: aiohttp is a separate
+HTTP stack with no native SOCKS support, so publoader installs a second hook on
+`aiohttp.ClientSession.__init__` that gives each session an `aiohttp_socks`
+`ProxyConnector` built from a random proxy in the pool. This works for
+`socks5://`, `socks4://` and `http(s)://` — but rotation is **per session**, not
+per request (a `ClientSession` keeps its proxy for its lifetime). `aiohttp_socks`
+ships in `requirements.txt` for this. An extension that passes its own
+`connector=` is left alone.
+
+An extension that sets its own `session.proxies`/`connector`, or uses yet
+another client (`httpx`, `urllib`, raw sockets), is left alone. To force
+*everything* in the container through one proxy regardless of library, set
+standard proxy env vars on the `publoader` service instead — **single proxy, no
+rotation, and a single value only (not a comma-separated list)**:
 
 ```yaml
     environment:
       - HTTP_PROXY=http://user:pass@1.2.3.4:8080
       - HTTPS_PROXY=http://user:pass@1.2.3.4:8080
 ```
+
+Note: aiohttp ignores these env vars unless a session is created with
+`trust_env=True`, so the `ClientSession` hook above (not env vars) is what
+proxies aiohttp extensions.
 
 ### Source-IP rotation over a routed IPv6 subnet
 

--- a/publoader/http/rotation.py
+++ b/publoader/http/rotation.py
@@ -156,6 +156,65 @@ def install_global_proxy_rotation(proxy_pool) -> "bool":
     return True
 
 
+def install_global_aiohttp_proxy_rotation(proxy_pool) -> "bool":
+    """Route aiohttp ``ClientSession``s through a random proxy from the pool.
+
+    aiohttp is a separate HTTP stack from ``requests`` (some extensions use it)
+    and has **no native SOCKS support**, so a proxy can only be applied via an
+    ``aiohttp_socks`` ProxyConnector supplied when the session is constructed.
+    That means **per-session** rotation — a random proxy per ``ClientSession``,
+    not per request — for socks5://, socks4:// and http(s):// alike. Patching
+    ``ClientSession.__init__`` at the class level is the one hook that reaches
+    every aiohttp-based extension without touching its code.
+
+    No-op (returns False) when the pool is empty or aiohttp / aiohttp_socks
+    aren't installed — nothing in core publoader depends on them; they only
+    arrive alongside an extension that uses aiohttp. Idempotent; install once at
+    startup before extensions load (forked workers inherit the patch).
+    """
+    pool = [p.strip() for p in (proxy_pool or []) if p and p.strip()]
+    if not pool:
+        return False
+
+    try:
+        import aiohttp
+        from aiohttp_socks import ProxyConnector
+    except ImportError:
+        logger.warning(
+            "aiohttp proxy rotation requested but aiohttp/aiohttp_socks are not "
+            "installed; aiohttp-based extensions will NOT be proxied."
+        )
+        return False
+
+    original_init = aiohttp.ClientSession.__init__
+    if getattr(original_init, "_publoader_proxy_rotation", False):
+        return True
+
+    def __init__(self, *args, **kwargs):
+        # Respect an explicitly supplied connector; only inject one when the
+        # caller left it to aiohttp's default (a fresh connector is built per
+        # session, and the session owns/closes it as usual).
+        if kwargs.get("connector") is None:
+            proxy = random.choice(pool)
+            try:
+                kwargs["connector"] = ProxyConnector.from_url(proxy)
+            except Exception as e:
+                logger.error(
+                    "aiohttp proxy connector build failed for %r: %s", proxy, e
+                )
+        original_init(self, *args, **kwargs)
+
+    __init__._publoader_proxy_rotation = True
+    __init__._publoader_original = original_init
+    aiohttp.ClientSession.__init__ = __init__
+    logger.info(
+        "Global aiohttp proxy rotation installed across %d proxies "
+        "(per-session; extensions included).",
+        len(pool),
+    )
+    return True
+
+
 def apply_ip_rotation(
     session,
     *,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,9 @@ Pillow>=10
 pydantic
 PyGithub
 pymongo
-requests
+requests[socks]
 scheduler
+# SOCKS proxy support for aiohttp-based extensions (aiohttp has no native SOCKS).
+# Pulls in aiohttp; used by the global aiohttp proxy-rotation hook. Harmless when
+# [Network] PROXIES is unset.
+aiohttp_socks

--- a/run.py
+++ b/run.py
@@ -17,7 +17,10 @@ from typing import Optional
 from scheduler import Scheduler
 
 from publoader.github_webhook import GithubWebhookListener
-from publoader.http.rotation import install_global_proxy_rotation
+from publoader.http.rotation import (
+    install_global_aiohttp_proxy_rotation,
+    install_global_proxy_rotation,
+)
 from publoader.ipc import IPCServer, ipc_call, is_instance_running
 from publoader.state import get_state_store
 from publoader.updater import PubloaderUpdater
@@ -1282,8 +1285,11 @@ if __name__ == "__main__":
     # Route all in-process HTTP through the proxy pool (if configured) before
     # anything makes a request — this is what proxies the in-process extension
     # scrapers, not just the MangaDex client. Installed before workers fork so
-    # forked children inherit it. No-op when [Network] PROXIES is empty.
+    # forked children inherit it. No-op when [Network] PROXIES is empty. The
+    # requests hook covers requests/cloudscraper (per request); the aiohttp hook
+    # covers aiohttp-based extensions incl. SOCKS (per session, via aiohttp_socks).
     install_global_proxy_rotation(outgoing_proxies)
+    install_global_aiohttp_proxy_rotation(outgoing_proxies)
 
     database_connection = get_database_connection()
     worker.main(database_connection)

--- a/tests/test_ip_rotation.py
+++ b/tests/test_ip_rotation.py
@@ -15,6 +15,7 @@ from publoader.http.rotation import (
     RotatingSourceAddressAdapter,
     apply_ip_rotation,
     generate_ipv6_pool,
+    install_global_aiohttp_proxy_rotation,
     install_global_proxy_rotation,
 )
 
@@ -25,6 +26,16 @@ def restore_session_request():
     original = _sessions.Session.request
     yield
     _sessions.Session.request = original
+
+
+@pytest.fixture
+def restore_aiohttp_init():
+    """Undo the global aiohttp ClientSession.__init__ monkeypatch after a test."""
+    aiohttp = pytest.importorskip("aiohttp")
+    pytest.importorskip("aiohttp_socks")
+    original = aiohttp.ClientSession.__init__
+    yield aiohttp
+    aiohttp.ClientSession.__init__ = original
 
 
 def test_generate_ipv6_pool_within_subnet_and_distinct():
@@ -206,6 +217,59 @@ def test_global_proxy_rotation_idempotent(restore_session_request):
     # Second install doesn't stack another wrapper.
     assert install_global_proxy_rotation(["http://1.2.3.4:8080"]) is True
     assert _sessions.Session.request is patched
+
+
+def test_aiohttp_rotation_injects_socks_connector(restore_aiohttp_init):
+    import asyncio
+
+    from aiohttp_socks import ProxyConnector, ProxyType
+
+    aiohttp = restore_aiohttp_init
+    assert (
+        install_global_aiohttp_proxy_rotation(["socks5://user:pass@1.2.3.4:1080"])
+        is True
+    )
+
+    async def check():
+        session = aiohttp.ClientSession()
+        conn = session.connector
+        assert isinstance(conn, ProxyConnector)
+        assert conn._proxy_host == "1.2.3.4"
+        assert conn._proxy_port == 1080
+        assert conn._proxy_type == ProxyType.SOCKS5
+        await session.close()
+
+    asyncio.run(check())
+
+
+def test_aiohttp_rotation_respects_explicit_connector(restore_aiohttp_init):
+    import asyncio
+
+    aiohttp = restore_aiohttp_init
+    install_global_aiohttp_proxy_rotation(["socks5://1.2.3.4:1080"])
+
+    async def check():
+        own = aiohttp.TCPConnector()
+        session = aiohttp.ClientSession(connector=own)
+        assert session.connector is own  # caller's connector preserved
+        await session.close()
+
+    asyncio.run(check())
+
+
+def test_aiohttp_rotation_empty_pool_is_noop(restore_aiohttp_init):
+    aiohttp = restore_aiohttp_init
+    before = aiohttp.ClientSession.__init__
+    assert install_global_aiohttp_proxy_rotation([]) is False
+    assert aiohttp.ClientSession.__init__ is before
+
+
+def test_aiohttp_rotation_idempotent(restore_aiohttp_init):
+    aiohttp = restore_aiohttp_init
+    install_global_aiohttp_proxy_rotation(["socks5://1.2.3.4:1080"])
+    patched = aiohttp.ClientSession.__init__
+    assert install_global_aiohttp_proxy_rotation(["socks5://1.2.3.4:1080"]) is True
+    assert aiohttp.ClientSession.__init__ is patched
 
 
 def test_apply_rotation_bad_subnet_is_non_fatal():


### PR DESCRIPTION
## What
Follow-up to #15. The global proxy hook there patched `requests.Session.request`, which covers requests/cloudscraper extensions but **not** extensions that use `aiohttp` — a separate HTTP stack. And aiohttp has **no native SOCKS support**, so SOCKS proxies can only be applied via an `aiohttp_socks` connector set at session construction.

## How
- `install_global_aiohttp_proxy_rotation()` patches `aiohttp.ClientSession.__init__` to inject an `aiohttp_socks.ProxyConnector` (built from a random proxy in `[Network] PROXIES`) when the caller supplies no `connector`. Covers `socks5://`, `socks4://`, `http(s)://`.
- Rotation is **per-session** (a `ClientSession` holds its proxy for its lifetime) — the ceiling for aiohttp+SOCKS, since the proxy is bound to the connector.
- No-op when `aiohttp`/`aiohttp_socks` aren't installed or `PROXIES` is empty. Idempotent. Installed in `run.py` at startup next to the requests hook, before workers fork.
- Explicit `connector=` is respected.

## Requirements
- `requests` → `requests[socks]` (PySocks — enables SOCKS for the requests hook too).
- add `aiohttp_socks` (pulls aiohttp).

## Tests
4 new (`socks connector injection`, explicit-connector respected, empty-pool no-op, idempotent), guarded with `importorskip`. Full suite: **188 passed**. Connector injection also verified live inside an event loop (SOCKS5 host/port/type correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)