### PR TITLE
Bound and back off the request retry loop on connection errors

### DIFF
--- a/publoader/http/model.py
+++ b/publoader/http/model.py
@@ -253,6 +253,14 @@ class HTTPModel(metaclass=Singleton):
                     continue
             except requests.RequestException as e:
                 logger.error(e)
+                # A connection-level failure never produces a response, so the
+                # counters below the try block are skipped — decrement here or
+                # a persistent outage (DNS failure, IP block, network down)
+                # spins this loop forever, hammering the API with no backoff.
+                retry -= 1
+                total_retry -= 1
+                if retry > 0 and total_retry > 0:
+                    time.sleep(min(90, 10 * run_number))
                 continue
 
             if (successful_codes and response.status_code not in successful_codes) or (

--- a/tests/test_request_retry.py
+++ b/tests/test_request_retry.py
@@ -1,0 +1,73 @@
+"""Tests for HTTPModel._request's connection-error retry behaviour.
+
+A RequestException (DNS failure, connection reset, IP block) produces no
+response, so the retry counters that live on the response path never ran —
+`except: continue` used to spin the `while retry > 0` loop forever, hammering
+the API with zero backoff. These tests pin the fixed behaviour: bounded
+attempts, backoff sleeps between them, and a RequestError once exhausted.
+No real network traffic is sent.
+"""
+import pytest
+import requests
+
+from publoader.http import model as model_module
+from publoader.http.model import HTTPModel
+from publoader.http.properties import RequestError
+
+
+@pytest.fixture
+def http_model():
+    return HTTPModel()
+
+
+def test_persistent_connection_error_raises_after_bounded_attempts(
+    http_model, monkeypatch
+):
+    attempts = []
+    sleeps = []
+
+    def failing_request(*args, **kwargs):
+        attempts.append(1)
+        raise requests.ConnectionError(
+            "HTTPSConnectionPool(host='api.mangadex.org', port=443): "
+            "Max retries exceeded with url: /manga"
+        )
+
+    monkeypatch.setattr(http_model.session, "request", failing_request)
+    monkeypatch.setattr(model_module.time, "sleep", lambda s: sleeps.append(s))
+
+    with pytest.raises(RequestError):
+        http_model._request("GET", "https://api.mangadex.org/manga")
+
+    assert len(attempts) == http_model.upload_retry_total
+    # Backoff between attempts, but not after the last one.
+    assert len(sleeps) == http_model.upload_retry_total - 1
+    assert all(s > 0 for s in sleeps)
+
+
+def test_connection_error_then_success_returns_response(http_model, monkeypatch):
+    calls = {"n": 0}
+
+    class FakeResponse:
+        status_code = 200
+        headers = {"x-ratelimit-retry-after": "0", "x-ratelimit-remaining": "10"}
+        url = "https://api.mangadex.org/manga"
+
+        def json(self):
+            return {"result": "ok", "data": []}
+
+    def flaky_request(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise requests.ConnectionError("first attempt fails")
+        return FakeResponse()
+
+    monkeypatch.setattr(http_model.session, "request", flaky_request)
+    monkeypatch.setattr(model_module.time, "sleep", lambda s: None)
+
+    response = http_model._request(
+        "GET", "https://api.mangadex.org/manga", sleep=False
+    )
+
+    assert calls["n"] == 2
+    assert response.status_code == 200


### PR DESCRIPTION
## Why

`[publoader] ERROR: HTTPSConnectionPool(host='api.mangadex.org', port=443): Max retries exceeded with url: /manga?ids[]=...` was spamming the production log. Tracing it:

- `HTTPModel._request` catches `requests.RequestException` with a bare `logger.error(e); continue` — but `retry -= 1` / `total_retry -= 1` only run on the response path. A connection-level failure therefore **never decrements the counters**, so `while retry > 0` spins forever with **zero backoff**: publoader hammers MangaDex as fast as connections can fail, flooding the log and making any edge-level IP block worse.

## What

- Decrement both retry counters in the `except` branch and sleep between attempts (10s ramp per attempt, capped at 90s — the same ceiling the 429 path uses). A persistent outage now exhausts the retry budget and raises `RequestError` like every other failure mode; a transient blip recovers on the next attempt.
- Regression tests: persistent connection errors raise `RequestError` after exactly `upload_retry_total` attempts with backoff sleeps in between; a single failure followed by success returns the response.

## Notes from the investigation

- The failing `/manga?ids[]=...` request itself is legal: MangaDex caps the ids filter at 100 per request and `_get_manga_data_md` has chunked at 100 since 2023. Verified live: 100 ids = HTTP 200 (4.8KB URL); 200 ids = HTTP **414 Request-URI Too Large** (~8KB URL limit). So the log spam was the retry loop, not an oversized request from current code.
- `python3 -m pytest`: 131 passed, 4 skipped (missing optional `aiohttp_socks`); the files that don't collect locally (`lib.GEN_EMAIL` pyOpenSSL/cryptography clash) fail identically on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)