### PR TITLE
Give the scheduler container public DNS to bypass LAN filtering

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,15 @@ services:
     # compose network, i.e. the cloudflared tunnel below.
     expose:
       - "8080"
+    # Public resolvers instead of the LAN's DNS. The home network's filtering
+    # resolver sinkholes mangadex.org (answers `::`/0.0.0.0), so every MangaDex
+    # call died with "Connection refused" the moment an extension run started.
+    # This bypasses the filter for this container only; compose service names
+    # (publoader, cloudflared, ...) still resolve via Docker's embedded DNS,
+    # which forwards to these servers only for external names.
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     volumes:
       - ./config.ini:/app/config.ini
       - ./logs:/app/logs


### PR DESCRIPTION
## Why

The production bot's MangaDex calls were failing with `[Errno 111] Connection refused`. Diagnosis (see the request replay + DNS checks): the LAN's filtering resolver sinkholes `mangadex.org` — inside the container `getent hosts api.mangadex.org` returned `::` (the AAAA equivalent of `0.0.0.0`), so the bot was connecting to itself on :443. The correct answer is `45.129.229.1`/`45.129.229.2` via `dxlb.mangadex.org`, and the exact failing 100-id `/manga` request returns HTTP 200 when resolved properly.

## What

Adds `dns: [1.1.1.1, 8.8.8.8]` to the `publoader` service only — the container that talks to MangaDex and runs the extension scrapers. Compose service-name resolution (`publoader`, `cloudflared`, ...) is unaffected: Docker's embedded DNS handles the compose network and forwards only external names to these resolvers. The bot/dash/tunnel containers keep the host's DNS.

Apply with `docker compose up -d` (recreates the container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)