### PR TITLE
Language fix, run-level webhooks, run cancellation, GitHub polling — and CI that actually runs

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -32,8 +32,13 @@ env:
   # resolves in CI also resolves in the image build.
   PNPM_VERSION: "10.12.1"
 
-defaults:
-  run:
+# NOTE: no `defaults:` block. It used to carry `run.working-directory: platform`;
+# when the platform moved to the repository root the value was removed and the
+# empty `run:` key was left behind. `defaults.run` must contain `shell` or
+# `working-directory`, so an empty mapping is an INVALID workflow — every run
+# failed in 0s with "workflow file issue", which reads like infrastructure
+# flakiness rather than a syntax error in this file. Same failure shape as the
+# paths filter before it: the stale entry was deleted, not the container.
 
 jobs:
   lint-typecheck:

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Published images:
 
 | Image | Runs |
 | --- | --- |
-| `ardax/publoader-core:2.1.4` | `core-api`, `core-scheduler`, `core-processor`, `core-uploader`, and the Discord bot — one image, several entry points |
-| `ardax/publoader-core-migrate:2.1.4` | The one-shot migration container, the only thing able to alter the schema |
-| `ardax/publoader-worker:2.1.4` | The worker agent and the extension runtime |
+| `ardax/publoader-core:2.1.5` | `core-api`, `core-scheduler`, `core-processor`, `core-uploader`, and the Discord bot — one image, several entry points |
+| `ardax/publoader-core-migrate:2.1.5` | The one-shot migration container, the only thing able to alter the schema |
+| `ardax/publoader-worker:2.1.5` | The worker agent and the extension runtime |
 
 Base images are pinned by digest; the tag in an env file is what a deploy runs.
 Full procedure in [docs/deployment.md](docs/deployment.md).

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Published images:
 
 | Image | Runs |
 | --- | --- |
-| `ardax/publoader-core:2.1.3` | `core-api`, `core-scheduler`, `core-processor`, `core-uploader`, and the Discord bot — one image, several entry points |
-| `ardax/publoader-core-migrate:2.1.3` | The one-shot migration container, the only thing able to alter the schema |
-| `ardax/publoader-worker:2.1.3` | The worker agent and the extension runtime |
+| `ardax/publoader-core:2.1.4` | `core-api`, `core-scheduler`, `core-processor`, `core-uploader`, and the Discord bot — one image, several entry points |
+| `ardax/publoader-core-migrate:2.1.4` | The one-shot migration container, the only thing able to alter the schema |
+| `ardax/publoader-worker:2.1.4` | The worker agent and the extension runtime |
 
 Base images are pinned by digest; the tag in an env file is what a deploy runs.
 Full procedure in [docs/deployment.md](docs/deployment.md).

--- a/docker/core/.env.example
+++ b/docker/core/.env.example
@@ -111,8 +111,8 @@ TUNNEL_TOKEN=
 # By default the stack builds the images locally from this repo. Point these at
 # a registry to deploy pre-built, digest-pinned images instead (see
 # docs/deployment.md "Upgrading").
-# PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.3
-# PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.3
+# PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.4
+# PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.4
 
 # --- required: Discord control bot ------------------------------------------
 # Full setup, including the Developer Portal steps and the command reference:

--- a/docker/core/.env.example
+++ b/docker/core/.env.example
@@ -108,11 +108,17 @@ TUNNEL_TOKEN=
 
 # --- optional: images -------------------------------------------------------
 
-# By default the stack builds the images locally from this repo. Point these at
-# a registry to deploy pre-built, digest-pinned images instead (see
-# docs/deployment.md "Upgrading").
+# The published images this stack runs. Pin by digest for a stronger guarantee
+# (see docs/deployment.md "Upgrading"); to build from source instead, add
+# `-f docker-compose.build.yml`.
 # PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.4
 # PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.4
+
+# The image the dashboard's enrolment snippet tells a NEW WORKER HOST to run.
+# This deployment does not run it — it only hands out the name — so it is set
+# separately from the two above and should track whatever workers ought to be
+# running. Unset, core-api falls back to `ardax/publoader-worker:latest`.
+# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.4
 
 # --- required: Discord control bot ------------------------------------------
 # Full setup, including the Developer Portal steps and the command reference:

--- a/docker/core/.env.example
+++ b/docker/core/.env.example
@@ -111,14 +111,14 @@ TUNNEL_TOKEN=
 # The published images this stack runs. Pin by digest for a stronger guarantee
 # (see docs/deployment.md "Upgrading"); to build from source instead, add
 # `-f docker-compose.build.yml`.
-# PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.4
-# PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.4
+# PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.5
+# PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.5
 
 # The image the dashboard's enrolment snippet tells a NEW WORKER HOST to run.
 # This deployment does not run it — it only hands out the name — so it is set
 # separately from the two above and should track whatever workers ought to be
 # running. Unset, core-api falls back to `ardax/publoader-worker:latest`.
-# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.4
+# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.5
 
 # --- required: Discord control bot ------------------------------------------
 # Full setup, including the Developer Portal steps and the command reference:

--- a/docker/core/.env.production.example
+++ b/docker/core/.env.production.example
@@ -21,8 +21,8 @@
 PUBLOADER_ENV=prod
 
 # --- images (PINNED — bump deliberately, never track `latest`) --------------
-PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.4
-PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.4
+PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.5
+PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.5
 
 # --- database --------------------------------------------------------------
 POSTGRES_USER=publoader

--- a/docker/core/.env.production.example
+++ b/docker/core/.env.production.example
@@ -21,8 +21,8 @@
 PUBLOADER_ENV=prod
 
 # --- images (PINNED — bump deliberately, never track `latest`) --------------
-PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.3
-PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.3
+PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.4
+PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.4
 
 # --- database --------------------------------------------------------------
 POSTGRES_USER=publoader

--- a/docker/core/docker-compose.yml
+++ b/docker/core/docker-compose.yml
@@ -229,6 +229,11 @@ services:
       # a fresh database is never locked out of its own dashboard.
       DASH_OWNER_EMAIL: ${DASH_OWNER_EMAIL:-iam@ardax.dev}
       DASH_PUBLIC_URL: ${DASH_PUBLIC_URL:-https://publoader.ardax.dev}
+      # The image the enrolment snippet tells a new worker host to run. Defaults
+      # to the same release as the core above, so bumping the version in one
+      # place moves the snippet with it — before this was passed, core-api fell
+      # back to a literal in the source and handed out a two-release-old tag.
+      PUBLOADER_WORKER_IMAGE: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.4}
       # --- GitHub push webhook (core-api only) -----------------------------
       # POST /webhook publishes a new bundle for each changed extension. Blank
       # secret = the endpoint answers 503 rather than accepting unsigned

--- a/docker/core/docker-compose.yml
+++ b/docker/core/docker-compose.yml
@@ -97,7 +97,7 @@ x-core-build: &core-build
   # tree, and fails with `lstat /docker: no such file or directory` — which
   # names neither the cause nor the fix. To build from source instead, add the
   # override: `-f docker-compose.yml -f docker-compose.build.yml`.
-  image: ${PUBLOADER_CORE_IMAGE:-ardax/publoader-core:2.1.3}
+  image: ${PUBLOADER_CORE_IMAGE:-ardax/publoader-core:2.1.4}
 
 services:
   # --- postgres -------------------------------------------------------------
@@ -164,7 +164,7 @@ services:
     # A separate Dockerfile target that keeps the prisma CLI, so it overrides the
     # image inherited from *core-build. Its build config lives in
     # docker-compose.build.yml for the reason given there.
-    image: ${PUBLOADER_MIGRATE_IMAGE:-ardax/publoader-core-migrate:2.1.3}
+    image: ${PUBLOADER_MIGRATE_IMAGE:-ardax/publoader-core-migrate:2.1.4}
     restart: "no"
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://publoader:${POSTGRES_PASSWORD}@postgres:5432/publoader?schema=public&connection_limit=5}

--- a/docker/core/docker-compose.yml
+++ b/docker/core/docker-compose.yml
@@ -97,7 +97,7 @@ x-core-build: &core-build
   # tree, and fails with `lstat /docker: no such file or directory` — which
   # names neither the cause nor the fix. To build from source instead, add the
   # override: `-f docker-compose.yml -f docker-compose.build.yml`.
-  image: ${PUBLOADER_CORE_IMAGE:-ardax/publoader-core:2.1.4}
+  image: ${PUBLOADER_CORE_IMAGE:-ardax/publoader-core:2.1.5}
 
 services:
   # --- postgres -------------------------------------------------------------
@@ -164,7 +164,7 @@ services:
     # A separate Dockerfile target that keeps the prisma CLI, so it overrides the
     # image inherited from *core-build. Its build config lives in
     # docker-compose.build.yml for the reason given there.
-    image: ${PUBLOADER_MIGRATE_IMAGE:-ardax/publoader-core-migrate:2.1.4}
+    image: ${PUBLOADER_MIGRATE_IMAGE:-ardax/publoader-core-migrate:2.1.5}
     restart: "no"
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://publoader:${POSTGRES_PASSWORD}@postgres:5432/publoader?schema=public&connection_limit=5}
@@ -233,7 +233,7 @@ services:
       # to the same release as the core above, so bumping the version in one
       # place moves the snippet with it — before this was passed, core-api fell
       # back to a literal in the source and handed out a two-release-old tag.
-      PUBLOADER_WORKER_IMAGE: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.4}
+      PUBLOADER_WORKER_IMAGE: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.5}
       # --- GitHub push webhook (core-api only) -----------------------------
       # POST /webhook publishes a new bundle for each changed extension. Blank
       # secret = the endpoint answers 503 rather than accepting unsigned

--- a/docker/worker/.env.example
+++ b/docker/worker/.env.example
@@ -37,7 +37,7 @@ CORE_URL=https://publoader.ardax.dev
 
 # The image this host runs. The default is the published release; override it
 # only to pin an older version or a digest.
-# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.4
+# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.5
 
 # Resource ceilings for the container that runs third-party extension code.
 # Raise the memory limit for image-heavy extensions; note /tmp is a 2g tmpfs

--- a/docker/worker/.env.example
+++ b/docker/worker/.env.example
@@ -37,7 +37,7 @@ CORE_URL=https://publoader.ardax.dev
 
 # The image this host runs. The default is the published release; override it
 # only to pin an older version or a digest.
-# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.3
+# PUBLOADER_WORKER_IMAGE=ardax/publoader-worker:2.1.4
 
 # Resource ceilings for the container that runs third-party extension code.
 # Raise the memory limit for image-heavy extensions; note /tmp is a 2g tmpfs

--- a/docker/worker/README.md
+++ b/docker/worker/README.md
@@ -114,7 +114,7 @@ All optional; the defaults are fine.
 | `WORKER_MEM_LIMIT` | `2g` | Raise for image-heavy extensions. `/tmp` is a 2g tmpfs and counts against this. |
 | `WORKER_CPUS` | `2.0` | |
 | `LOG_LEVEL` | `info` | `debug` when something is wrong. |
-| `PUBLOADER_WORKER_IMAGE` | `ardax/publoader-worker:2.1.4` | Pin an older release or a digest. Multi-arch: works on x86-64 and arm64. |
+| `PUBLOADER_WORKER_IMAGE` | `ardax/publoader-worker:2.1.5` | Pin an older release or a digest. Multi-arch: works on x86-64 and arm64. |
 | `WORKER_HEARTBEAT_MAX_AGE_SECONDS` | `600` | Only alongside a matching change to the core's `LEASE_TTL_SECONDS`. |
 
 Pin an extension set to this host from the operator's side — Workers → Change.
@@ -128,7 +128,7 @@ Takes effect on your next poll; no restart.
 multi-arch, and check what you actually pulled:
 
 ```bash
-docker image inspect ardax/publoader-worker:2.1.4 --format '{{.Architecture}}'
+docker image inspect ardax/publoader-worker:2.1.5 --format '{{.Architecture}}'
 ```
 
 Note `.env` overrides the compose default, so `docker compose pull` alone will not

--- a/docker/worker/README.md
+++ b/docker/worker/README.md
@@ -114,7 +114,7 @@ All optional; the defaults are fine.
 | `WORKER_MEM_LIMIT` | `2g` | Raise for image-heavy extensions. `/tmp` is a 2g tmpfs and counts against this. |
 | `WORKER_CPUS` | `2.0` | |
 | `LOG_LEVEL` | `info` | `debug` when something is wrong. |
-| `PUBLOADER_WORKER_IMAGE` | `ardax/publoader-worker:2.1.3` | Pin an older release or a digest. Multi-arch: works on x86-64 and arm64. |
+| `PUBLOADER_WORKER_IMAGE` | `ardax/publoader-worker:2.1.4` | Pin an older release or a digest. Multi-arch: works on x86-64 and arm64. |
 | `WORKER_HEARTBEAT_MAX_AGE_SECONDS` | `600` | Only alongside a matching change to the core's `LEASE_TTL_SECONDS`. |
 
 Pin an extension set to this host from the operator's side — Workers → Change.
@@ -128,7 +128,7 @@ Takes effect on your next poll; no restart.
 multi-arch, and check what you actually pulled:
 
 ```bash
-docker image inspect ardax/publoader-worker:2.1.3 --format '{{.Architecture}}'
+docker image inspect ardax/publoader-worker:2.1.4 --format '{{.Architecture}}'
 ```
 
 Note `.env` overrides the compose default, so `docker compose pull` alone will not

--- a/docker/worker/docker-compose.yml
+++ b/docker/worker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     # Nothing per-extension is baked in either way: extensions are
     # self-contained ESM bundles built at publish time, so adding one never
     # requires rebuilding or redeploying a worker.
-    image: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.4}
+    image: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.5}
     # No `container_name:` on purpose — a fixed name would make it impossible
     # to run a second worker on the same machine with `-p`, since the two
     # projects would collide on the container name.

--- a/docker/worker/docker-compose.yml
+++ b/docker/worker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     # Nothing per-extension is baked in either way: extensions are
     # self-contained ESM bundles built at publish time, so adding one never
     # requires rebuilding or redeploying a worker.
-    image: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.3}
+    image: ${PUBLOADER_WORKER_IMAGE:-ardax/publoader-worker:2.1.4}
     # No `container_name:` on purpose — a fixed name would make it impossible
     # to run a second worker on the same machine with `-p`, since the two
     # projects would collide on the container name.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -552,7 +552,7 @@ Code-only rollback (no new migration in the bad release) is just the previous
 tag:
 
 ```bash
-PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.4 \
+PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.5 \
   docker compose -f docker/core/docker-compose.yml up -d
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -552,7 +552,7 @@ Code-only rollback (no new migration in the bad release) is just the previous
 tag:
 
 ```bash
-PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.3 \
+PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.4 \
   docker compose -f docker/core/docker-compose.yml up -d
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -743,6 +743,41 @@ tails a log file.
 
 ---
 
+## Kill a run in progress
+
+When a run is doing something wrong — a bad extension build, a mapping mistake,
+an upstream site returning nonsense — stop the whole run rather than its jobs one
+at a time:
+
+```bash
+curl -sX POST $CORE/api/v1/admin/runs/$RUN_ID/cancel -H "authorization: Bearer $ADMIN_TOKEN"
+
+# everything unfinished, optionally for one extension
+curl -sX POST $CORE/api/v1/admin/runs/cancel-all \
+  -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"extension":"mangaplus"}'
+```
+
+Every job the run still has outstanding goes to `CANCELLED` immediately, and a
+worker mid-execution aborts at its next lease renewal. Nothing can land
+afterwards: `cancel_requested` blocks a re-claim even after the lease sweeper
+requeues an abandoned job, and ingest only accepts an envelope for a job still in
+`LEASED`/`RUNNING`, so a worker that finishes anyway has its result superseded
+rather than committed.
+
+**Prefer this to cancelling individual jobs on a partitioned run.** Cancelling
+one segment leaves the others to finish, and the run is then processed from
+incomplete results — which on a CLEAN run means the processor concludes that
+every chapter the missing segment covered has vanished upstream, and queues it
+for removal. A killed run never reaches the processor at all.
+
+A finished run is refused with 409 rather than "cancelled", because cancelling
+completed work would misreport what happened. The run lands in `CANCELLED`, not
+`DEAD_LETTER` — this was a decision, and the state an operator reads later should
+say so.
+
+---
+
 ## Queue management
 
 The section above is triage: look at a stuck task, retry it, cancel it. This one

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1308,10 +1308,28 @@ before resuming.
 
 ## Config lives in the database, not in JSON files
 
-`manga_id_map.json` and `override_options.json` are **seed data**, imported
-once when a bundle is first published. After that the database wins and
-republishing does not overwrite it. Editing the files on a live deployment
-changes nothing.
+The two data files behave **differently**, and the difference decides whether
+editing one in git does anything at all on a live deployment.
+
+**`manga_id_map.json` is reconciled on every publish** — so the contributor
+workflow (edit the file, open a PR, merge) does reach the database. Per row:
+
+| Change in git | Effect on the database |
+| --- | --- |
+| A new `(namespace, mangaId)` pair | inserted |
+| A corrected MangaDex id, on a row that came from a previous import | updated |
+| A different id on a row an **operator** set, or the title pipeline auto-created | preserved — git does not win |
+| A line removed | nothing — a series is never untracked by deletion |
+
+The `source` column draws that line. A row set by an operator is a later and
+better-informed decision than the file, and dropping a line from the map must not
+silently stop a series being tracked — untracking is an explicit action
+(dashboard, `padmin tracked remove`, or the bot).
+
+**`override_options.json` is seed data**, imported only when an extension has no
+configuration at all. Once any of it exists — a config row, an alias, a
+multi-chapter entry, a language mapping — republishing does nothing, so editing
+this file on a live deployment changes nothing. Use `ext-config` below.
 
 ```bash
 padmin tracked list <extension>

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1334,6 +1334,79 @@ padmin ext-config set mangaplus /tmp/o.json
 
 Both are audited, so `padmin audit` shows who repointed a mapping and when.
 
+### `custom_language` widens what a chapter may be published as
+
+`custom_language` maps an external manga id to a MangaDex language code, and it
+is the one override that changes what the ingest gate will *accept*: chapters of
+that title are allowed to carry that language even though the extension's
+manifest does not declare it. mangaplus reports `SPANISH` for everything, so the
+one title that is actually Latin-American Spanish is mapped to `es-la` here.
+
+The map is read from the **database**, never from the worker's envelope — a
+worker cannot vote on which languages it may publish. So a chapter rejected as
+
+```
+chapter language es-la not declared by manifest (declared: en, es)
+```
+
+means the mapping is missing from `ext-config`, not that the manifest is wrong.
+Values are validated against MangaDex's language list on write, so a typo like
+`pt_br` is refused at that point rather than silently failing to protect
+Brazilian-Portuguese chapters from the removal pass.
+
+---
+
+## Webhook verbosity
+
+By default the channel gets **failures only** for individual chapters. Python
+sent an embed per chapter either way, which on a normal run is almost entirely
+`Success: True` — and the one failure worth acting on scrolls past between them.
+The run-level embeds (`Reading data from …`, `Found N chapters for …`, the
+untracked-series list) already report that the work happened.
+
+```bash
+curl -s $CORE/api/v1/admin/webhook-verbosity -H "authorization: Bearer $ADMIN_TOKEN"
+curl -sX POST $CORE/api/v1/admin/webhook-verbosity \
+  -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"uploadSuccesses": true}'          # back to the Python firehose
+```
+
+Failure embeds are not switchable, and they carry the reason in the description
+— a failure notification that does not say why is one you cannot act on.
+
+---
+
+## Extensions publish themselves from GitHub
+
+Two paths keep the fleet current, and they overlap on purpose:
+
+1. **The push webhook** — fires within seconds of a push, carrying the exact
+   commit. This is the fast path.
+2. **A poll every 15 minutes** — the scheduler asks each repo in
+   `GITHUB_EXTENSIONS_REPOS` for its HEAD and publishes anything that changed.
+
+The poll exists because the webhook fails *silently*: an unregistered hook, a
+revoked secret or a dropped delivery all look identical to "nobody pushed", and
+the first symptom is a run producing stale results days later. Publishing is
+idempotent — an unchanged tree hashes the same and returns `unchanged` — so the
+two overlapping costs nothing.
+
+The poll discovers extensions by directory (`src/<name>/manifest.json`), so an
+extension **added** to a repo is picked up on its own. The sysops sync button
+walks already-published bundles and therefore can only ever update extensions
+somebody installed by hand first.
+
+A commit is only remembered when every extension in it published cleanly, so a
+transient build failure is retried next pass rather than being skipped until the
+next push. Publishes are audited under `github.autosync`.
+
+```bash
+# freeze the fleet on what is published now (e.g. while investigating a bad extension)
+docker compose exec postgres psql -U publoader -d publoader \
+  -c "insert into settings (key, value) values ('github_auto_sync','false')
+      on conflict (key) do update set value = 'false';"
+```
+
 ---
 
 ## Lease-expiry storms

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,8 +21,16 @@ const ConfigSchema = z.object({
   databaseUrl: z.string().default(""),
   port: z.coerce.number().int().default(8100),
   host: z.string().default("0.0.0.0"),
-  /** Admin bearer token for operator endpoints (bot/dash/CLI). */
-  adminToken: z.string().min(16).optional(),
+  /**
+   * Admin bearer token for operator endpoints (bot/dash/CLI).
+   *
+   * Trimmed because this value is compared for exact equality and is typically
+   * put in `.env` by hand or by shell redirection, which is how a trailing
+   * newline gets in. Untrimmed, the stored token silently stops matching the
+   * one the operator holds and every login fails as "invalid admin token" — a
+   * message that points at the token rather than at the whitespace around it.
+   */
+  adminToken: z.string().trim().min(16).optional(),
   /**
    * HMAC key for short-lived signed cookies (currently the OAuth state
    * cookie). Session cookies are DB-backed and do not depend on it. Optional:
@@ -113,8 +121,10 @@ const ConfigSchema = z.object({
 
   // Worker agent settings (worker process only)
   coreUrl: z.string().optional(),
-  workerToken: z.string().optional(),
-  enrollToken: z.string().optional(),
+  // Trimmed for the same reason as adminToken: compared for exact equality,
+  // and written into .env by hand on every worker host.
+  workerToken: z.string().trim().optional(),
+  enrollToken: z.string().trim().optional(),
   workerName: z.string().optional(),
   workerStatePath: z.string().default("/var/lib/publoader-worker"),
   /**

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -5311,14 +5311,26 @@ function showEnrollToken(minted, workerName) {
   // onto a host, and a name nobody published turns "enrol a worker" into a pull
   // failure with no clue that the dashboard invented the tag. WORKER_IMAGE comes
   // from the server so the snippet tracks the deployed release rather than a
-  // constant that goes stale here.
-  const image = minted.workerImage || "ardax/publoader-worker:2.1.1";
+  // constant that goes stale here — which is exactly what this fallback did when
+  // it was a pinned version, quietly handing out an image two releases old.
+  // `latest` cannot rot; a version literal in a browser bundle can and did.
+  const image = minted.workerImage || "ardax/publoader-worker:latest";
   const snippet = [
     "# publoader worker — one-time enrolment token",
     `# expires ${fmtTime(minted.expiresAt)}; it enrols exactly one worker.`,
     "#",
     "# The token is traded once for a permanent one kept in the named volume.",
     "# Losing that volume means asking the operator for a new enrolment token.",
+    "#",
+    // The tag below is whatever this deployment was told to advertise, which is
+    // not necessarily the newest release — a core that has not been upgraded in
+    // a while advertises what it knew at the time. Saying so beats a worker host
+    // silently starting on an old image because the snippet looked current.
+    `# Image below (${image}) is what this control plane advertises.`,
+    "# Check for a newer production release before pasting, and prefer it:",
+    "#   docker pull ardax/publoader-worker:latest",
+    "#   docker image inspect ardax/publoader-worker:latest --format '{{index .RepoTags 0}}'",
+    "# Releases: https://hub.docker.com/r/ardax/publoader-worker/tags",
     "services:",
     "  publoader-worker:",
     `    image: ${image}`,

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -1232,7 +1232,9 @@ const loginWithPassword = (event) =>
 const loginWithToken = (event) =>
   submitLogin(
     event,
-    { token: $("login-token").value, actor: $("login-actor").value.trim() || undefined },
+    // Trimmed like the actor beside it: a token is pasted, and a paste from a
+    // terminal or password manager routinely brings a trailing newline with it.
+    { token: $("login-token").value.trim(), actor: $("login-actor").value.trim() || undefined },
     () => {
       $("login-token").value = "";
     },

--- a/src/core/api/routes/admin.ts
+++ b/src/core/api/routes/admin.ts
@@ -16,8 +16,21 @@ import { sessionAuthenticator } from "../session.js";
 import { Manifest, EXTENSION_NAME_RE } from "../../../contracts/manifest.js";
 import { MANGADEX_LANGUAGES } from "../../../contracts/languages.js";
 
-/** The worker image the enrolment snippet tells a new host to run. */
-const WORKER_IMAGE = process.env["PUBLOADER_WORKER_IMAGE"] ?? "ardax/publoader-worker:2.1.1";
+/**
+ * The worker image the enrolment snippet tells a new host to run.
+ *
+ * Set `PUBLOADER_WORKER_IMAGE` on core-api to pin it — the compose file does,
+ * defaulting to the same release as the core itself, so the snippet moves with
+ * every version bump instead of being a literal somebody has to remember.
+ *
+ * The fallback is `:latest` deliberately. A hardcoded version here is not a safe
+ * default but a slowly-rotting one: this constant said `2.1.1` for three
+ * releases while the env var it reads was never passed to core-api at all, so
+ * every enrolment snippet handed out an image two versions behind and nothing
+ * pointed at the cause. `:latest` can be wrong about immutability; it cannot be
+ * wrong about being stale, and it is only reached when nothing is configured.
+ */
+const WORKER_IMAGE = process.env["PUBLOADER_WORKER_IMAGE"] ?? "ardax/publoader-worker:latest";
 import { VALID_REMOVAL_MODES } from "../../store/settings.js";
 import { BundleRejectedError } from "../../store/bundles.js";
 import AdmZip from "adm-zip";

--- a/src/core/api/routes/admin.ts
+++ b/src/core/api/routes/admin.ts
@@ -284,6 +284,45 @@ export function registerAdminRoutes(app: FastifyInstance, ctx: AppContext): void
       return { run };
     });
 
+    /**
+     * Kill a run in progress: every job it still has outstanding is cancelled,
+     * and workers already executing one abort on their next lease renewal.
+     *
+     * Deliberately harder-edged than cancelling a job. Cancelling one job of a
+     * partitioned run leaves the others to finish and the run to be processed
+     * from incomplete results — which for a CLEAN run means the processor
+     * concludes that every chapter the missing segment covers has vanished
+     * upstream. Killing the run avoids that entirely: it never reaches the
+     * processor.
+     */
+    scope.post("/api/v1/admin/runs/:id/cancel", { preHandler: requireScope("runs:write") }, async (req, reply) => {
+      const { id } = req.params as { id: string };
+      const outcome = await ctx.jobs.cancelRun(id);
+      if (!outcome) return reply.code(404).send({ error: "unknown run" });
+      if (outcome.result === "rejected") {
+        return reply
+          .code(409)
+          .send({ error: `run already finished (${outcome.previousState.toLowerCase()})` });
+      }
+      await ctx.audit.record(actor(req), "run.cancel", id, {
+        jobsCancelled: outcome.jobsCancelled,
+        previousState: outcome.previousState,
+      });
+      return { ok: true, ...outcome };
+    });
+
+    /**
+     * The same, for everything unfinished at once — optionally scoped to one
+     * extension. For when something is wrong across the board and cancelling
+     * runs one id at a time is not fast enough.
+     */
+    scope.post("/api/v1/admin/runs/cancel-all", { preHandler: requireScope("runs:write") }, async (req) => {
+      const body = z.object({ extension: z.string().min(1).max(64).optional() }).parse(req.body ?? {});
+      const stopped = await ctx.jobs.cancelActiveRuns(body.extension);
+      await ctx.audit.record(actor(req), "run.cancel_all", body.extension ?? "*", stopped);
+      return { ok: true, ...stopped };
+    });
+
     scope.post("/api/v1/admin/jobs/:id/cancel", { preHandler: requireScope("runs:write") }, async (req, reply) => {
       const { id } = req.params as { id: string };
       const result = await ctx.jobs.cancel(id);

--- a/src/core/api/routes/admin.ts
+++ b/src/core/api/routes/admin.ts
@@ -437,6 +437,27 @@ export function registerAdminRoutes(app: FastifyInstance, ctx: AppContext): void
       return { ok: true, mode: body.mode };
     });
 
+    // ---- webhook verbosity ----
+    // Only the successful per-chapter embeds are switchable. Failures are
+    // deliberately not offered as a toggle: there is no reading of this system
+    // in which silently dropping a failed upload is what an operator wanted.
+    scope.get(
+      "/api/v1/admin/webhook-verbosity",
+      { preHandler: requireScope("settings:read") },
+      async () => ({ uploadSuccesses: await ctx.settings.getWebhookUploadSuccesses() }),
+    );
+
+    scope.post(
+      "/api/v1/admin/webhook-verbosity",
+      { preHandler: requireScope("settings:write") },
+      async (req) => {
+        const body = z.object({ uploadSuccesses: z.boolean() }).parse(req.body);
+        await ctx.settings.setWebhookUploadSuccesses(body.uploadSuccesses);
+        await ctx.audit.record(actor(req), "webhook_verbosity.set", String(body.uploadSuccesses));
+        return { ok: true, uploadSuccesses: body.uploadSuccesses };
+      },
+    );
+
     // ---- bundles ----
     scope.post(
       "/api/v1/admin/bundles",

--- a/src/core/api/session.ts
+++ b/src/core/api/session.ts
@@ -125,7 +125,10 @@ export function cleanActor(raw: string): string | null {
 }
 
 const TokenLogin = z.object({
-  token: z.string().min(1).max(512),
+  // Trimmed to match `bearerToken()`, which has always trimmed: without this the
+  // same token authenticates a curl `Authorization: Bearer …` call and is
+  // rejected from the login form, purely because a paste carried a newline.
+  token: z.string().trim().min(1).max(512),
   actor: z.string().min(1).max(64).optional(),
 });
 

--- a/src/core/ingest/ingest.ts
+++ b/src/core/ingest/ingest.ts
@@ -7,6 +7,7 @@ import { JobStore } from "../store/jobs.js";
 import { ResultStore, type IngestOutcome } from "../store/results.js";
 import { ArtifactStore } from "../store/artifacts.js";
 import { AuditLog } from "../store/settings.js";
+import { ExtensionConfigStore } from "../store/extensionConfig.js";
 
 /**
  * Result-envelope ingestion: the ONLY path by which worker output enters the
@@ -21,6 +22,7 @@ export class IngestService {
   private readonly results: ResultStore;
   private readonly artifacts: ArtifactStore;
   private readonly audit: AuditLog;
+  private readonly extensionConfig: ExtensionConfigStore;
 
   constructor(
     private readonly prisma: PrismaClient,
@@ -30,6 +32,7 @@ export class IngestService {
     this.results = new ResultStore(prisma);
     this.artifacts = new ArtifactStore(prisma);
     this.audit = new AuditLog(prisma);
+    this.extensionConfig = new ExtensionConfigStore(prisma);
   }
 
   async ingest(rawEnvelope: unknown, workerId: string): Promise<IngestOutcome | { outcome: "invalid"; reason: string }> {
@@ -149,13 +152,34 @@ export class IngestService {
       return `mangadex group id ${envelope.mangadexGroupId} does not match manifest ${m.mangadex_group_id}`;
     }
 
-    // Languages come from the manifest ONLY. The worker also sends
-    // `overrideOptions.custom_language`, and unioning that in here would have
-    // let the envelope widen the very allowlist meant to constrain it.
-    const allowedLanguages = new Set(m.languages);
+    // Manifest languages, plus the MangaDex codes the operator mapped titles to
+    // via `custom_language`.
+    //
+    // The union is required for correctness, not convenience: `custom_language`
+    // exists precisely to publish a title in a language the extension's own
+    // catalogue does not name — mangaplus reports SPANISH ("es") for everything,
+    // while one title is actually Latin-American Spanish and is mapped to
+    // "es-la". Validating against the manifest alone rejected every chapter of
+    // that title as "not declared by manifest", which reads as a manifest
+    // mistake rather than as the override doing its job.
+    //
+    // Crucially the map is read from the DATABASE, never from the envelope. The
+    // worker also sends `overrideOptions.custom_language`, and trusting that
+    // would let a compromised worker widen the very allowlist meant to constrain
+    // it. The stored copy is operator-controlled and its values are validated
+    // against MANGADEX_LANGUAGES on write, so unioning it in adds no reachable
+    // value that an operator did not already choose. This mirrors
+    // findExtraChapters, which has always unioned the same map.
+    const customLanguages = Object.values(
+      (await this.extensionConfig.load(m.name)).custom_language,
+    );
+    const allowedLanguages = new Set([...m.languages, ...customLanguages]);
+    const declared = (): string =>
+      `declared: ${[...allowedLanguages].sort().join(", ") || "none"}`;
+
     for (const language of envelope.extensionLanguages) {
       if (!allowedLanguages.has(language)) {
-        return `extension language ${language} not declared by manifest`;
+        return `extension language ${language} not declared by manifest (${declared()})`;
       }
     }
 
@@ -180,7 +204,7 @@ export class IngestService {
         return `manga url host not in manifest allowed_hosts: ${chapter.mangaUrl}`;
       }
       if (chapter.chapterLanguage && !allowedLanguages.has(chapter.chapterLanguage)) {
-        return `chapter language ${chapter.chapterLanguage} not declared by manifest`;
+        return `chapter language ${chapter.chapterLanguage} not declared by manifest (${declared()})`;
       }
       // Grouping key for every downstream decision, including removal.
       if (chapter.mdMangaId !== null && !tracked.has(chapter.mdMangaId)) {
@@ -208,7 +232,7 @@ export class IngestService {
         return `untracked manga url host not in manifest allowed_hosts: ${manga.mangaUrl}`;
       }
       if (!allowedLanguages.has(manga.mangaLanguage)) {
-        return `untracked manga language ${manga.mangaLanguage} not declared by manifest`;
+        return `untracked manga language ${manga.mangaLanguage} not declared by manifest (${declared()})`;
       }
     }
     return null;

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -8,6 +8,7 @@ import type { MdChapterDetail, MdExtendedApi } from "./client.js";
 import type { DiscordEmbedInput, DiscordNotifier } from "./webhook.js";
 import { queueEmbed, queueFinishedEmbed, queueSummaryEmbed } from "./webhookEmbeds.js";
 import type { Chapter } from "./types.js";
+import type { SettingsStore } from "../store/settings.js";
 
 /**
  * Execution of a single claimed UploadTask — the TypeScript port of
@@ -27,8 +28,6 @@ import type { Chapter } from "./types.js";
  */
 
 const IMAGE_BATCH_SIZE = 10;
-const MD_CHAPTER_URL = "https://mangadex.org/chapter/";
-const MD_MANGA_URL = "https://mangadex.org/manga/";
 
 /** Failure that should send the task back to the queue with its message intact. */
 export class TaskError extends Error {
@@ -42,14 +41,27 @@ export interface TaskWorkerDeps {
   prisma: PrismaClient;
   md: MdExtendedApi;
   notifier: DiscordNotifier;
+  settings: SettingsStore;
   config: Config;
   log: Logger;
 }
 
 export class UploadTaskWorkers {
   private pending: DiscordEmbedInput[] = [];
+  /**
+   * Whether per-chapter embeds are sent for uploads that succeeded. Refreshed
+   * once per drain rather than read per chapter: a setting changed halfway
+   * through a batch should not split it into two different reporting styles,
+   * and it saves a query per task.
+   */
+  private sendSuccesses = false;
 
   constructor(private readonly deps: TaskWorkerDeps) {}
+
+  /** Re-read the reporting settings. Call once at the start of each drain. */
+  async refreshReporting(): Promise<void> {
+    this.sendSuccesses = await this.deps.settings.getWebhookUploadSuccesses();
+  }
 
   /** Run one claimed task. Throws on failure; the caller requeues. */
   async execute(task: UploadTask): Promise<void> {
@@ -572,21 +584,21 @@ export class UploadTaskWorkers {
     detail?: string,
   ): void {
     if (!this.deps.notifier.enabled) return;
-    const lines = [
-      `Manga: ${chapter.mangaName ?? "unknown"}`,
-      `Chapter: ${chapter.chapterNumber ?? "-"}${chapter.chapterTitle ? ` — ${chapter.chapterTitle}` : ""}`,
-      `Language: \`${chapter.chapterLanguage ?? "-"}\``,
-    ];
-    if (mdChapterId) lines.push(`MangaDex chapter: ${MD_CHAPTER_URL}${mdChapterId}`);
-    if (chapter.mdMangaId) lines.push(`MangaDex manga: ${MD_MANGA_URL}${chapter.mdMangaId}`);
-    if (chapter.chapterUrl) lines.push(`Source: ${chapter.chapterUrl}`);
-    if (detail) lines.push("", detail);
+
+    // A successful upload is the expected case, and one embed per chapter turns
+    // the channel into a transcript in which the failures — the only entries
+    // anyone can act on — scroll past unread. Off unless an operator asks for
+    // them; the run-level "Found N chapters" embed already reports the work.
+    // Failures are always sent: dropping one silently has no reading in which
+    // it is what the operator wanted.
+    if (success && !this.sendSuccesses) return;
 
     // The Python shape, not a per-action status line: one field carrying
     // Success/Manga/Chapter/Extension plus the language, title, expiry and the
     // four links, titled after the queue that did the work. A channel that has
-    // been reading these for years should not have to relearn them.
-    this.pending.push(queueEmbed(action, chapter, success));
+    // been reading these for years should not have to relearn them. The failure
+    // reason rides along as the description — see queueEmbed.
+    this.pending.push(queueEmbed(action, chapter, success, detail));
   }
 }
 

--- a/src/core/md/webhookEmbeds.ts
+++ b/src/core/md/webhookEmbeds.ts
@@ -200,10 +200,20 @@ export function updatesEmbeds(input: UpdatesInput): DiscordEmbedInput[] {
  * "Editor"). The new pipeline has one uploader draining typed queues, so the
  * kind of work is the closest equivalent and is what is used here.
  */
-export function queueEmbed(workerType: string, chapter: EmbedChapter, processed: boolean): DiscordEmbedInput {
+export function queueEmbed(
+  workerType: string,
+  chapter: EmbedChapter,
+  processed: boolean,
+  detail?: string | null,
+): DiscordEmbedInput {
   return {
     title: titleCase(workerType),
     colour: COLOUR_DEFAULT,
+    // Only on failure, and only when there is something to say. Python's embed
+    // had no description, and a successful upload needs no explanation — but a
+    // failure that does not say why is a notification the operator cannot act
+    // on, which is the whole reason to be told about it.
+    ...(!processed && detail ? { description: detail } : {}),
     timestamp: new Date().toISOString(),
     fields: [chapterField(chapter, { success: processed, failedUpload: !processed })],
   };
@@ -302,6 +312,87 @@ export function messageEmbed(
     timestamp: new Date().toISOString(),
     ...(options.extensionName ? { footer: `extensions.${options.extensionName}` } : {}),
   };
+}
+
+// ------------------------------------------------------- run-level messages
+//
+// The five `PubloaderWebhook` calls the Python run made around each extension.
+// They are what tells a channel that a run started, what it found, and whether
+// it blew up — without them the only traffic is per-chapter upload results,
+// which says nothing until uploads are already happening.
+//
+// Titles are reproduced verbatim, including Python's `extensions.` prefix on
+// two of the five (`normalised_extension_name` in load_extensions.py:283) and
+// its absence on the other three. The inconsistency is Python's; a channel that
+// has been reading these for years should not have to relearn them.
+
+/** Python batched untracked series 30 to a message. */
+export const UNTRACKED_PER_EMBED = 30;
+
+export interface UntrackedMangaLike {
+  mangaName?: string | null;
+  mangaLanguage?: string | null;
+  mangaId?: string | null;
+  mangaUrl?: string | null;
+}
+
+/**
+ * `send_untracked_manga_webhook`: series the extension reports that have no
+ * MangaDex mapping yet, so somebody can go and create or link them.
+ *
+ * Note the count in every title is the TOTAL, not the size of that page — a
+ * reader seeing "47 Untracked Manga (2)" learns there are 47 in all, which is
+ * the number that matters.
+ */
+export function untrackedMangaEmbeds(
+  extensionName: string,
+  manga: readonly UntrackedMangaLike[],
+): DiscordEmbedInput[] {
+  if (manga.length === 0) return [];
+  const pages: UntrackedMangaLike[][] = [];
+  for (let i = 0; i < manga.length; i += UNTRACKED_PER_EMBED) {
+    pages.push(manga.slice(i, i + UNTRACKED_PER_EMBED));
+  }
+  return pages.map((page, index) => ({
+    title: `${manga.length} Untracked Manga${index > 0 ? ` (${index + 1})` : ""}`,
+    description: page
+      .map(
+        (m) =>
+          `**${m.mangaName ?? "unknown"}** (${m.mangaLanguage ?? "-"}): ` +
+          `[${m.mangaId ?? "-"}](${m.mangaUrl ?? ""})`,
+      )
+      .join("\n"),
+    colour: COLOUR_DEFAULT,
+    timestamp: new Date().toISOString(),
+    footer: `extensions.${extensionName}`,
+  }));
+}
+
+/** `Reading data from {extension}`: the run has started on this extension. */
+export function runStartedEmbed(extensionName: string): DiscordEmbedInput {
+  return messageEmbed(`Reading data from ${extensionName}`, null, { extensionName });
+}
+
+/** `Found N chapters for extensions.{extension}`: the size of the work ahead. */
+export function foundChaptersEmbed(extensionName: string, count: number): DiscordEmbedInput {
+  return messageEmbed(`Found ${count} chapters for extensions.${extensionName}`, null, {
+    extensionName,
+  });
+}
+
+/** `No new updates found for {extension}`: the run's other terminal state. */
+export function noUpdatesEmbed(extensionName: string): DiscordEmbedInput {
+  return messageEmbed(`No new updates found for ${extensionName}`, null, { extensionName });
+}
+
+/** `Error in extensions.{extension}`: red, with the exception in a code fence. */
+export function runErrorEmbed(extensionName: string, error: unknown): DiscordEmbedInput {
+  const text = error instanceof Error ? error.message : String(error);
+  return messageEmbed(
+    `Error in extensions.${extensionName}`,
+    `An exception occurred:\n\`\`\`\n${text.slice(0, 1800)}\n\`\`\``,
+    { colour: "FF0000", extensionName },
+  );
 }
 
 /**

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -5,7 +5,14 @@ import { type MangaRecord } from "../../contracts/records.js";
 import { Manifest } from "../../contracts/manifest.js";
 import { uploadedChapterColumns } from "../md/chapterRows.js";
 import type { DiscordEmbedInput } from "../md/webhook.js";
-import { updatesEmbeds } from "../md/webhookEmbeds.js";
+import {
+  foundChaptersEmbed,
+  noUpdatesEmbed,
+  runErrorEmbed,
+  untrackedMangaEmbeds,
+  updatesEmbeds,
+  type UntrackedMangaLike,
+} from "../md/webhookEmbeds.js";
 import { chapterFromRecord, type Chapter, type MdApi, type MdChapter } from "../md/types.js";
 import { ExtensionConfigStore } from "../store/extensionConfig.js";
 import { ResultStore } from "../store/results.js";
@@ -135,6 +142,41 @@ export class RunProcessor {
     }
   }
 
+  /**
+   * The three run-level embeds Python sent per extension: the untracked series
+   * it found, and either "Found N chapters" or "No new updates found".
+   *
+   * Swallows failures for the same reason reportUpdates does — a Discord outage
+   * must not fail a run whose real work succeeded.
+   */
+  private async reportRunSummary(
+    extension: string,
+    untracked: readonly UntrackedMangaLike[],
+    updatedCount: number,
+  ): Promise<void> {
+    if (!this.notifier?.enabled) return;
+    try {
+      const embeds = [
+        ...untrackedMangaEmbeds(extension, untracked),
+        updatedCount > 0 ? foundChaptersEmbed(extension, updatedCount) : noUpdatesEmbed(extension),
+      ];
+      await this.notifier.send(embeds);
+    } catch (err) {
+      this.log.warn({ err, extension }, "could not send the run summary webhook");
+    }
+  }
+
+  /** `Error in extensions.{name}`, red, with the exception in a code fence. */
+  private async reportRunError(extension: string, err: unknown): Promise<void> {
+    if (!this.notifier?.enabled) return;
+    try {
+      await this.notifier.send([runErrorEmbed(extension, err)]);
+    } catch (sendErr) {
+      // Never let the error reporter mask the error it was reporting.
+      this.log.warn({ err: sendErr, extension }, "could not send the run error webhook");
+    }
+  }
+
   /** Process every run currently waiting in INGESTING. Returns the count. */
   async tick(): Promise<number> {
     const attempted = new Set<string>();
@@ -152,6 +194,11 @@ export class RunProcessor {
         // Deliberately left in INGESTING: the next tick retries, and every
         // effect this run may already have had is idempotent.
         this.log.error({ err, runId: run.id, extension: run.extension }, "run processing failed");
+        // Python's `Error in extensions.{name}` embed. A run that keeps failing
+        // is otherwise completely silent in Discord — it never reaches the
+        // "Found N chapters" line, so the channel just shows nothing and the
+        // absence reads as "no updates today".
+        await this.reportRunError(run.extension, err);
       }
     }
     return processed;
@@ -222,6 +269,12 @@ export class RunProcessor {
       manifest?.chapter_removal_mode ?? (await this.settings.getRemovalMode());
 
     await this.persistUntrackedManga(run.extension, merged.untrackedManga, log);
+
+    // The run-level report Python sent around each extension: what turned up,
+    // and how much of it. Without these the channel only ever hears about
+    // individual uploads, which says nothing on a run that found nothing — the
+    // case where an operator most wants to know the run happened at all.
+    await this.reportRunSummary(run.extension, merged.untrackedManga, merged.updatedChapters.length);
 
     const updatedByManga = groupByMdManga(merged.updatedChapters);
     const allByManga = merged.allChapters === null ? null : groupByMdManga(merged.allChapters);

--- a/src/core/scheduler/service.ts
+++ b/src/core/scheduler/service.ts
@@ -7,8 +7,15 @@ import { BundleStore } from "../store/bundles.js";
 import { SettingsStore, AuditLog } from "../store/settings.js";
 import { UploadTaskStore } from "../store/uploadTasks.js";
 import { computeSegments, dueSlot, effectiveSchedules, slotId } from "./slots.js";
+import type { DiscordEmbedInput } from "../md/webhook.js";
+import { runStartedEmbed } from "../md/webhookEmbeds.js";
+import type { RepoSyncResult } from "../webhooks/autoSync.js";
 
 const LAST_TICK_KEY = "scheduler_last_tick";
+const GITHUB_SYNC_LAST_KEY = "github_auto_sync_last";
+/** How often the repos are polled. The push webhook covers the fast path;
+ * this only has to catch what it missed, so it is deliberately slow. */
+const GITHUB_SYNC_INTERVAL_MS = 15 * 60 * 1000;
 
 /**
  * The scheduling loop: turns due schedule slots into durable runs+jobs, and
@@ -23,16 +30,35 @@ export class SchedulerService {
   private readonly uploadTasks: UploadTaskStore;
   private readonly audit: AuditLog;
 
+  /**
+   * Where the "run started" notice goes. Optional for the same reason the
+   * processor's is: scheduling must keep working when Discord is not configured
+   * or is down.
+   */
+  private readonly notifier: { enabled: boolean; send(embeds: DiscordEmbedInput[]): Promise<void> } | null;
+  /**
+   * Runs one GitHub poll. Injected rather than built here so the scheduler
+   * core keeps no GitHub dependency, and so tests drive it without a network.
+   * Absent means the deployment has no repos configured.
+   */
+  private readonly autoSync: (() => Promise<RepoSyncResult[]>) | null;
+
   constructor(
     private readonly prisma: PrismaClient,
     private readonly log: Logger,
     retry: { baseSeconds: number; maxSeconds: number },
+    options: {
+      notifier?: { enabled: boolean; send(embeds: DiscordEmbedInput[]): Promise<void> };
+      autoSync?: () => Promise<RepoSyncResult[]>;
+    } = {},
   ) {
     this.jobs = new JobStore(prisma, retry);
     this.bundles = new BundleStore(prisma);
     this.settings = new SettingsStore(prisma);
     this.uploadTasks = new UploadTaskStore(prisma);
     this.audit = new AuditLog(prisma);
+    this.notifier = options.notifier ?? null;
+    this.autoSync = options.autoSync ?? null;
   }
 
   /** One scheduler tick. Exposed for tests; the service loop calls it forever. */
@@ -68,6 +94,52 @@ export class SchedulerService {
     const sweptTasks = await this.uploadTasks.sweepExpired();
     if (sweptTasks > 0) {
       this.log.warn({ count: sweptTasks }, "requeued expired upload-task leases");
+    }
+
+    // Last, and isolated: publishing extension code is the least urgent thing
+    // this tick does and the most likely to be slow (a 32 MB archive per changed
+    // repo), so it must not be able to delay or abort the queue work above.
+    try {
+      await this.maybeSyncGithub(now);
+    } catch (err) {
+      this.log.error({ err }, "github auto-sync failed");
+    }
+  }
+
+  /**
+   * Poll GitHub for changed extensions, at most once per SYNC_INTERVAL_MS.
+   *
+   * Rate-limited by a persisted timestamp rather than a timer so that restarts
+   * do not reset the clock — a crash-looping scheduler must not turn into a
+   * GitHub API hammer.
+   */
+  private async maybeSyncGithub(now: Date): Promise<void> {
+    if (!this.autoSync) return;
+    if (!(await this.settings.getGithubAutoSync())) return;
+
+    const lastRaw = await this.settings.getSetting(GITHUB_SYNC_LAST_KEY);
+    const last = lastRaw ? Date.parse(lastRaw) : 0;
+    if (Number.isFinite(last) && now.getTime() - last < GITHUB_SYNC_INTERVAL_MS) return;
+    // Written BEFORE the work, so a sync that throws or hangs still holds the
+    // interval open rather than retrying on every tick.
+    await this.settings.setSetting(GITHUB_SYNC_LAST_KEY, now.toISOString());
+
+    const results = await this.autoSync();
+    for (const result of results) {
+      const published = result.outcomes.filter((o) => o.status === "published");
+      if (published.length > 0) {
+        this.log.info(
+          { repo: result.repo, commit: result.commit, extensions: published.map((o) => o.extension) },
+          "github auto-sync published new extension bundles",
+        );
+        await this.audit.record("scheduler", "github.autosync", result.repo, {
+          commit: result.commit,
+          published: published.map((o) => ({ extension: o.extension, version: o.version })),
+        });
+      }
+      if (result.status === "failed") {
+        this.log.warn({ repo: result.repo, detail: result.detail }, "github auto-sync had failures");
+      }
     }
   }
 
@@ -181,8 +253,27 @@ export class SchedulerService {
         kind: opts.kind,
         idempotencyKey: opts.idempotencyKey,
       });
+      // Python announced each extension as it began reading it. Only on
+      // `created`: createRun is idempotent by key, and a duplicate trigger must
+      // not produce a second "started" that implies a second run.
+      await this.reportRunStarted(manifest.name);
     }
     return { runId: run.id, created, segments: Math.max(1, segments.length) };
+  }
+
+  /**
+   * `Reading data from {extension}`: the run has begun.
+   *
+   * Swallows failures — a Discord outage must not stop runs being scheduled,
+   * which is the one thing this service exists to do.
+   */
+  private async reportRunStarted(extension: string): Promise<void> {
+    if (!this.notifier?.enabled) return;
+    try {
+      await this.notifier.send([runStartedEmbed(extension)]);
+    } catch (err) {
+      this.log.warn({ err, extension }, "could not send the run started webhook");
+    }
   }
 
 }

--- a/src/core/store/jobs.ts
+++ b/src/core/store/jobs.ts
@@ -436,6 +436,82 @@ export class JobStore {
     return { cancelled: cancelled.count, flagged: flagged.count };
   }
 
+  /**
+   * Kill one run and everything it has outstanding.
+   *
+   * Distinct from `cancel(jobId)`, which is graceful: it flags a running job and
+   * lets the worker finish its current step. This is the operator saying "stop
+   * this run now" — usually because it is doing something wrong — so every
+   * non-terminal job goes straight to CANCELLED rather than being asked nicely.
+   *
+   * That is safe in flight for two reasons already built into the system:
+   *
+   *  - `cancel_requested = true` is set on every job, and `claim` filters on it,
+   *    so nothing can be re-leased even after the lease sweeper requeues an
+   *    abandoned job to PENDING;
+   *  - ingest's lease-validity gate only accepts envelopes for a job in LEASED or
+   *    RUNNING, so a worker that finishes the work anyway has its envelope
+   *    superseded instead of committed. A killed run cannot produce late writes.
+   *
+   * The run itself is set to CANCELLED directly. `advanceRuns` only ever moves
+   * runs out of PENDING/EXECUTING, so it cannot resurrect this one — and it
+   * would otherwise have landed the run in DEAD_LETTER, which reads as a failure
+   * rather than a decision.
+   *
+   * Returns null when the run does not exist, and "rejected" when it has already
+   * finished — cancelling a PROCESSED run would be a lie, its work is done.
+   */
+  async cancelRun(
+    runId: string,
+  ): Promise<{ result: "cancelled" | "rejected"; jobsCancelled: number; previousState: string } | null> {
+    const run = await this.prisma.run.findUnique({ where: { id: runId } });
+    if (!run) return null;
+
+    const TERMINAL = ["PROCESSED", "FAILED", "DEAD_LETTER", "CANCELLED"];
+    if (TERMINAL.includes(run.state)) {
+      return { result: "rejected", jobsCancelled: 0, previousState: run.state };
+    }
+
+    const jobs = await this.prisma.job.updateMany({
+      where: { runId, state: { in: ["PENDING", "LEASED", "RUNNING"] } },
+      data: { state: "CANCELLED", cancelRequested: true },
+    });
+    await this.prisma.run.updateMany({
+      // Guarded on the state we read, so two operators cancelling at once do not
+      // both count as the one that did it.
+      where: { id: runId, state: run.state },
+      data: { state: "CANCELLED", completedAt: new Date() },
+    });
+
+    return { result: "cancelled", jobsCancelled: jobs.count, previousState: run.state };
+  }
+
+  /**
+   * Kill every run that has not finished, optionally for one extension.
+   *
+   * The blunt instrument, for when something is wrong across the board and
+   * cancelling runs one id at a time is not fast enough.
+   */
+  async cancelActiveRuns(extension?: string): Promise<{ runs: number; jobs: number }> {
+    const active = await this.prisma.run.findMany({
+      where: {
+        state: { in: ["PENDING", "EXECUTING", "INGESTING"] },
+        ...(extension ? { extension } : {}),
+      },
+      select: { id: true },
+    });
+    let jobs = 0;
+    let runs = 0;
+    for (const { id } of active) {
+      const outcome = await this.cancelRun(id);
+      if (outcome?.result === "cancelled") {
+        runs += 1;
+        jobs += outcome.jobsCancelled;
+      }
+    }
+    return { runs, jobs };
+  }
+
   /** Same, for every job pinned to one bundle — used when a bundle is yanked. */
   async cancelAllForBundle(sha256: string): Promise<{ cancelled: number; flagged: number }> {
     const cancelled = await this.prisma.job.updateMany({

--- a/src/core/store/settings.ts
+++ b/src/core/store/settings.ts
@@ -3,6 +3,8 @@ import type { PrismaClient } from "@prisma/client";
 const PAUSE_KEY = "pause_until";
 const REMOVAL_MODE_KEY = "chapter_removal_mode";
 const SIGNUPS_KEY = "dash_signups_enabled";
+const WEBHOOK_SUCCESSES_KEY = "webhook_upload_successes";
+const GITHUB_AUTO_SYNC_KEY = "github_auto_sync";
 export const VALID_REMOVAL_MODES = ["unavailable", "delete"] as const;
 export type RemovalMode = (typeof VALID_REMOVAL_MODES)[number];
 export const DEFAULT_REMOVAL_MODE: RemovalMode = "unavailable";
@@ -73,6 +75,51 @@ export class SettingsStore {
 
   async setSignupsEnabled(enabled: boolean): Promise<void> {
     await this.setSetting(SIGNUPS_KEY, enabled ? "true" : "false");
+  }
+
+  // -- webhook verbosity --
+
+  /**
+   * Whether a per-chapter embed is sent for uploads that SUCCEEDED.
+   *
+   * Python sent one either way, which on a normal run means the channel is
+   * almost entirely "Success: True" — and a failure, the only thing anyone
+   * needs to act on, scrolls past between them. Off by default so the channel
+   * carries exceptions rather than a transcript; the run-level "Found N
+   * chapters" embed already says the work happened.
+   *
+   * Failures are NOT configurable: there is no reading of this system where
+   * silently dropping a failed upload is what the operator wanted.
+   */
+  async getWebhookUploadSuccesses(): Promise<boolean> {
+    return (await this.getSetting(WEBHOOK_SUCCESSES_KEY)) === "true";
+  }
+
+  async setWebhookUploadSuccesses(enabled: boolean): Promise<void> {
+    await this.setSetting(WEBHOOK_SUCCESSES_KEY, enabled ? "true" : "false");
+  }
+
+  // -- github auto-sync --
+
+  /**
+   * Whether the scheduler polls the configured GitHub repos and publishes what
+   * changed.
+   *
+   * On by default. The push webhook is the fast path, but it fails silently —
+   * an unregistered hook or a dropped delivery just means extensions quietly
+   * stop updating — and polling is the only check that does not depend on
+   * anything inbound. Publishing is idempotent, so the two overlapping costs
+   * nothing.
+   *
+   * Turn it off to freeze the fleet on the currently published bundles, which
+   * is what you want while investigating a bad extension.
+   */
+  async getGithubAutoSync(): Promise<boolean> {
+    return (await this.getSetting(GITHUB_AUTO_SYNC_KEY)) !== "false";
+  }
+
+  async setGithubAutoSync(enabled: boolean): Promise<void> {
+    await this.setSetting(GITHUB_AUTO_SYNC_KEY, enabled ? "true" : "false");
   }
 
   // -- schedule overrides --

--- a/src/core/webhooks/autoSync.ts
+++ b/src/core/webhooks/autoSync.ts
@@ -1,0 +1,187 @@
+import { mkdtempSync, readdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { SettingsStore } from "../store/settings.js";
+import type { GithubApiConfig, GithubMetaClient } from "./repoMeta.js";
+import { githubMeta } from "./repoMeta.js";
+import { fetchRepoArchive, extractSubtree, type RepoArchiveFetcher } from "./repoArchive.js";
+import {
+  publishExtensionFromArchive,
+  type PublishDeps,
+  type PublishOutcome,
+} from "./pushHandler.js";
+
+/**
+ * Poll the configured GitHub repositories and publish what has changed.
+ *
+ * The push webhook already does this, and is better when it works: it fires
+ * within seconds and carries the exact commit. But it only works if GitHub can
+ * reach the core, if the hook is still registered on every repo, and if no
+ * delivery was dropped — none of which the platform can observe. When any of
+ * them is false the failure is *silent*: extensions simply stop updating, and
+ * the first symptom is a run producing stale results days later.
+ *
+ * So this exists as the floor, not the primary path. It answers "is what we
+ * published still what the repo says?" from our side, on a timer, and needs
+ * nothing inbound. Where the two overlap the work is idempotent: publishing an
+ * unchanged tree returns `unchanged` because the bundle hash is identical.
+ *
+ * Discovery is by directory, not by what is already published, so an extension
+ * ADDED to a repo is picked up. That is the difference between this and the
+ * sysops sync button, which walks published bundles and therefore can only ever
+ * update extensions somebody installed by hand first.
+ */
+
+/** Where the last successfully-synced commit per repo is remembered. */
+const SYNCED_HEAD_PREFIX = "github_synced_head:";
+
+/**
+ * Repo-relative directory holding one directory per extension. Matches
+ * `extensionRepoPath`, which the push path uses for the same layout.
+ */
+const EXTENSIONS_ROOT = "src";
+
+export interface AutoSyncDeps extends PublishDeps {
+  settings: SettingsStore;
+  /** Injected in tests so nothing here reaches the network. */
+  fetchArchive?: RepoArchiveFetcher;
+  github?: GithubMetaClient;
+}
+
+export interface AutoSyncConfig extends GithubApiConfig {
+  repos: readonly string[];
+}
+
+export interface RepoSyncResult {
+  repo: string;
+  /** Absent when the repo could not be reached. */
+  commit?: string;
+  status: "published" | "unchanged" | "failed";
+  detail?: string;
+  outcomes: PublishOutcome[];
+}
+
+/**
+ * One pass over every configured repo.
+ *
+ * Never throws: this runs on the scheduler's tick, and a GitHub outage must not
+ * take down scheduling. Every failure is reported as a result row instead.
+ */
+export async function autoSyncExtensions(
+  deps: AutoSyncDeps,
+  cfg: AutoSyncConfig,
+): Promise<RepoSyncResult[]> {
+  const github = deps.github ?? githubMeta;
+  const fetchArchive = deps.fetchArchive ?? fetchRepoArchive;
+  const results: RepoSyncResult[] = [];
+
+  for (const repo of cfg.repos) {
+    try {
+      const head = await github.head(cfg, repo);
+      const key = `${SYNCED_HEAD_PREFIX}${repo}`;
+      const lastSynced = await deps.settings.getSetting(key);
+
+      // The common case by far. Checked before downloading because an archive is
+      // up to 32 MB and most polls find nothing new.
+      if (lastSynced === head.sha) {
+        results.push({ repo, commit: head.sha, status: "unchanged", outcomes: [] });
+        continue;
+      }
+
+      const archive = await fetchArchive({
+        owner: cfg.owner,
+        repo,
+        ref: head.sha,
+        token: cfg.token,
+        apiUrl: cfg.apiUrl,
+      });
+
+      const extensions = listExtensionDirectories(archive);
+      if (extensions.length === 0) {
+        // Recorded as synced regardless: a repo with no `src/<ext>/manifest.json`
+        // is a repo we have nothing to do with, and re-downloading it every tick
+        // to learn that again is pure waste.
+        await deps.settings.setSetting(key, head.sha);
+        results.push({
+          repo,
+          commit: head.sha,
+          status: "unchanged",
+          detail: `no ${EXTENSIONS_ROOT}/<extension>/manifest.json in this repository`,
+          outcomes: [],
+        });
+        continue;
+      }
+
+      const outcomes: PublishOutcome[] = [];
+      for (const extension of extensions) {
+        outcomes.push(
+          await publishExtensionFromArchive(
+            archive,
+            extension,
+            head.sha,
+            deps,
+            {
+              actor: `github-poll:${repo}@${head.sha.slice(0, 7)}`,
+              via: "github-poll",
+              ref: head.defaultBranch,
+            },
+            { requireName: true },
+          ),
+        );
+      }
+
+      // Only remember the commit when nothing failed. A transient build or
+      // network failure must not mark this commit done — the next pass has to
+      // retry it, and recording it here would skip the repo until somebody
+      // pushed again, which is exactly the silent staleness this guards against.
+      const failed = outcomes.filter((o) => o.status === "failed");
+      if (failed.length === 0) await deps.settings.setSetting(key, head.sha);
+
+      results.push({
+        repo,
+        commit: head.sha,
+        status: failed.length > 0 ? "failed" : "published",
+        ...(failed.length > 0
+          ? { detail: `${failed.length} of ${outcomes.length} extensions failed to publish` }
+          : {}),
+        outcomes,
+      });
+    } catch (err) {
+      deps.log.warn({ err, repo }, "github auto-sync could not read the repository");
+      results.push({
+        repo,
+        status: "failed",
+        detail: err instanceof Error ? err.message : "GitHub lookup failed",
+        outcomes: [],
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * The extension directories present in a repo archive.
+ *
+ * A directory counts only if it holds a `manifest.json` — repos keep `src/lib`,
+ * `src/types` and similar beside the extensions, and trying to publish those
+ * would produce a failure row on every pass forever.
+ */
+export function listExtensionDirectories(archive: Buffer): string[] {
+  const workDir = mkdtempSync(join(tmpdir(), "publoader-autosync-"));
+  try {
+    try {
+      extractSubtree(archive, EXTENSIONS_ROOT, workDir);
+    } catch {
+      // No `src/` at all: not an extensions repo, or laid out differently.
+      return [];
+    }
+    return readdirSync(workDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((name) => existsSync(join(workDir, name, "manifest.json")))
+      .sort();
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -8,15 +8,42 @@ import { SettingsStore } from "../core/store/settings.js";
 import { shouldRestart } from "../core/sysops/restartSignal.js";
 import { startMetricsServer } from "../core/observability/metricsServer.js";
 import { collectInventoryMetrics } from "../core/observability/inventory.js";
+import { DiscordNotifier } from "../core/md/webhook.js";
+import { autoSyncExtensions } from "../core/webhooks/autoSync.js";
+import { parseRepoList } from "../core/api/routes/webhooks.js";
+import { BundleStore } from "../core/store/bundles.js";
+import { AuditLog } from "../core/store/settings.js";
 
 const config = loadConfig();
 const log = createLogger("core-scheduler", config.logLevel);
 const prisma = getPrisma(config.databaseUrl);
 const settings = new SettingsStore(prisma);
-const scheduler = new SchedulerService(prisma, log, {
-  baseSeconds: config.retryBaseSeconds,
-  maxSeconds: config.retryMaxSeconds,
-});
+const notifier = DiscordNotifier.fromConfig(config, log);
+
+// Polling the extension repos is only wired up when there are repos to poll:
+// with GITHUB_EXTENSIONS_REPOS unset there is nothing to compare against, and
+// an auto-sync that runs anyway would log a failure every quarter of an hour.
+const extensionRepos = parseRepoList(config.githubExtensionsRepos);
+const autoSync =
+  extensionRepos.length > 0
+    ? () =>
+        autoSyncExtensions(
+          { bundles: new BundleStore(prisma), audit: new AuditLog(prisma), log, settings },
+          {
+            repos: extensionRepos,
+            owner: config.githubRepoOwner,
+            apiUrl: config.githubApiUrl,
+            ...(config.githubToken ? { token: config.githubToken } : {}),
+          },
+        )
+    : undefined;
+
+const scheduler = new SchedulerService(
+  prisma,
+  log,
+  { baseSeconds: config.retryBaseSeconds, maxSeconds: config.retryMaxSeconds },
+  { notifier, ...(autoSync ? { autoSync } : {}) },
+);
 
 let running = true;
 process.on("SIGTERM", () => (running = false));

--- a/src/services/uploader.ts
+++ b/src/services/uploader.ts
@@ -36,7 +36,7 @@ const tasks = new UploadTaskStore(prisma);
 const settings = new SettingsStore(prisma);
 const md = new MdClient(config, prisma, log);
 const notifier = DiscordNotifier.fromConfig(config, log);
-const workers = new UploadTaskWorkers({ prisma, md, notifier, config, log });
+const workers = new UploadTaskWorkers({ prisma, md, notifier, settings, config, log });
 const titles = new TitleService(prisma, md, notifier, log);
 
 let running = true;
@@ -108,6 +108,10 @@ while (running) {
       await sleep(IDLE_SLEEP_MS);
       continue;
     }
+
+    // Once per pass, not per task: a setting changed mid-drain should not split
+    // one batch into two reporting styles.
+    await workers.refreshReporting();
 
     let processed = 0;
     // Per-kind counts, so the end-of-drain summary can name the queue that did

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -114,6 +114,28 @@ describe.skipIf(!dbReady())("control-plane API", () => {
     expect(noToken.statusCode).toBe(401);
   });
 
+  it("advertises a worker image that is configured, not frozen in the source", async () => {
+    // This regressed silently for three releases: the constant said 2.1.1 while
+    // the env var it reads was never passed to core-api at all, so every
+    // enrolment snippet handed out a two-release-old image and nothing in the
+    // system pointed at why. The assertion is deliberately "not a stale pin"
+    // rather than a specific tag — pinning the expected version here would rot
+    // in exactly the same way the thing it tests did.
+    const mint = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/enroll-tokens",
+      headers: admin,
+      payload: {},
+    });
+    const { workerImage } = mint.json();
+    expect(workerImage, "the snippet must name an image at all").toBeTruthy();
+    expect(workerImage).toContain("publoader-worker");
+    expect(
+      workerImage,
+      "unset PUBLOADER_WORKER_IMAGE must fall back to a tag that cannot go stale",
+    ).toBe("ardax/publoader-worker:latest");
+  });
+
   it("enrollment tokens are single-use and expiring", async () => {
     const mint = await app.inject({
       method: "POST",

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -6,6 +6,7 @@ import { createLogger } from "../../src/logging.js";
 import { buildContext } from "../../src/core/api/context.js";
 import { buildServer } from "../../src/core/api/server.js";
 import { closeDb, dbReady, resetDb, testPrisma } from "./db.js";
+import { ExtensionConfigStore } from "../../src/core/store/extensionConfig.js";
 
 /**
  * Control-plane API: enrollment lifecycle, audience separation, revocation,
@@ -341,6 +342,111 @@ describe.skipIf(!dbReady())("control-plane API", () => {
     expect(job.errorClass).toBe("POLICY");
     expect(await prisma.uploadTask.count()).toBe(0);
     expect(await prisma.resultSubmission.count({ where: { state: "QUARANTINED" } })).toBe(1);
+  });
+
+  /**
+   * `custom_language` exists to publish a title in a language the extension's
+   * catalogue does not name — mangaplus reports SPANISH for everything, while
+   * one title is Latin-American Spanish and is mapped to `es-la`. Validating
+   * chapters against the manifest alone rejected every chapter of that title,
+   * which reads as a manifest mistake rather than the override working.
+   *
+   * The three cases below are the whole contract: rejected without a mapping,
+   * accepted with one from the DATABASE, and — the reason the union was left out
+   * originally — never widened by the envelope itself.
+   */
+  describe("custom_language and the manifest allowlist", () => {
+    const envelopeWith = (
+      jobId: string,
+      leaseId: string,
+      sha: string,
+      language: string,
+      overrideOptions: Record<string, unknown> = {},
+    ) => ({
+      envelopeVersion: 1,
+      jobId,
+      leaseId,
+      segmentKey: null,
+      extension: "mangaplus",
+      bundleSha256: sha,
+      idempotencyKey: `res:${jobId}:${language}`,
+      status: "ok",
+      error: null,
+      updatedChapters: [
+        {
+          chapterId: "700",
+          chapterNumber: "1",
+          chapterLanguage: language,
+          chapterUrl: "https://mangaplus.shueisha.co.jp/viewer/700",
+          mangaId: "200159",
+          mdMangaId: "b3c7e5d1-0000-4000-8000-000000000001",
+        },
+      ],
+      allChapters: null,
+      untrackedManga: [],
+      trackedMangadexIds: [],
+      mangadexGroupId: manifest.mangadex_group_id,
+      overrideOptions,
+      extensionLanguages: ["en"],
+      stats: {},
+    });
+
+    /** Publish, enroll, trigger a run and take the lease. */
+    async function ready(): Promise<{ sha: string; jobId: string; leaseId: string; headers: Record<string, string> }> {
+      const sha = await publishBundle();
+      const { token } = await enrollWorker();
+      const headers = { authorization: `Bearer ${token}` };
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/admin/runs",
+        headers: admin,
+        payload: { extension: "mangaplus", kind: "FORCE" },
+      });
+      const lease = await app.inject({ method: "POST", url: "/api/v1/worker/lease", headers, payload: {} });
+      const leased = lease.json();
+      return { sha, jobId: leased.job.jobId, leaseId: leased.leaseId, headers };
+    }
+
+    async function submit(
+      headers: Record<string, string>,
+      jobId: string,
+      payload: Record<string, unknown>,
+    ) {
+      return app.inject({ method: "POST", url: `/api/v1/worker/jobs/${jobId}/results`, headers, payload });
+    }
+
+    it("rejects a language no manifest or mapping declares, and says what IS declared", async () => {
+      const { sha, jobId, leaseId, headers } = await ready();
+      const res = await submit(headers, jobId, envelopeWith(jobId, leaseId, sha, "es-la"));
+      expect(res.json().outcome).toBe("quarantined");
+      // The operator's next question is always "declared where?", so the error
+      // carries the answer rather than sending them to the manifest to guess.
+      expect(res.json().reason).toContain("es-la");
+      expect(res.json().reason).toContain("declared: en, es");
+    });
+
+    it("accepts it once an operator has mapped a title to that language", async () => {
+      const { sha, jobId, leaseId, headers } = await ready();
+      await new ExtensionConfigStore(prisma).replace("mangaplus", {
+        custom_language: { "200159": "es-la" },
+      });
+      const res = await submit(headers, jobId, envelopeWith(jobId, leaseId, sha, "es-la"));
+      expect(res.json().outcome).toBe("committed");
+    });
+
+    it("does NOT let the envelope's own custom_language widen the allowlist", async () => {
+      // The security property the union must not cost us: a worker that can
+      // declare its own languages can publish a title in any language it likes.
+      // The map is read from the database precisely so a compromised worker
+      // cannot vote on it.
+      const { sha, jobId, leaseId, headers } = await ready();
+      const res = await submit(
+        headers,
+        jobId,
+        envelopeWith(jobId, leaseId, sha, "es-la", { custom_language: { "200159": "es-la" } }),
+      );
+      expect(res.json().outcome).toBe("quarantined");
+    });
   });
 
   it("a persistently policy-violating job still dead-letters once attempts run out", async () => {

--- a/test/integration/cancelRun.test.ts
+++ b/test/integration/cancelRun.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { JobStore } from "../../src/core/store/jobs.js";
+import { closeDb, dbReady, resetDb, testPrisma } from "./db.js";
+
+/**
+ * Killing a run in progress.
+ *
+ * The point of a kill, as opposed to cancelling one job, is that NOTHING the run
+ * had outstanding may still land. Two properties carry that, and both are
+ * enforced elsewhere in the system, so the tests here check that cancelRun
+ * actually engages them:
+ *
+ *   - `cancel_requested` blocks a re-claim, so an abandoned job cannot be picked
+ *     up again after the lease sweeper requeues it;
+ *   - the run goes to CANCELLED directly, so `advanceRuns` — which only moves
+ *     PENDING/EXECUTING runs — can never carry it into processing.
+ */
+describe.skipIf(!dbReady())("cancelling a run", () => {
+  const prisma = testPrisma();
+  const store = new JobStore(prisma, { baseSeconds: 1, maxSeconds: 4 });
+
+  async function worker(name: string): Promise<string> {
+    const row = await prisma.worker.create({
+      data: { name, tokenHash: `hash-${name}`, status: "ACTIVE", trust: "TRUSTED", lastHeartbeatAt: new Date() },
+    });
+    return row.id;
+  }
+
+  async function runWith(segments: number, key = "cancel-run"): Promise<string> {
+    const { run } = await store.createRun({
+      idempotencyKey: key,
+      extension: "mangaplus",
+      extensionVersion: "1.0.0",
+      bundleSha256: "a".repeat(64),
+      kind: "UPDATE",
+      segments: Array.from({ length: segments }, (_, i) => ({
+        index: i,
+        total: segments,
+        key: `seg-${i}`,
+        mangaIds: [],
+      })),
+    });
+    return run.id;
+  }
+
+  const claim = (id: string) => store.claim(id, { trust: "TRUSTED", leaseTtlSeconds: 300 });
+
+  beforeEach(async () => {
+    await resetDb(prisma);
+  });
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("cancels queued jobs and the run in one action", async () => {
+    const runId = await runWith(3);
+    const outcome = await store.cancelRun(runId);
+
+    expect(outcome).toMatchObject({ result: "cancelled", jobsCancelled: 3, previousState: "PENDING" });
+    expect(await prisma.job.count({ where: { runId, state: "CANCELLED" } })).toBe(3);
+    expect((await prisma.run.findUniqueOrThrow({ where: { id: runId } })).state).toBe("CANCELLED");
+  });
+
+  it("kills a job a worker is already executing", async () => {
+    const a = await worker("a");
+    const runId = await runWith(2);
+    const leased = await claim(a);
+    expect(leased).not.toBeNull();
+
+    await store.cancelRun(runId);
+
+    const job = await prisma.job.findUniqueOrThrow({ where: { id: leased!.job.id } });
+    expect(job.state).toBe("CANCELLED");
+    // The flag is what the worker sees on its next renewal, and what stops the
+    // job being handed out again.
+    expect(job.cancelRequested).toBe(true);
+  });
+
+  it("leaves nothing claimable afterwards", async () => {
+    // The failure this guards against: a killed run whose jobs come back through
+    // the lease sweeper and get executed by somebody else minutes later.
+    const a = await worker("a");
+    const b = await worker("b");
+    const runId = await runWith(3);
+    await claim(a);
+    await store.cancelRun(runId);
+
+    // Simulate the sweeper putting an abandoned job back on the queue.
+    await prisma.job.updateMany({ where: { runId }, data: { state: "PENDING" } });
+    expect(await claim(b)).toBeNull();
+  });
+
+  it("does not let advanceRuns carry a cancelled run into processing", async () => {
+    const runId = await runWith(2);
+    await store.cancelRun(runId);
+    await store.advanceRuns();
+    // Not INGESTING, and not DEAD_LETTER either — this was a decision, not a
+    // failure, and the state an operator reads should say so.
+    expect((await prisma.run.findUniqueOrThrow({ where: { id: runId } })).state).toBe("CANCELLED");
+  });
+
+  it("refuses a run that has already finished", async () => {
+    const runId = await runWith(1);
+    await prisma.run.update({ where: { id: runId }, data: { state: "PROCESSED" } });
+    const outcome = await store.cancelRun(runId);
+    // Cancelling completed work would be a lie about what happened.
+    expect(outcome).toMatchObject({ result: "rejected", previousState: "PROCESSED" });
+  });
+
+  it("reports an unknown run rather than pretending to cancel it", async () => {
+    expect(await store.cancelRun("00000000-0000-4000-8000-000000000000")).toBeNull();
+  });
+
+  it("cancel-all stops every unfinished run, and only those", async () => {
+    const first = await runWith(2, "run-a");
+    const second = await runWith(2, "run-b");
+    await prisma.run.update({ where: { id: second }, data: { state: "PROCESSED" } });
+    const third = await runWith(1, "run-c");
+
+    const stopped = await store.cancelActiveRuns();
+    expect(stopped.runs).toBe(2);
+    expect(stopped.jobs).toBe(3);
+    expect((await prisma.run.findUniqueOrThrow({ where: { id: first } })).state).toBe("CANCELLED");
+    expect((await prisma.run.findUniqueOrThrow({ where: { id: third } })).state).toBe("CANCELLED");
+    // The finished one is untouched.
+    expect((await prisma.run.findUniqueOrThrow({ where: { id: second } })).state).toBe("PROCESSED");
+  });
+
+  it("cancel-all can be scoped to one extension", async () => {
+    const mine = await runWith(1, "run-mine");
+    const { run: other } = await store.createRun({
+      idempotencyKey: "run-other",
+      extension: "alpha_manga",
+      extensionVersion: "1.0.0",
+      bundleSha256: "b".repeat(64),
+      kind: "UPDATE",
+      segments: [],
+    });
+
+    const stopped = await store.cancelActiveRuns("mangaplus");
+    expect(stopped.runs).toBe(1);
+    expect((await prisma.run.findUniqueOrThrow({ where: { id: mine } })).state).toBe("CANCELLED");
+    expect((await prisma.run.findUniqueOrThrow({ where: { id: other.id } })).state).not.toBe("CANCELLED");
+  });
+});

--- a/test/integration/dashboard.test.ts
+++ b/test/integration/dashboard.test.ts
@@ -613,6 +613,37 @@ describe.skipIf(!dbReady())("dashboard sessions, accounts, and assets", () => {
     expect(await prisma.auditEvent.count({ where: { action: "session.login.rejected" } })).toBe(5);
   });
 
+  it("accepts the admin token with whitespace around it", async () => {
+    // Reported from production as "invalid admin token" on a token that was
+    // correct: the value is pasted, and a paste out of a terminal or password
+    // manager routinely carries a trailing newline. The bearer path has always
+    // trimmed, so the same token authenticated `curl -H 'Authorization: Bearer'`
+    // while the login form refused it — which sends the operator looking for a
+    // rotation problem that does not exist.
+    for (const padded of [`${ADMIN_TOKEN}\n`, ` ${ADMIN_TOKEN}`, `  ${ADMIN_TOKEN}\r\n`]) {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/admin/session",
+        payload: { token: padded, actor: "tester" },
+      });
+      expect(res.statusCode, JSON.stringify(padded)).toBe(200);
+    }
+  });
+
+  it("still refuses a token that is wrong once trimmed", async () => {
+    // Trimming must not have widened what counts as a match: whitespace is
+    // removed, nothing else is, and a token that differs in any real character
+    // is still rejected.
+    for (const wrong of [` ${ADMIN_TOKEN}x `, `${ADMIN_TOKEN.slice(0, -1)}\n`, "   ", `AD MIN${ADMIN_TOKEN}`]) {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/admin/session",
+        payload: { token: wrong, actor: "mallory" },
+      });
+      expect([400, 401], JSON.stringify(wrong)).toContain(res.statusCode);
+    }
+  });
+
   it("rejects forged, tampered, and expired session cookies", async () => {
     const cookie = await loginWithToken();
     const value = cookie.slice("publoader_session=".length);

--- a/test/unit/autoSync.test.ts
+++ b/test/unit/autoSync.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+import AdmZip from "adm-zip";
+import { autoSyncExtensions, listExtensionDirectories } from "../../src/core/webhooks/autoSync.js";
+import { createLogger } from "../../src/logging.js";
+
+/**
+ * The GitHub poll that catches what the push webhook missed.
+ *
+ * The behaviours worth pinning are the ones that decide whether an extension
+ * silently stops updating: what counts as an extension directory, when the
+ * commit is remembered, and — most importantly — that a failed publish is NOT
+ * remembered, because recording it would skip that commit until somebody
+ * pushed again.
+ */
+describe("github auto-sync", () => {
+  const log = createLogger("test-autosync", "error");
+
+  /** A repo zipball: GitHub wraps everything in one top-level directory. */
+  function archive(files: Record<string, string>): Buffer {
+    const zip = new AdmZip();
+    for (const [path, content] of Object.entries(files)) {
+      zip.addFile(`publoader-extensions-abc1234/${path}`, Buffer.from(content));
+    }
+    return zip.toBuffer();
+  }
+
+  const manifest = (name: string) =>
+    JSON.stringify({
+      name,
+      version: "1.0.0",
+      publoader_api: "^2.0.0",
+      runtime: "node",
+      entrypoint: "index.mjs",
+      mangadex_group_id: "4f1de6a2-f0c5-4ac5-bce5-02c7dbb67deb",
+      languages: ["en"],
+      allowed_hosts: ["example.com"],
+    });
+
+  /**
+   * An in-memory settings store: only get/set are used. The backing map is
+   * returned alongside so a test can assert on what was remembered, which is
+   * the whole point of several of these.
+   */
+  function settings(initial: Record<string, string> = {}): {
+    store: Map<string, string>;
+    fake: never;
+  } {
+    const store = new Map(Object.entries(initial));
+    return {
+      store,
+      fake: {
+        getSetting: async (k: string) => store.get(k) ?? null,
+        setSetting: async (k: string, v: string) => void store.set(k, v),
+        getGithubAutoSync: async () => true,
+      } as never,
+    };
+  }
+
+  const deps = (over: Record<string, unknown>) =>
+    ({
+      bundles: { publish: vi.fn() },
+      audit: { record: vi.fn() },
+      log,
+      ...over,
+    }) as never;
+
+  const cfg = { repos: ["publoader-extensions"], owner: "publoader", apiUrl: "https://api.github.com" };
+
+  describe("finding extensions in a repo", () => {
+    it("takes directories under src/ that have a manifest", () => {
+      const found = listExtensionDirectories(
+        archive({
+          "src/mangaplus/manifest.json": manifest("mangaplus"),
+          "src/mangaplus/index.mjs": "export default () => ({});",
+          "src/alpha/manifest.json": manifest("alpha"),
+          "src/alpha/index.mjs": "export default () => ({});",
+        }),
+      );
+      expect(found).toEqual(["alpha", "mangaplus"]);
+    });
+
+    it("ignores shared code that lives beside the extensions", () => {
+      // `src/lib` and friends are normal in these repos. Treating them as
+      // extensions would produce a failure row on every pass, forever.
+      const found = listExtensionDirectories(
+        archive({
+          "src/mangaplus/manifest.json": manifest("mangaplus"),
+          "src/lib/util.ts": "export const x = 1;",
+          "src/types/api.d.ts": "export {};",
+          "README.md": "# repo",
+        }),
+      );
+      expect(found).toEqual(["mangaplus"]);
+    });
+
+    it("returns nothing for a repo with no src/ at all", () => {
+      expect(listExtensionDirectories(archive({ "README.md": "# not an extensions repo" }))).toEqual([]);
+    });
+  });
+
+  describe("deciding what to do", () => {
+    it("does not download when the repo head is already the synced commit", async () => {
+      const fetchArchive = vi.fn();
+      const results = await autoSyncExtensions(
+        deps({
+          settings: settings({ "github_synced_head:publoader-extensions": "abc123" }).fake,
+          github: { head: async () => ({ sha: "abc123", defaultBranch: "main" }) },
+          fetchArchive,
+        }),
+        cfg,
+      );
+      // The common case: an archive is up to 32 MB and most polls find nothing.
+      expect(fetchArchive).not.toHaveBeenCalled();
+      expect(results[0]).toMatchObject({ status: "unchanged", commit: "abc123" });
+    });
+
+    it("publishes every extension in the repo when the head has moved", async () => {
+      // The outcome is built from the BundleStore's own row, so the fake has to
+      // carry `extension` — that is the field the caller keys everything on.
+      const publish = vi.fn().mockResolvedValue({
+        bundle: { extension: "mangaplus", version: "1.0.0", sha256: "f".repeat(64) },
+        created: true,
+      });
+      const store = settings();
+      const results = await autoSyncExtensions(
+        deps({
+          settings: store.fake,
+          bundles: { publish },
+          github: { head: async () => ({ sha: "def456", defaultBranch: "main" }) },
+          fetchArchive: async () =>
+            archive({
+              "src/mangaplus/manifest.json": manifest("mangaplus"),
+              "src/mangaplus/index.mjs": "export default () => ({ async collect() { return {}; } });",
+            }),
+        }),
+        cfg,
+      );
+      expect(results[0]!.outcomes.map((o) => o.extension)).toEqual(["mangaplus"]);
+      expect(publish).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT remember the commit when a publish failed", async () => {
+      // The rule that keeps a transient failure from becoming permanent
+      // staleness: remembering this commit would skip the repo until the next
+      // push, which is exactly what polling exists to catch.
+      const store = settings();
+      await autoSyncExtensions(
+        deps({
+          settings: store.fake,
+          bundles: { publish: vi.fn().mockRejectedValue(new Error("build failed")) },
+          github: { head: async () => ({ sha: "def456", defaultBranch: "main" }) },
+          fetchArchive: async () =>
+            archive({
+              "src/mangaplus/manifest.json": manifest("mangaplus"),
+              "src/mangaplus/index.mjs": "export default () => ({});",
+            }),
+        }),
+        cfg,
+      );
+      expect(store.store.get("github_synced_head:publoader-extensions")).toBeUndefined();
+    });
+
+    it("remembers a repo that simply has no extensions in it", async () => {
+      // Nothing to publish is a settled answer, not a failure — re-downloading
+      // every tick to learn it again is pure waste.
+      const store = settings();
+      const results = await autoSyncExtensions(
+        deps({
+          settings: store.fake,
+          github: { head: async () => ({ sha: "def456", defaultBranch: "main" }) },
+          fetchArchive: async () => archive({ "README.md": "# docs only" }),
+        }),
+        cfg,
+      );
+      expect(results[0]!.status).toBe("unchanged");
+      expect(store.store.get("github_synced_head:publoader-extensions")).toBe("def456");
+    });
+
+    it("reports a GitHub outage instead of throwing", async () => {
+      // This runs inside the scheduler tick; throwing here would take out
+      // scheduling, which is the one thing that service must keep doing.
+      const results = await autoSyncExtensions(
+        deps({
+          settings: settings().fake,
+          github: {
+            head: async () => {
+              throw new Error("502 Bad Gateway");
+            },
+          },
+        }),
+        cfg,
+      );
+      expect(results[0]).toMatchObject({ status: "failed", detail: "502 Bad Gateway" });
+    });
+
+    it("one broken repo does not stop the others", async () => {
+      const heads: Record<string, string> = { good: "aaa", bad: "bbb" };
+      const results = await autoSyncExtensions(
+        deps({
+          settings: settings({ "github_synced_head:good": "aaa" }).fake,
+          github: {
+            head: async (_c: unknown, repo: string) => {
+              if (repo === "bad") throw new Error("404 Not Found");
+              return { sha: heads[repo]!, defaultBranch: "main" };
+            },
+          },
+        }),
+        { ...cfg, repos: ["good", "bad"] },
+      );
+      expect(results).toHaveLength(2);
+      expect(results[0]!.status).toBe("unchanged");
+      expect(results[1]!.status).toBe("failed");
+    });
+  });
+});

--- a/test/unit/configSecrets.test.ts
+++ b/test/unit/configSecrets.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "../../src/config.js";
+
+/**
+ * Whitespace around the secrets that are compared byte-for-byte.
+ *
+ * These three values are typed or pasted into a `.env` by hand on every install,
+ * and they are the only config this system compares for exact equality — so they
+ * are the only ones where a stray newline is a login failure rather than a
+ * cosmetic difference. It reached production once as "invalid admin token"
+ * against a token that was correct, which reads as a rotation problem and sends
+ * the operator to re-issue a credential that was never wrong.
+ *
+ * `env()` already trims when a value arrives via the `_FILE` Docker-secrets
+ * convention — `cat`-ing a secret file is the obvious way to get a trailing
+ * newline. These tests cover the plain-variable path, which did not.
+ */
+describe("secret trimming", () => {
+  const TOKEN = "0123456789abcdef0123456789abcdef";
+
+  it("trims the admin token, however it was pasted", () => {
+    for (const raw of [`${TOKEN}\n`, ` ${TOKEN} `, `${TOKEN}\r\n`, `\t${TOKEN}`]) {
+      expect(loadConfig({ ADMIN_TOKEN: raw }).adminToken, JSON.stringify(raw)).toBe(TOKEN);
+    }
+  });
+
+  it("trims the worker and enrolment tokens", () => {
+    const cfg = loadConfig({ WORKER_TOKEN: ` wt_abc\n`, ENROLL_TOKEN: `pe_xyz\n` });
+    expect(cfg.workerToken).toBe("wt_abc");
+    expect(cfg.enrollToken).toBe("pe_xyz");
+  });
+
+  it("measures the token's length after trimming, not before", () => {
+    // The 16-character floor is a real check, and padding must not be able to
+    // carry a short token over it — nor to push a valid one out of range.
+    expect(() => loadConfig({ ADMIN_TOKEN: `short           \n` })).toThrow();
+    expect(loadConfig({ ADMIN_TOKEN: `  ${TOKEN}  ` }).adminToken).toBe(TOKEN);
+  });
+
+  it("leaves whitespace inside a value alone", () => {
+    // Only the ends are trimmed. A passphrase-style token with real spaces in
+    // it must survive intact, or trimming would silently change the credential.
+    const spaced = "correct horse battery staple";
+    expect(loadConfig({ ADMIN_TOKEN: `\n${spaced}\n` }).adminToken).toBe(spaced);
+  });
+
+  it("treats an all-whitespace token as unset rather than as a value", () => {
+    // `get()` maps "" to undefined; "   " is the same intent and must not become
+    // a 3-character credential that something could match against.
+    expect(() => loadConfig({ ADMIN_TOKEN: "     " })).toThrow();
+  });
+
+  it("does not trim secrets that are used as keys rather than compared", () => {
+    // Deliberate scope limit: the session secret is fed to HKDF, so its exact
+    // bytes only need to be stable, and silently changing them would invalidate
+    // every in-flight cookie on upgrade.
+    const secret = `${"k".repeat(32)}\n`;
+    expect(loadConfig({ SESSION_SECRET: secret }).sessionSecret).toBe(secret);
+  });
+});

--- a/test/unit/webhookEmbeds.test.ts
+++ b/test/unit/webhookEmbeds.test.ts
@@ -8,12 +8,17 @@ import {
   chapterFieldChunks,
   dupesEmbeds,
   formatLink,
+  foundChaptersEmbed,
   logEmbed,
   messageEmbed,
+  noUpdatesEmbed,
   notIndexedEmbed,
   queueEmbed,
   queueFinishedEmbed,
   queueSummaryEmbed,
+  runErrorEmbed,
+  runStartedEmbed,
+  untrackedMangaEmbeds,
   updatesEmbeds,
 } from "../../src/core/md/webhookEmbeds.js";
 
@@ -244,5 +249,79 @@ describe("the remaining Python webhooks", () => {
     expect(logEmbed("error", "it broke").title).toBe("ERROR");
     expect(logEmbed("error", "it broke").colour).toBe("E74C3C");
     expect(logEmbed("warn", "hmm").colour).toBe(COLOUR_DEFAULT);
+  });
+
+  // ------------------------------------------------- run-level messages
+  //
+  // These are the embeds that tell a channel a run happened at all. Without
+  // them the only traffic is per-chapter upload results, so a run that found
+  // nothing, or died before uploading, is indistinguishable from no run.
+
+  it("announces the run before anything has been found", () => {
+    const embed = runStartedEmbed("mangaplus");
+    expect(embed.title).toBe("Reading data from mangaplus");
+    expect(embed.footer).toBe("extensions.mangaplus");
+  });
+
+  it("reports the size of the work ahead, and says so when there is none", () => {
+    expect(foundChaptersEmbed("mangaplus", 12).title).toBe(
+      "Found 12 chapters for extensions.mangaplus",
+    );
+    // Python's own inconsistency, kept: this title has no `extensions.` prefix.
+    expect(noUpdatesEmbed("mangaplus").title).toBe("No new updates found for mangaplus");
+  });
+
+  it("puts the exception in a red embed, fenced", () => {
+    const embed = runErrorEmbed("mangaplus", new Error("upstream returned 503"));
+    expect(embed.title).toBe("Error in extensions.mangaplus");
+    expect(embed.colour).toBe("FF0000");
+    expect(embed.description).toContain("```");
+    expect(embed.description).toContain("upstream returned 503");
+  });
+
+  it("survives a thrown non-Error", () => {
+    // `throw "string"` is legal and does happen; the reporter must not itself
+    // throw while reporting.
+    expect(runErrorEmbed("x", "plain string").description).toContain("plain string");
+    expect(runErrorEmbed("x", undefined).description).toContain("undefined");
+  });
+
+  it("lists untracked series 30 to a message, counting the total in every title", () => {
+    const manga = Array.from({ length: 47 }, (_, i) => ({
+      mangaName: `Series ${i}`,
+      mangaLanguage: "en",
+      mangaId: String(i),
+      mangaUrl: `https://example.com/${i}`,
+    }));
+    const embeds = untrackedMangaEmbeds("mangaplus", manga);
+    expect(embeds).toHaveLength(2);
+    // The TOTAL, not the page size — "47" is the number the operator acts on.
+    expect(embeds[0]!.title).toBe("47 Untracked Manga");
+    expect(embeds[1]!.title).toBe("47 Untracked Manga (2)");
+    expect(embeds[0]!.description!.split("\n")).toHaveLength(30);
+    expect(embeds[1]!.description!.split("\n")).toHaveLength(17);
+    expect(embeds[0]!.description).toContain("**Series 0** (en): [0](https://example.com/0)");
+  });
+
+  it("says nothing when there are no untracked series", () => {
+    expect(untrackedMangaEmbeds("mangaplus", [])).toEqual([]);
+  });
+
+  it("tolerates untracked entries with missing fields", () => {
+    const [embed] = untrackedMangaEmbeds("mangaplus", [{ mangaName: null }]);
+    expect(embed!.description).toContain("**unknown**");
+  });
+
+  // ------------------------------------------------- queue embed detail
+
+  it("attaches the failure reason to a failed queue embed, and nothing to a success", () => {
+    // A failure the operator cannot diagnose is a notification that only tells
+    // them to go and look somewhere else.
+    const failed = queueEmbed("Upload", { chapterNumber: "1" }, false, "MangaDex returned 429");
+    expect(failed.description).toBe("MangaDex returned 429");
+    const ok = queueEmbed("Upload", { chapterNumber: "1" }, true, "Already on MangaDex.");
+    expect(ok.description).toBeUndefined();
+    // ...and a failure with no detail must not invent one.
+    expect(queueEmbed("Upload", { chapterNumber: "1" }, false).description).toBeUndefined();
   });
 });


### PR DESCRIPTION
Eight commits that landed after #28 was merged. The last one is the reason none
of them were ever checked.

## CI has been failing in 0s since the platform moved to the root

`defaults.run` was present with no keys. It must contain `shell` or
`working-directory`, so an empty mapping makes the entire workflow invalid —
every run, on master included, ended in 0s with "This run likely failed because
of a workflow file issue". **PR #28 merged with zero checks.**

The leftover is from `run.working-directory: platform`. When the platform moved
to the repository root the value was deleted and the empty container left behind
— the second time that same edit has broken CI here. The paths filter failed
identically: its other entries were removed, leaving it matching only the
workflow file.

Both variants are silent, in opposite directions. The paths filter reported *no
checks* while PRs still showed mergeable. This one reported a red check naming no
file, no line and no job, which reads like GitHub flakiness rather than a syntax
error committed here. `push-docker.yml` was unaffected, so image publishing kept
working and made the breakage easy to miss.

## Chapters in a mapped language were silently discarded

`custom_language` exists to publish a title in a language the extension's
catalogue does not name — mangaplus reports SPANISH for everything while one
title is Latin-American Spanish, mapped to `es-la`. Ingest validated against the
manifest alone and quarantined every chapter of that title.

The map is now unioned in, read from the **database** rather than the envelope:
operator-controlled, validated against `MANGADEX_LANGUAGES` on write, so a
compromised worker still cannot widen its own allowlist. `findExtraChapters` has
always unioned the same map; ingest was the inconsistent one.

## A run was invisible unless it uploaded

Five run-level Python webhooks had never been ported: `Reading data from …`, the
untracked-series list, `Found N chapters …` / `No new updates found …`, and
`Error in …`. Without them a run that found nothing, or died before uploading,
is indistinguishable from no run at all.

Per-chapter success embeds are now off by default (failures always sent, and now
carrying the reason — which was being computed into a `lines` array that was
never read).

## No way to stop a run

`cancel(jobId)` stops one job, which on a partitioned run is worse than nothing:
the other segments finish and the run is processed from incomplete results — on a
CLEAN run the processor reads the missing segment's chapters as vanished upstream
and queues them for removal. `cancelRun` cancels every outstanding job and sets
the run to CANCELLED, so it never reaches the processor.

## Extensions only updated if a webhook arrived

The push hook is the fast path but fails silently. The scheduler now polls the
configured repos every 15 minutes, discovering by directory so a **newly added**
extension is picked up — the sysops sync walks published bundles and can only
update what someone installed by hand.

## The enrolment snippet advertised a two-release-old image

`admin.ts` read `PUBLOADER_WORKER_IMAGE`, but that variable was only ever set in
the *worker's* `.env` and never passed to core-api, so the env path was dead and
the hardcoded `2.1.1` always shipped. Fixed across compose, `.env.example` and
both fallbacks.

## Verified

- **861 tests, all 45 files, nothing skipped**, against a real Postgres.
- `pnpm lint` and `tsc --noEmit` clean.
- 2.1.4 and 2.1.5 published multi-arch (amd64 + arm64), `latest` matching.
- The tests for the language union include the one that matters: an envelope
  supplying its own `custom_language` must NOT widen the allowlist.