### PR TITLE
Spoof extension scraper headers to mimic a real browser session

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -59,6 +59,14 @@ SOURCE_IPS=
 # How many addresses to generate from SOURCE_IPV6_SUBNET.
 SOURCE_IP_POOL_SIZE=64
 #
+# Extension header spoofing. The in-process extension scrapers present as a real
+# browser (a fresh, self-consistent User-Agent + client-hint header set per
+# session) so third-party sites don't reject the default python-requests/aiohttp
+# User-Agent. On by default; set to false to send each extension's native
+# User-Agent instead. The MangaDex client is unaffected — it always identifies
+# honestly as publoader/<version>.
+SPOOF_EXTENSION_HEADERS=true
+#
 # Hosts that must NEVER be proxied (comma/space separated). The MongoDB host
 # from MONGODB_URI and localhost are excluded automatically, so DB traffic
 # always goes direct; add anything else here (e.g. a TLS cert's OCSP responder).

--- a/publoader/http/model.py
+++ b/publoader/http/model.py
@@ -35,6 +35,10 @@ class HTTPModel(metaclass=Singleton):
     def __init__(self) -> None:
         self.session = requests.Session()
         self.session.headers.update({"User-Agent": f"publoader/{__version__}"})
+        # Our own MangaDex traffic identifies honestly as publoader; opt it out
+        # of the browser-header spoofing that the extension scrapers get (see
+        # install_global_header_spoofing in http/rotation.py).
+        self.session._publoader_no_spoof = True
 
         # Optional outgoing-IP rotation to dodge per-IP rate-limit bans. Returns
         # the proxy pool to rotate per request (empty unless proxy mode is on);

--- a/publoader/http/rotation.py
+++ b/publoader/http/rotation.py
@@ -287,6 +287,217 @@ def install_global_aiohttp_proxy_rotation(proxy_pool) -> "bool":
     return True
 
 
+# ---------------------------------------------------------------------------
+# Extension header spoofing
+# ---------------------------------------------------------------------------
+#
+# The MangaDex client (HTTPModel) identifies honestly as ``publoader/<version>``
+# — that is the courteous, expected identity for our own API traffic and MUST
+# NOT be spoofed. The *extensions*, however, scrape third-party sites that fend
+# off bots by fingerprinting the default ``python-requests/x.y`` (or bare
+# aiohttp) User-Agent. Presenting a coherent, real-browser header set makes each
+# extension session look like an ordinary user's browser tab.
+#
+# Each profile below is internally consistent: the User-Agent, the ``Sec-CH-UA``
+# client-hint trio and the platform all describe the *same* browser/OS, because
+# a mismatched set (e.g. a Chrome UA with a Firefox-shaped header list) is itself
+# a bot tell. The MangaDex session opts out via the ``_publoader_no_spoof``
+# marker (see HTTPModel), so this never touches our first-party traffic.
+
+_BROWSER_PROFILES = (
+    {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        ),
+        "Sec-CH-UA": '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+        "Sec-CH-UA-Mobile": "?0",
+        "Sec-CH-UA-Platform": '"Windows"',
+    },
+    {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        ),
+        "Sec-CH-UA": '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+        "Sec-CH-UA-Mobile": "?0",
+        "Sec-CH-UA-Platform": '"macOS"',
+    },
+    {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) "
+            "Gecko/20100101 Firefox/133.0"
+        ),
+        # Firefox does not send Sec-CH-UA client hints.
+    },
+    {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) "
+            "Gecko/20100101 Firefox/133.0"
+        ),
+    },
+    {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+            "(KHTML, like Gecko) Version/18.1 Safari/605.1.15"
+        ),
+        # Safari does not send Sec-CH-UA client hints either.
+    },
+    {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0"
+        ),
+        "Sec-CH-UA": '"Microsoft Edge";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+        "Sec-CH-UA-Mobile": "?0",
+        "Sec-CH-UA-Platform": '"Windows"',
+    },
+    {
+        "User-Agent": (
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36"
+        ),
+        "Sec-CH-UA": '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+        "Sec-CH-UA-Mobile": "?1",
+        "Sec-CH-UA-Platform": '"Android"',
+    },
+)
+
+# Headers common to every profile — a normal browser sends these on essentially
+# every navigation regardless of engine.
+_COMMON_SPOOF_HEADERS = {
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,image/apng,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+}
+
+
+def random_browser_headers() -> "dict":
+    """Return a coherent, real-browser header set for one spoofed session.
+
+    Combines a randomly chosen browser/OS profile with the common navigation
+    headers. Every returned dict is self-consistent (UA matches the client-hint
+    headers), so a site fingerprinting the combination sees a plausible browser.
+    """
+    profile = random.choice(_BROWSER_PROFILES)
+    return {**_COMMON_SPOOF_HEADERS, **profile}
+
+
+def install_global_header_spoofing(enabled: "bool" = True) -> "bool":
+    """Make every in-process ``requests``/``cloudscraper`` session present as a
+    real browser, so extension scrapers dodge default-User-Agent bot filters.
+
+    Like the proxy hook, this patches ``requests.Session.request`` at the class
+    level — the single seam that reaches every extension without touching its
+    code. The first request a session makes picks one browser profile and pins
+    it onto ``session.headers`` (via ``setdefault``, so any header the extension
+    set itself always wins); every later request from that same session reuses
+    it. Pinning per session — rather than randomising per request — is the point:
+    a real user's browser keeps a stable identity for the life of a session, and
+    flipping User-Agent between requests would itself look automated.
+
+    Two sessions are left strictly alone: any marked ``_publoader_no_spoof``
+    (the MangaDex client, which must stay ``publoader/<version>``), and any that
+    already carries our spoof (idempotent per session). Install once at startup
+    before extensions load; forked workers inherit the patch. No-op when
+    disabled. Returns True if spoofing is active afterwards.
+    """
+    if not enabled:
+        return False
+
+    from requests import sessions as _sessions
+    from requests.utils import default_headers as _requests_default_headers
+
+    # requests pre-seeds every Session with User-Agent (``python-requests/x``),
+    # Accept, Accept-Encoding and Connection. Those library defaults are exactly
+    # the bot tells we want to overwrite — but a value the *extension* set is
+    # not, so we replace a header only when it is still at the library default
+    # (or absent), and leave anything customised alone.
+    _lib_defaults = _requests_default_headers()
+
+    original = _sessions.Session.request
+    if getattr(original, "_publoader_header_spoof", False):
+        return True
+
+    def request(self, method, url, **kwargs):
+        if not getattr(self, "_publoader_no_spoof", False) and not getattr(
+            self, "_publoader_spoof_applied", False
+        ):
+            for key, value in random_browser_headers().items():
+                current = self.headers.get(key)
+                if current is None or current == _lib_defaults.get(key):
+                    self.headers[key] = value
+            self._publoader_spoof_applied = True
+        return original(self, method, url, **kwargs)
+
+    request._publoader_header_spoof = True
+    request._publoader_original = original
+    _sessions.Session.request = request
+    msg = (
+        "Global header spoofing installed (requests/cloudscraper; per session; "
+        "extensions present as real browsers, MangaDex client exempt)."
+    )
+    logger.info(msg)
+    print(msg)
+    return True
+
+
+def install_global_aiohttp_header_spoofing(enabled: "bool" = True) -> "bool":
+    """Give every aiohttp ``ClientSession`` real-browser default headers.
+
+    aiohttp is a separate HTTP stack from ``requests`` (some extensions use it),
+    so it needs its own hook. Patching ``ClientSession.__init__`` injects a
+    randomly chosen browser profile as the session's default headers — one
+    identity per session, mirroring the requests hook. Any header the caller
+    passed to the constructor wins over ours (caller headers layer on top).
+
+    No MangaDex traffic goes through aiohttp, so there is no opt-out to honour
+    here. No-op (returns False) when disabled or aiohttp isn't installed —
+    nothing in core publoader depends on it; it only arrives with an extension.
+    Idempotent; install once at startup before extensions load.
+    """
+    if not enabled:
+        return False
+
+    try:
+        import aiohttp
+    except ImportError:
+        return False
+
+    original_init = aiohttp.ClientSession.__init__
+    if getattr(original_init, "_publoader_header_spoof", False):
+        return True
+
+    def __init__(self, *args, **kwargs):
+        # Layer our browser defaults *under* any headers the caller supplied,
+        # so an extension that sets its own headers is never overridden.
+        spoofed = random_browser_headers()
+        caller_headers = kwargs.get("headers")
+        if caller_headers:
+            spoofed.update(dict(caller_headers))
+        kwargs["headers"] = spoofed
+        original_init(self, *args, **kwargs)
+
+    __init__._publoader_header_spoof = True
+    __init__._publoader_original = original_init
+    aiohttp.ClientSession.__init__ = __init__
+    msg = (
+        "Global aiohttp header spoofing installed (per session; extensions "
+        "present as real browsers)."
+    )
+    logger.info(msg)
+    print(msg)
+    return True
+
+
 def apply_ip_rotation(
     session,
     *,

--- a/publoader/utils/config.py
+++ b/publoader/utils/config.py
@@ -189,6 +189,14 @@ except ValueError:
 if outgoing_source_pool_size < 1:
     outgoing_source_pool_size = 1
 
+# Whether the in-process extension scrapers spoof real-browser headers (a fresh
+# browser identity per session) to dodge default-User-Agent bot filters. The
+# MangaDex client always stays honest as publoader/<version> regardless. On by
+# default; set to a falsey value to send extensions' native User-Agent instead.
+spoof_extension_headers = (
+    _config_get("Network", "spoof_extension_headers", "true") or "true"
+).strip().lower() not in ("0", "false", "no", "off", "")
+
 
 def _mongo_hosts(uri: str) -> "list[str]":
     """Extract host name(s) from a MongoDB connection string, no DNS lookups.

--- a/run.py
+++ b/run.py
@@ -18,7 +18,9 @@ from scheduler import Scheduler
 
 from publoader.github_webhook import GithubWebhookListener
 from publoader.http.rotation import (
+    install_global_aiohttp_header_spoofing,
     install_global_aiohttp_proxy_rotation,
+    install_global_header_spoofing,
     install_global_proxy_rotation,
 )
 from publoader.ipc import IPCServer, ipc_call, is_instance_running
@@ -37,6 +39,7 @@ from publoader.utils.config import (
     github_webhook_secret,
     no_proxy_hosts,
     outgoing_proxies,
+    spoof_extension_headers,
 )
 from publoader.utils.utils import (
     get_current_datetime,
@@ -1293,6 +1296,14 @@ if __name__ == "__main__":
     # requests during TLS handshakes, which the hook would otherwise proxy.
     install_global_proxy_rotation(outgoing_proxies, no_proxy_hosts=no_proxy_hosts)
     install_global_aiohttp_proxy_rotation(outgoing_proxies)
+
+    # Make the in-process extension scrapers present as real browsers (a fresh
+    # browser identity per session) so third-party sites don't reject the
+    # default python-requests/aiohttp User-Agent. Installed alongside the proxy
+    # hooks, before workers fork. The MangaDex client stays honest as
+    # publoader/<version> (its session is marked _publoader_no_spoof).
+    install_global_header_spoofing(spoof_extension_headers)
+    install_global_aiohttp_header_spoofing(spoof_extension_headers)
 
     database_connection = get_database_connection()
     worker.main(database_connection)

--- a/tests/test_header_spoofing.py
+++ b/tests/test_header_spoofing.py
@@ -1,0 +1,202 @@
+"""Tests for extension header spoofing (publoader/http/rotation.py).
+
+Covers the browser-profile header set, the global ``requests.Session.request``
+spoof hook (per-session identity, caller-header precedence, the MangaDex
+opt-out, idempotency, disabled no-op), and the aiohttp ``ClientSession``
+spoof hook. No real network traffic is sent — a stub adapter answers requests
+locally.
+"""
+import asyncio
+
+import pytest
+import requests
+from requests.adapters import HTTPAdapter
+from requests.models import Response
+
+from requests import sessions as _sessions
+
+from publoader.http.rotation import (
+    install_global_aiohttp_header_spoofing,
+    install_global_header_spoofing,
+    random_browser_headers,
+)
+
+
+class _StubAdapter(HTTPAdapter):
+    """Answers every request with a canned 200 and records the sent headers."""
+
+    def __init__(self):
+        super().__init__()
+        self.last_headers = None
+
+    def send(self, request, **kwargs):
+        self.last_headers = request.headers
+        resp = Response()
+        resp.status_code = 200
+        resp._content = b""
+        resp.url = request.url
+        resp.request = request
+        return resp
+
+
+@pytest.fixture
+def restore_session_request():
+    """Undo the global Session.request monkeypatch after a test."""
+    original = _sessions.Session.request
+    yield
+    _sessions.Session.request = original
+
+
+@pytest.fixture
+def restore_aiohttp_init():
+    """Undo the global aiohttp ClientSession.__init__ monkeypatch after a test."""
+    aiohttp = pytest.importorskip("aiohttp")
+    original = aiohttp.ClientSession.__init__
+    yield aiohttp
+    aiohttp.ClientSession.__init__ = original
+
+
+def _stubbed_session():
+    """A Session whose transport is a local stub (no network)."""
+    session = requests.Session()
+    adapter = _StubAdapter()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session, adapter
+
+
+# --- random_browser_headers -------------------------------------------------
+
+
+def test_random_browser_headers_is_coherent():
+    for _ in range(30):
+        headers = random_browser_headers()
+        ua = headers["User-Agent"]
+        assert "python-requests" not in ua
+        assert headers["Accept-Language"].startswith("en")
+        assert headers["Accept-Encoding"]
+        # Client hints only ship on Chromium engines, and then must agree with
+        # the User-Agent's mobile-ness.
+        if "Sec-CH-UA" in headers:
+            assert "Chrome" in ua or "Edg" in ua
+            mobile = headers["Sec-CH-UA-Mobile"]
+            assert (mobile == "?1") == ("Mobile" in ua)
+        else:
+            # Firefox/Safari send neither the brand list nor the mobile hint.
+            assert "Sec-CH-UA-Mobile" not in headers
+
+
+# --- requests hook ----------------------------------------------------------
+
+
+def test_spoof_pins_browser_headers_on_session(restore_session_request):
+    assert install_global_header_spoofing(True) is True
+    session, adapter = _stubbed_session()
+
+    session.get("http://example.test/")
+
+    sent = adapter.last_headers
+    assert "python-requests" not in sent["User-Agent"]
+    assert sent["Accept-Language"].startswith("en")
+
+
+def test_spoof_identity_stable_across_requests(restore_session_request):
+    install_global_header_spoofing(True)
+    session, adapter = _stubbed_session()
+
+    session.get("http://example.test/one")
+    first = adapter.last_headers["User-Agent"]
+    session.get("http://example.test/two")
+    second = adapter.last_headers["User-Agent"]
+
+    # A real user's browser keeps one identity for the whole session.
+    assert first == second
+
+
+def test_spoof_respects_caller_headers(restore_session_request):
+    install_global_header_spoofing(True)
+    session, adapter = _stubbed_session()
+    session.headers["User-Agent"] = "my-extension/2.0"
+
+    session.get("http://example.test/")
+
+    # Header the extension set itself always wins over the spoof default.
+    assert adapter.last_headers["User-Agent"] == "my-extension/2.0"
+    # ...but unset headers are still filled in.
+    assert adapter.last_headers["Accept-Language"].startswith("en")
+
+
+def test_mangadex_session_is_not_spoofed(restore_session_request):
+    install_global_header_spoofing(True)
+    session, adapter = _stubbed_session()
+    session.headers["User-Agent"] = "publoader/9.9.9"
+    session._publoader_no_spoof = True
+
+    session.get("http://example.test/")
+
+    assert adapter.last_headers["User-Agent"] == "publoader/9.9.9"
+    # None of the browser navigation headers were added.
+    assert "Sec-Fetch-Mode" not in adapter.last_headers
+
+
+def test_spoof_disabled_is_noop(restore_session_request):
+    before = _sessions.Session.request
+    assert install_global_header_spoofing(False) is False
+    assert _sessions.Session.request is before
+
+
+def test_spoof_idempotent(restore_session_request):
+    install_global_header_spoofing(True)
+    patched = _sessions.Session.request
+    assert install_global_header_spoofing(True) is True
+    assert _sessions.Session.request is patched
+
+
+# --- aiohttp hook -----------------------------------------------------------
+
+
+def test_aiohttp_spoof_injects_default_headers(restore_aiohttp_init):
+    aiohttp = restore_aiohttp_init
+    install_global_aiohttp_header_spoofing(True)
+
+    async def check():
+        session = aiohttp.ClientSession()
+        headers = dict(session._default_headers)
+        await session.close()
+        return headers
+
+    headers = asyncio.run(check())
+    assert "python-requests" not in headers.get("User-Agent", "")
+    assert headers.get("User-Agent")
+    assert headers.get("Accept-Language", "").startswith("en")
+
+
+def test_aiohttp_spoof_caller_headers_win(restore_aiohttp_init):
+    aiohttp = restore_aiohttp_init
+    install_global_aiohttp_header_spoofing(True)
+
+    async def check():
+        session = aiohttp.ClientSession(headers={"User-Agent": "ext/1.0"})
+        headers = dict(session._default_headers)
+        await session.close()
+        return headers
+
+    headers = asyncio.run(check())
+    assert headers["User-Agent"] == "ext/1.0"
+    # Spoof still supplies the headers the caller didn't set.
+    assert headers.get("Accept-Language", "").startswith("en")
+
+
+def test_aiohttp_spoof_disabled_is_noop(restore_aiohttp_init):
+    aiohttp = restore_aiohttp_init
+    before = aiohttp.ClientSession.__init__
+    assert install_global_aiohttp_header_spoofing(False) is False
+    assert aiohttp.ClientSession.__init__ is before
+
+
+def test_aiohttp_spoof_idempotent(restore_aiohttp_init):
+    aiohttp = restore_aiohttp_init
+    install_global_aiohttp_header_spoofing(True)
+    patched = aiohttp.ClientSession.__init__
+    assert install_global_aiohttp_header_spoofing(True) is True
+    assert aiohttp.ClientSession.__init__ is patched


### PR DESCRIPTION
## What

The in-process extension scrapers make their own `requests`/`cloudscraper`/`aiohttp` calls. Sites that fingerprint the default `python-requests/x.y` (or bare aiohttp) User-Agent reject them as bots. This makes each extension session present as a coherent, real browser instead.

The **MangaDex client stays honest** — it still identifies as `publoader/<version>`. Only the third-party extension traffic is spoofed.

## How

Mirrors the existing proxy-rotation pattern in `publoader/http/rotation.py` (class-level monkeypatch of `Session.request` / `ClientSession.__init__`, the one seam that reaches every extension without touching its code):

- **`install_global_header_spoofing`** (requests/cloudscraper) and **`install_global_aiohttp_header_spoofing`** (aiohttp). Each session picks **one** internally-consistent browser profile — User-Agent + matching `Sec-CH-UA` client hints (Chromium only) + common navigation headers — and **pins it for the session's lifetime**. A stable per-session identity mimics a real user; flipping UA per request would itself look automated.
- Headers the extension set itself always win. Only the requests-library defaults (`python-requests` UA, `Accept`, `Accept-Encoding`) get overwritten.
- The MangaDex client (`HTTPModel`) opts out via a `_publoader_no_spoof` marker on its session.
- `[Network] SPOOF_EXTENSION_HEADERS` config toggle, **on by default**. Wired into `run.py` next to the proxy hooks, before workers fork so children inherit the patch.

## Tests

`tests/test_header_spoofing.py` — 11 new tests (profile coherence, per-session identity stability, caller-header precedence, MangaDex opt-out, disabled no-op, idempotency, aiohttp injection). No real network. Full suite: **209 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)