### PR TITLE
Default the compose files to the multi-arch images

### DIFF
--- a/platform/docker/core/.env.production.example
+++ b/platform/docker/core/.env.production.example
@@ -21,8 +21,8 @@
 PUBLOADER_ENV=prod
 
 # --- images (PINNED — bump deliberately, never track `latest`) --------------
-PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.0.2
-PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.0.2
+PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.1
+PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.1
 
 # --- database --------------------------------------------------------------
 POSTGRES_USER=publoader

--- a/platform/docker/core/docker-compose.yml
+++ b/platform/docker/core/docker-compose.yml
@@ -90,7 +90,7 @@ x-core-build: &core-build
   # referencing the same `image:` tag everywhere means all four are guaranteed
   # to run the identical build — a mixed-version control plane is a class of
   # bug that is very hard to see.
-  image: ${PUBLOADER_CORE_IMAGE:-ardax/publoader-core:2.0.0}
+  image: ${PUBLOADER_CORE_IMAGE:-ardax/publoader-core:2.1.1}
   build:
     context: ../../..
     dockerfile: platform/docker/core/Dockerfile
@@ -162,7 +162,7 @@ services:
       context: ../../..
       dockerfile: platform/docker/core/Dockerfile
       target: migrate
-    image: ${PUBLOADER_MIGRATE_IMAGE:-ardax/publoader-core-migrate:2.0.0}
+    image: ${PUBLOADER_MIGRATE_IMAGE:-ardax/publoader-core-migrate:2.1.1}
     restart: "no"
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://publoader:${POSTGRES_PASSWORD}@postgres:5432/publoader?schema=public&connection_limit=5}

--- a/platform/docker/worker/docker-compose.yml
+++ b/platform/docker/worker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     # Built from this repo by default. Once images are published, set
     # PUBLOADER_WORKER_IMAGE to a digest-pinned tag in .env and remove nothing
     # else — worker hosts should not need a source checkout to run.
-    image: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.0.0}
+    image: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.1}
     build:
       context: ../..
       dockerfile: docker/worker/Dockerfile


### PR DESCRIPTION
The published 2.0.x and 2.1.0 images were built on an arm64 machine and pushed single-arch, so an x86_64 server pulling them got an arm64 binary. The symptom is `exec ./node_modules/.bin/prisma: exec format error` and `migrate` exiting 255 — which reads like a Prisma failure and is really a CPU architecture mismatch.

2.1.1 is built for linux/amd64 and linux/arm64 and is now the default in all three compose files. This matters more than a version bump normally would, because the default is what a deployment gets when its `.env` does not pin the images — which is the common case and was silently landing on an arm64-only tag.

Verified on amd64 rather than trusting the manifest, since Prisma ships native engines and a multi-arch manifest says nothing about what is inside: the amd64 migrate image applied all 9 migrations to a real database, and the amd64 core image served /healthz, /readyz and /dash. `binaryTargets` already carried both `debian-openssl-3.0.x` and `linux-arm64-openssl-3.0.x`, which is why one build covers both.

Note for anyone hitting this: `.env` overrides the compose default, so `docker compose pull` alone does not move a deployment off a bad tag, and docker caches by tag — an already-pulled arm64 image is reused until it is removed.