### PR TITLE
Add /kill command to kill all queued and running tasks

### DIFF
--- a/publoader/bot/server.py
+++ b/publoader/bot/server.py
@@ -1182,6 +1182,25 @@ def _register_commands(bot: PubloaderBot) -> None:
             return
         await bot._dispatch(ctx, "restart_workers")
 
+    # ----- /kill: drop queued tasks + abort worker processing -----
+
+    @bot.tree.command(
+        name="kill",
+        description="Kill all queued/running tasks: drop queued jobs and restart workers (admin-only).",
+    )
+    async def _slash_kill(interaction: discord.Interaction):
+        if not _is_admin(interaction.user):
+            await interaction.response.send_message("Not allowed.", ephemeral=True)
+            return
+        await bot._dispatch_slash(interaction, "kill_tasks")
+
+    @bot.command(name="kill")
+    async def _prefix_kill(ctx: commands.Context):
+        if not _is_admin(ctx.author):
+            await ctx.send("Not allowed.")
+            return
+        await bot._dispatch(ctx, "kill_tasks")
+
     # ----- /queue group: peek + clear worker queues -----
     queue_group = app_commands.Group(
         name="queue",

--- a/run.py
+++ b/run.py
@@ -947,6 +947,50 @@ def _setup_ipc_server(database_connection) -> IPCServer:
             return {"ok": False, "error": str(e)}
         return {"ok": True, "restarted": sorted(_worker_tables())}
 
+    def cmd_kill_tasks(_req):
+        """Kill every current task: drop all queued IPC jobs (releasing the
+        in-flight claims of dropped runs so they can be re-queued) and kill +
+        respawn the worker subprocesses to abort whatever they are processing.
+
+        A run already executing on the main thread can't be interrupted from
+        here — that needs a container `/restart` — so report it instead.
+        Queued Mongo documents are untouched; `/queue clear` handles those."""
+        dropped: dict = {}
+        while True:
+            try:
+                kind, payload = _ipc_jobs.get_nowait()
+            except queue.Empty:
+                break
+            dropped[kind] = dropped.get(kind, 0) + 1
+            if kind == JOB_RUN:
+                _release_extensions(payload.get("extension_names") or [])
+
+        try:
+            worker.kill()
+            worker.main(database_connection)
+            workers_restarted = True
+        except Exception as e:  # pragma: no cover - defensive
+            logger.exception("worker restart during kill_tasks failed")
+            workers_restarted = False
+            worker_error = str(e)
+        else:
+            worker_error = None
+
+        result = {
+            "ok": workers_restarted,
+            "dropped_jobs": dropped,
+            "workers_restarted": workers_restarted,
+            "run_in_progress": _run_lock.locked(),
+        }
+        if worker_error:
+            result["error"] = f"worker restart failed: {worker_error}"
+        if result["run_in_progress"]:
+            result["note"] = (
+                "an extension run is executing right now and can't be killed "
+                "in-place; use /restart to stop it."
+            )
+        return result
+
     def cmd_stats(_req):
         """Document counts for the worker queues plus the core collections."""
         out: dict = {"queues": {}, "collections": {}}
@@ -1151,6 +1195,7 @@ def _setup_ipc_server(database_connection) -> IPCServer:
     server.register("queue_peek", cmd_queue_peek)
     server.register("queue_clear", cmd_queue_clear)
     server.register("restart_workers", cmd_restart_workers)
+    server.register("kill_tasks", cmd_kill_tasks)
     server.register("stats", cmd_stats)
     server.register("config_show", cmd_config_show)
     server.register("config_set", cmd_config_set)

--- a/tests/test_bot_control.py
+++ b/tests/test_bot_control.py
@@ -432,3 +432,64 @@ def test_logout_when_no_token_file(tmp_path, handlers, monkeypatch):
     result = h["logout"]({})
     assert result["ok"] is True
     assert result["file_removed"] is False
+
+
+# ---------- kill_tasks ----------
+
+
+@pytest.fixture(autouse=True)
+def _reset_task_state():
+    # kill_tasks drains the module-global job queue and claim set; keep tests
+    # isolated from each other and from cmd_run's side effects.
+    yield
+    while not run_module._ipc_jobs.empty():
+        run_module._ipc_jobs.get_nowait()
+    with run_module._inflight_lock:
+        run_module._inflight_extensions.clear()
+
+
+def test_kill_tasks_drops_queued_jobs_and_releases_claims(handlers, monkeypatch):
+    h, _db = handlers
+    monkeypatch.setattr(run_module.worker, "kill", lambda: None)
+    monkeypatch.setattr(run_module.worker, "main", lambda *_a, **_k: None)
+
+    queued = h["run"]({"extensions": ["demo"]})
+    assert queued["queued"] is True
+    run_module._ipc_jobs.put((run_module.JOB_PULL, {"repos": ["extensions"]}))
+
+    result = h["kill_tasks"]({})
+    assert result["ok"] is True
+    assert result["dropped_jobs"] == {run_module.JOB_RUN: 1, run_module.JOB_PULL: 1}
+    assert result["workers_restarted"] is True
+    assert result["run_in_progress"] is False
+    assert run_module._ipc_jobs.empty()
+    # The dropped run's claim is released, so the extension can be re-queued.
+    assert h["run"]({"extensions": ["demo"]})["queued"] is True
+
+
+def test_kill_tasks_reports_run_in_progress(handlers, monkeypatch):
+    h, _db = handlers
+    monkeypatch.setattr(run_module.worker, "kill", lambda: None)
+    monkeypatch.setattr(run_module.worker, "main", lambda *_a, **_k: None)
+
+    assert run_module._run_lock.acquire(blocking=False)
+    try:
+        result = h["kill_tasks"]({})
+    finally:
+        run_module._run_lock.release()
+    assert result["ok"] is True
+    assert result["run_in_progress"] is True
+    assert "restart" in result["note"]
+
+
+def test_kill_tasks_reports_worker_restart_failure(handlers, monkeypatch):
+    h, _db = handlers
+
+    def _boom():
+        raise RuntimeError("no docker")
+
+    monkeypatch.setattr(run_module.worker, "kill", _boom)
+    result = h["kill_tasks"]({})
+    assert result["ok"] is False
+    assert result["workers_restarted"] is False
+    assert "no docker" in result["error"]


### PR DESCRIPTION
## Summary
- New `kill_tasks` IPC handler in `run.py`: drains every queued IPC job (run/pull/restart), releases the in-flight extension claims of dropped runs so they can be re-queued immediately, and kills + respawns the worker subprocesses to abort whatever they are currently processing.
- A run already executing on the scheduler's main thread cannot be interrupted from an IPC thread, so the handler reports `run_in_progress` and points the operator at `/restart` for that case.
- Queued Mongo documents are deliberately untouched — `/queue clear` already covers those.
- Exposed as admin-only `/kill` slash and `!kill` prefix commands in the Discord bot.

## Testing
- 3 new tests in `tests/test_bot_control.py` (drop + claim release, run-in-progress reporting, worker-restart failure).
- Full suite: 212 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)