### PR TITLE
Fix lost envelopes on large runs, and the API's missing MangaDex credentials

### DIFF
--- a/docker/core/docker-compose.yml
+++ b/docker/core/docker-compose.yml
@@ -187,12 +187,25 @@ services:
   # host would put the enroll endpoint and the admin API on the host's
   # interfaces, reachable without passing the tunnel's WAF rules.
   core-api:
-    <<: [*app-security, *core-build]
+    # `public-dns` for the same reason core-uploader has it: this service now
+    # reaches MangaDex directly.
+    <<: [*app-security, *core-build, *public-dns]
     depends_on:
       migrate:
         condition: service_completed_successfully
     environment:
-      <<: *core-env
+      # MangaDex credentials, for the two operator actions that touch a title
+      # synchronously: approving an untracked series (which must create the title
+      # and hand back its id) and pushing corrections to an existing entry.
+      # Without them both endpoints answer 503 "title service not available on
+      # this instance", which reads like a broken deployment rather than a
+      # missing variable.
+      #
+      # This does widen what an internet-facing service holds, so to be precise
+      # about what has NOT changed: uploading chapters remains core-uploader's
+      # alone — it owns the upload queue and the upload session, and no other
+      # process claims from it.
+      <<: [*core-env, *md-env]
       PORT: "8100"
       HOST: 0.0.0.0
       # Metrics are NOT on 8100. The tunnel forwards every path on the public

--- a/runner-node/runner.mjs
+++ b/runner-node/runner.mjs
@@ -811,8 +811,29 @@ function durationS(startedAt) {
   return Math.round(performance.now() - startedAt) / 1000;
 }
 
+/**
+ * Write the envelope and WAIT for it to reach the OS.
+ *
+ * `process.stdout.write` to a pipe is asynchronous: past the pipe buffer
+ * (~64 KiB on Linux) it queues the rest and returns false, and `process.exit()`
+ * discards whatever is still queued. The agent captures stdout, so it is always
+ * a pipe — and a CLEAN run returns the extension's whole catalogue, which for a
+ * thousand-series extension is far over that buffer.
+ *
+ * The result was a runner that exited 0 having printed nothing the agent could
+ * find: "runner exited 0/null without an envelope", reported as TRANSIENT and
+ * retried forever, with the size of the answer deciding whether it happened.
+ * Small UPDATE runs fit in the buffer and always worked, which is why this hid.
+ */
 function emit(payload) {
-  emitLine(JSON.stringify(payload) + "\n");
+  const line = JSON.stringify(payload) + "\n";
+  return new Promise((resolve) => {
+    // The callback fires once the chunk is flushed, not merely accepted.
+    if (!emitLine(line, () => resolve())) return;
+    // Fully buffered: the callback still runs, but resolving here too keeps the
+    // common small-envelope path from waiting a tick.
+    resolve();
+  });
 }
 
 async function main() {
@@ -839,8 +860,8 @@ async function main() {
     const budgetS = Number(job.timeoutSeconds);
     if (Number.isFinite(budgetS) && budgetS > 0) {
       const timer = setTimeout(
-        () => {
-          emit(
+        async () => {
+          await emit(
             errorEnvelope("TRANSIENT", `collect() exceeded the ${budgetS}s job budget`, startedAt),
           );
           process.exit(0);
@@ -859,12 +880,12 @@ async function main() {
     // of the wrong shape: all properties of the pinned bundle, so a retry
     // cannot help. A throw from inside collect() is usually the upstream site.
     const errClass = err instanceof Error && err.publoaderPhase === "run" ? "TRANSIENT" : "PERMANENT";
-    emit(errorEnvelope(errClass, `${name}: ${message}`, startedAt));
+    await emit(errorEnvelope(errClass, `${name}: ${message}`, startedAt));
     return 0;
   }
 
   const { httpRequests, ...envelopeFields } = result;
-  emit({
+  await emit({
     runnerVersion: RUNNER_VERSION,
     status: "ok",
     error: null,

--- a/test/e2e/fixtures/e2etest/index.mjs
+++ b/test/e2e/fixtures/e2etest/index.mjs
@@ -15,6 +15,13 @@
 const MANGA_ID = "m1";
 const SLOW_MARKER = "slow";
 const SLOW_MS = 90_000;
+/**
+ * Marker that makes this fixture return a catalogue too large for a pipe
+ * buffer. A real CLEAN run over a thousand-series extension does the same thing
+ * naturally; this reproduces it deterministically and in a fraction of a second.
+ */
+const BULK_MARKER = "bulk";
+const BULK_CHAPTERS = 4000;
 
 /** An ExtensionFactory: takes the context, returns something with collect(). */
 const factory = (ctx) => ({
@@ -28,8 +35,14 @@ const factory = (ctx) => ({
     const now = new Date();
     const expire = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
 
+    // Bulk mode returns a catalogue too large for a pipe buffer, which is what
+    // a real CLEAN run over a thousand-series extension produces naturally.
+    const numbers = ctx.mangaIdMap.has(BULK_MARKER)
+      ? Array.from({ length: BULK_CHAPTERS }, (_, i) => String(i + 1))
+      : ["1", "2"];
+
     const updatedChapters = [];
-    for (const number of ["1", "2"]) {
+    for (const number of numbers) {
       const chapterId = `c${number}`;
       if (posted.has(chapterId)) continue;
       updatedChapters.push({

--- a/test/unit/nodeRunner.test.ts
+++ b/test/unit/nodeRunner.test.ts
@@ -208,3 +208,32 @@ describe("node runner", () => {
     expect(envelope.status).toBe("ok");
   });
 });
+
+describe("large envelopes", () => {
+  /**
+   * The runner writes its envelope to stdout and then calls `process.exit()`.
+   * stdout to a pipe — which is always the case, because the agent captures it —
+   * is asynchronous: past the pipe buffer (~64 KiB) `write()` queues the rest and
+   * returns false, and `process.exit()` discards whatever is still queued.
+   *
+   * The result was a runner that exited 0 having printed a truncated line the
+   * agent could not parse: "runner exited 0/null without an envelope", classed
+   * TRANSIENT and retried forever. It only happened when the answer was big, so
+   * ordinary UPDATE runs always worked and a CLEAN run over a large catalogue
+   * did not.
+   */
+  it("delivers an envelope far larger than the pipe buffer", async () => {
+    const envelope = await runFixture({
+      kind: "CLEAN",
+      mangaIdMap: { [MD_MANGA_ID]: ["m1", "bulk"] },
+    });
+
+    expect(envelope.status).toBe("ok");
+    expect(envelope.updatedChapters.length).toBeGreaterThan(1000);
+
+    // The assertion that matters is the size: anything under the buffer would
+    // pass whether or not the flush is awaited.
+    const bytes = Buffer.byteLength(JSON.stringify(envelope));
+    expect(bytes, "envelope is too small to exercise the bug").toBeGreaterThan(256 * 1024);
+  });
+});


### PR DESCRIPTION
Two failures seen on the running stack.

## `runner exited 0/null without an envelope`

Not a crash — a lost write. `process.stdout.write` to a pipe is asynchronous:
past the pipe buffer (~64 KiB) it queues the remainder and returns false, and
`process.exit()` discards whatever is still queued. The agent captures stdout, so
it is always a pipe, and a CLEAN run returns the extension's whole catalogue,
which for a thousand-series extension is hundreds of kilobytes.

The agent therefore received a truncated line, could not parse it, classed the
run TRANSIENT, retried, and truncated identically. The size of the answer decided
whether it happened, which is why it stayed hidden: ordinary UPDATE runs are a
few chapters and fit in the buffer every time.

`emit` now resolves only once the write is flushed and every caller awaits it.
Reproduced in isolation first — a 500 KB write followed by `process.exit()`
delivers exactly 65536 bytes. The regression test drives the real runner as a
subprocess against a fixture returning 4000 chapters and asserts the envelope
arrives intact; confirmed it fails without the fix, since a test that never saw
the bug would pass on a small envelope either way.

## `title service not available on this instance`

The compose passed the MangaDex environment to core-uploader only, so
`config.mdUsername` was empty in core-api and `ctx.titleService` was never built.
Approving an untracked series and pushing corrections to an existing entry both
answered 503, which reads like a broken deployment rather than a missing
variable.

Neither could be deferred to the uploader. Approve creates the title and hands
back its id to a waiting human, and the uploader's own pass deliberately skips
these rows — `tick()` only auto-creates for extensions with `auto_create_titles`,
and an extension that requires approval is by definition not one, so a queued row
would sit NEW forever.

The code always intended this: services/api.ts builds the title service whenever
credentials are present and says so. The compose was out of step.

It does widen what an internet-facing service holds, so to be precise about what
has not changed: uploading chapters remains core-uploader's alone — it owns the
upload queue and the upload session, and nothing else claims from it. core-api
gains title creation and title edits, both operator-initiated and both audited.

Verified against the running stack: approve now answers 409 "unknown untracked
manga" for a made-up id rather than 503.

824 tests, lint and typecheck clean. Published as 2.1.3 (multi-arch); the worker
image is the one that carries the envelope fix.