### PR TITLE
Stop deployed compose files from trying to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Published images:
 
 | Image | Runs |
 | --- | --- |
-| `ardax/publoader-core:2.1.1` | `core-api`, `core-scheduler`, `core-processor`, `core-uploader`, and the Discord bot — one image, several entry points |
-| `ardax/publoader-core-migrate:2.1.1` | The one-shot migration container, the only thing able to alter the schema |
-| `ardax/publoader-worker:2.1.1` | The worker agent and the extension runtime |
+| `ardax/publoader-core:2.1.3` | `core-api`, `core-scheduler`, `core-processor`, `core-uploader`, and the Discord bot — one image, several entry points |
+| `ardax/publoader-core-migrate:2.1.3` | The one-shot migration container, the only thing able to alter the schema |
+| `ardax/publoader-worker:2.1.3` | The worker agent and the extension runtime |
 
 Base images are pinned by digest; the tag in an env file is what a deploy runs.
 Full procedure in [docs/deployment.md](docs/deployment.md).

--- a/docker/core/.env.example
+++ b/docker/core/.env.example
@@ -111,8 +111,8 @@ TUNNEL_TOKEN=
 # By default the stack builds the images locally from this repo. Point these at
 # a registry to deploy pre-built, digest-pinned images instead (see
 # docs/deployment.md "Upgrading").
-# PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.1
-# PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.1
+# PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.3
+# PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.3
 
 # --- required: Discord control bot ------------------------------------------
 # Full setup, including the Developer Portal steps and the command reference:

--- a/docker/core/.env.production.example
+++ b/docker/core/.env.production.example
@@ -21,8 +21,8 @@
 PUBLOADER_ENV=prod
 
 # --- images (PINNED — bump deliberately, never track `latest`) --------------
-PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.1
-PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.1
+PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.3
+PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.3
 
 # --- database --------------------------------------------------------------
 POSTGRES_USER=publoader

--- a/docker/core/docker-compose.build.yml
+++ b/docker/core/docker-compose.build.yml
@@ -1,0 +1,43 @@
+# Build the core images from this checkout instead of pulling them.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+#
+# Kept apart from docker-compose.yml because that file is deployed on its own:
+# servers copy it next to a `.env` and run it with no source tree present. A
+# `build:` section there is not inert — compose resolves the build context and
+# tries to build, so a server that has only the two files fails with
+#
+#   lstat /docker: no such file or directory
+#
+# naming neither the missing source tree nor the fix. Splitting the two means
+# the deploy path cannot accidentally take the build path, and the paths below
+# are free to assume a full checkout because reaching this file requires one.
+#
+# You do not need this to run the stack, and you do not need it to release:
+# .github/workflows/push-docker.yml builds the published multi-arch images with
+# buildx directly. Use it to run a local patch, or to build where pulling is not
+# possible. For day-to-day development prefer docker/dev/docker-compose.yml,
+# which builds the whole system with MangaDex faked.
+
+services:
+  core-api:
+    build: &core-image
+      context: ../..
+      dockerfile: docker/core/Dockerfile
+
+  core-scheduler:
+    build: *core-image
+
+  core-processor:
+    build: *core-image
+
+  core-uploader:
+    build: *core-image
+
+  # The one service built from a different target: `migrate` keeps the prisma
+  # CLI that the runtime image drops.
+  migrate:
+    build:
+      context: ../..
+      dockerfile: docker/core/Dockerfile
+      target: migrate

--- a/docker/core/docker-compose.yml
+++ b/docker/core/docker-compose.yml
@@ -86,14 +86,18 @@ x-public-dns: &public-dns
     - 8.8.8.8
 
 x-core-build: &core-build
-  # One image, four services (see docker/core/Dockerfile). Building here and
-  # referencing the same `image:` tag everywhere means all four are guaranteed
-  # to run the identical build — a mixed-version control plane is a class of
-  # bug that is very hard to see.
-  image: ${PUBLOADER_CORE_IMAGE:-ardax/publoader-core:2.1.1}
-  build:
-    context: ../..
-    dockerfile: docker/core/Dockerfile
+  # One image, four services (see docker/core/Dockerfile). Referencing the same
+  # `image:` tag everywhere means all four are guaranteed to run the identical
+  # build — a mixed-version control plane is a class of bug that is very hard
+  # to see.
+  #
+  # Deliberately NO `build:` here. A server runs this file with nothing beside
+  # it but `.env`, and a `build:` section makes compose try to build instead of
+  # pull: it resolves the build context relative to this file, finds no source
+  # tree, and fails with `lstat /docker: no such file or directory` — which
+  # names neither the cause nor the fix. To build from source instead, add the
+  # override: `-f docker-compose.yml -f docker-compose.build.yml`.
+  image: ${PUBLOADER_CORE_IMAGE:-ardax/publoader-core:2.1.3}
 
 services:
   # --- postgres -------------------------------------------------------------
@@ -157,12 +161,10 @@ services:
   # resets, or drops anything.
   migrate:
     <<: [*app-security, *core-build]
-    # `migrate` is a separate Dockerfile target that keeps the prisma CLI.
-    build:
-      context: ../..
-      dockerfile: docker/core/Dockerfile
-      target: migrate
-    image: ${PUBLOADER_MIGRATE_IMAGE:-ardax/publoader-core-migrate:2.1.1}
+    # A separate Dockerfile target that keeps the prisma CLI, so it overrides the
+    # image inherited from *core-build. Its build config lives in
+    # docker-compose.build.yml for the reason given there.
+    image: ${PUBLOADER_MIGRATE_IMAGE:-ardax/publoader-core-migrate:2.1.3}
     restart: "no"
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://publoader:${POSTGRES_PASSWORD}@postgres:5432/publoader?schema=public&connection_limit=5}

--- a/docker/worker/.env.example
+++ b/docker/worker/.env.example
@@ -37,7 +37,7 @@ CORE_URL=https://publoader.ardax.dev
 
 # The image this host runs. The default is the published release; override it
 # only to pin an older version or a digest.
-# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.1
+# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.3
 
 # Resource ceilings for the container that runs third-party extension code.
 # Raise the memory limit for image-heavy extensions; note /tmp is a 2g tmpfs

--- a/docker/worker/README.md
+++ b/docker/worker/README.md
@@ -134,6 +134,10 @@ docker image inspect ardax/publoader-worker:2.1.1 --format '{{.Architecture}}'
 Note `.env` overrides the compose default, so `docker compose pull` alone will not
 move you off a bad tag — and Docker caches by tag, so remove the image first.
 
+**`lstat /docker: no such file or directory`** — the compose files moved to the
+repository root. Run from `docker/worker/`, not `platform/docker/worker/`, and
+delete the leftover `platform/` directory.
+
 **`invalid or used enrollment token`** — it's single-use and may have expired, or
 the volume was deleted after a successful enrolment. Ask for a new one.
 

--- a/docker/worker/README.md
+++ b/docker/worker/README.md
@@ -114,7 +114,7 @@ All optional; the defaults are fine.
 | `WORKER_MEM_LIMIT` | `2g` | Raise for image-heavy extensions. `/tmp` is a 2g tmpfs and counts against this. |
 | `WORKER_CPUS` | `2.0` | |
 | `LOG_LEVEL` | `info` | `debug` when something is wrong. |
-| `PUBLOADER_WORKER_IMAGE` | `ardax/publoader-worker:2.1.1` | Pin an older release or a digest. Multi-arch: works on x86-64 and arm64. |
+| `PUBLOADER_WORKER_IMAGE` | `ardax/publoader-worker:2.1.3` | Pin an older release or a digest. Multi-arch: works on x86-64 and arm64. |
 | `WORKER_HEARTBEAT_MAX_AGE_SECONDS` | `600` | Only alongside a matching change to the core's `LEASE_TTL_SECONDS`. |
 
 Pin an extension set to this host from the operator's side — Workers → Change.
@@ -128,7 +128,7 @@ Takes effect on your next poll; no restart.
 multi-arch, and check what you actually pulled:
 
 ```bash
-docker image inspect ardax/publoader-worker:2.1.1 --format '{{.Architecture}}'
+docker image inspect ardax/publoader-worker:2.1.3 --format '{{.Architecture}}'
 ```
 
 Note `.env` overrides the compose default, so `docker compose pull` alone will not

--- a/docker/worker/docker-compose.build.yml
+++ b/docker/worker/docker-compose.build.yml
@@ -1,0 +1,17 @@
+# Build the worker image from this checkout instead of pulling it.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+#
+# Kept apart from docker-compose.yml for the same reason as the core stack: that
+# file is copied to worker hosts with nothing beside it but `.env`, and a
+# `build:` section there makes compose try to build rather than pull, failing on
+# the absent source tree with `lstat /docker: no such file or directory`.
+#
+# Published images are built by .github/workflows/push-docker.yml, so this is
+# only for running a local patch or building where pulling is not possible.
+
+services:
+  worker-agent:
+    build:
+      context: ../..
+      dockerfile: docker/worker/Dockerfile

--- a/docker/worker/docker-compose.yml
+++ b/docker/worker/docker-compose.yml
@@ -26,16 +26,16 @@ name: publoader-worker
 
 services:
   worker-agent:
-    # Built from this repo by default. Once images are published, set
-    # PUBLOADER_WORKER_IMAGE to a digest-pinned tag in .env and remove nothing
-    # else — worker hosts should not need a source checkout to run.
-    image: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.1}
-    build:
-      context: ../..
-      dockerfile: docker/worker/Dockerfile
-      # No build args: extensions are self-contained ESM bundles built at
-      # publish time, so the image has no per-extension dependencies to bake in
-      # and adding an extension no longer requires rebuilding workers.
+    # Pulled, not built: a worker host runs this file next to a `.env` and
+    # nothing else. A `build:` section here would break exactly that — compose
+    # would resolve the build context relative to this file, find no source
+    # tree, and fail with `lstat /docker: no such file or directory`. To build
+    # from a checkout, add `-f docker-compose.build.yml`.
+    #
+    # Nothing per-extension is baked in either way: extensions are
+    # self-contained ESM bundles built at publish time, so adding one never
+    # requires rebuilding or redeploying a worker.
+    image: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.3}
     # No `container_name:` on purpose — a fixed name would make it impossible
     # to run a second worker on the same machine with `-p`, since the two
     # projects would collide on the container name.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -123,7 +123,8 @@ accepted as `<VAR>_FILE`, and the commented `secrets:` block at the bottom of
 Then bring it up from the repository root:
 
 ```bash
-docker compose -f docker/core/docker-compose.yml up -d --build
+docker compose -f docker/core/docker-compose.yml pull
+docker compose -f docker/core/docker-compose.yml up -d
 docker compose -f docker/core/docker-compose.yml ps
 ```
 
@@ -467,7 +468,8 @@ cd docker/worker
 cp .env.example .env && chmod 600 .env
 # set WORKER_NAME and paste the pe_… token into ENROLL_TOKEN
 cd -
-docker compose -f docker/worker/docker-compose.yml up -d --build
+docker compose -f docker/worker/docker-compose.yml pull
+docker compose -f docker/worker/docker-compose.yml up -d
 docker compose -f docker/worker/docker-compose.yml logs -f
 ```
 
@@ -521,7 +523,8 @@ drops anything, so re-running it is safe.
 
 ```bash
 git pull
-docker compose -f docker/core/docker-compose.yml up -d --build
+docker compose -f docker/core/docker-compose.yml pull
+docker compose -f docker/core/docker-compose.yml up -d
 ```
 
 **From a registry** — set `PUBLOADER_CORE_IMAGE` and `PUBLOADER_MIGRATE_IMAGE`
@@ -534,7 +537,7 @@ docker compose -f docker/core/docker-compose.yml up -d
 
 Workers upgrade independently and can lag the core by a version; the API is
 versioned (`/api/v1/`) for exactly that reason. Rolling the fleet is: drain,
-wait for the current job to finish, `up -d --build`, un-drain (next section).
+wait for the current job to finish, `pull && up -d`, un-drain (next section).
 
 Watch the first minutes after an upgrade:
 
@@ -549,7 +552,7 @@ Code-only rollback (no new migration in the bad release) is just the previous
 tag:
 
 ```bash
-PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.1 \
+PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.3 \
   docker compose -f docker/core/docker-compose.yml up -d
 ```
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -80,7 +80,8 @@ cd $REPO/docker/core
 cp .env.example .env
 # Fill in: POSTGRES_PASSWORD, ADMIN_TOKEN (openssl rand -base64 48),
 # MANGADEX_*, DISCORD_WEBHOOK_URLS, TUNNEL_TOKEN.
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 The `migrate` service runs `prisma migrate deploy` and exits 0 before any
@@ -343,7 +344,8 @@ On the worker host:
 cd $REPO/docker/worker
 cp .env.example .env
 # Set WORKER_NAME and paste the token as ENROLL_TOKEN.
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 Back on the operator machine:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -215,7 +215,8 @@ cd publoader/docker/worker
 cp .env.example .env
 # WORKER_NAME=hetzner-fsn-1
 # ENROLL_TOKEN=pe_...
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 docker compose logs -f worker-agent
 ```
 
@@ -328,7 +329,8 @@ padmin pause --minutes 30
 
 # 2. New image.
 #    Set PUBLOADER_CORE_IMAGE in .env to the new tag, or rebuild from source:
-docker compose build
+#    (to build from source instead: add -f docker-compose.build.yml)
+docker compose pull
 
 # 3. Migrate + restart. `up -d` reruns `migrate deploy` (idempotent — it applies
 #    only migrations absent from _prisma_migrations) before starting services.
@@ -434,7 +436,7 @@ padmin stats
 
 # worker host
 cd docker/worker
-docker compose pull      # or: docker compose build
+docker compose pull
 docker compose up -d
 
 # operator

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -298,6 +298,24 @@ worker submitted.
 
 ## Upgrade the core
 
+> **One-off: the compose files moved.** Everything that lived under `platform/`
+> is now at the repository root, so the stack is at `docker/core/`, not
+> `platform/docker/core/`. A server still sitting in the old directory fails with
+>
+> ```
+> lstat /docker: no such file or directory
+> ```
+>
+> which names neither the path nor the move. The compose file's `context: ../..`
+> resolves to `platform/` there, and `platform/` no longer contains `docker/`.
+>
+> ```bash
+> cd <repo> && git pull
+> rm -rf platform          # leftovers; git does not remove an untracked directory
+> cd docker/core
+> docker compose --env-file .env config | grep image:   # proves you are in the right place
+> ```
+
 Core services are stateless; the schema is not. Migration runs first, as a
 one-shot container, and every service waits on it.
 


### PR DESCRIPTION
Reported live: a core host upgrading to the current release failed at `up` with

```
lstat /docker: no such file or directory
```

## Why it happened

`docker/core/docker-compose.yml` and `docker/worker/docker-compose.yml` both
carried a `build:` section. That is harmless in a checkout and fatal without
one — compose resolves the build context relative to the compose file, finds no
`docker/` directory there, and fails. The host in question had only the compose
file and `.env`, which is exactly what the install instructions ask for; the
worker file even said so in a comment directly above its own `build:` block.

The docs pushed people down the same path: `up -d --build` was the instruction
for both installing and upgrading a server, so every deployment was one absent
checkout away from this error.

## What changed

- Both deploy composes are pull-only. Building moved to a
  `docker-compose.build.yml` override beside each stack, so the deploy path
  cannot silently become the build path.
- Deploy docs `pull` instead of `--build`. The `docker/dev` invocations still
  build — that stack exists to build from source.
- Image pins move to 2.1.3; several files still advertised 2.1.1, which predates
  both the multi-arch images and the credentials fix.
- The `platform/` → root move is documented at the top of the upgrade runbook
  and in the worker README, since it produces the same error message from a
  different cause and every existing deployment crosses it once.

Nothing loses the ability to build: released images come from buildx in
`push-docker.yml`, and the override reproduces the previous behaviour exactly.

## Verified

- Copied *only* `docker-compose.yml` + `.env` into an empty directory — the
  shape of a real server — and both stacks resolve; before this they failed.
- Booted the core stack from that bare directory on pulled images alone.
- Both build overrides still resolve their context to the repo root.
- `pnpm lint` clean; 577 tests pass (247 Postgres-gated ones skipped, no DB in
  this shell); docs link check clean.