### PR TITLE
Put the series map back into GitHub once a week

### DIFF
--- a/docker/core/.env.production.example
+++ b/docker/core/.env.production.example
@@ -124,6 +124,25 @@ GITHUB_EXTENSIONS_REPOS=publoader-extensions,publoader-extensions-private
 # (`./scripts/publoader prod upgrade <tag>`). Set it only so the delivery log
 # says so explicitly instead of "untracked repo".
 GITHUB_CORE_REPO=publoader
-# Fine-grained PAT, Contents:read on the extensions repos. Required for the
-# private one. Prefer GITHUB_TOKEN_FILE with a Docker secret.
+# Fine-grained PAT on the extensions repos. Contents:read is enough for the
+# webhook (required for the private repo); the weekly series-map sync below
+# also needs Contents:WRITE. Prefer GITHUB_TOKEN_FILE with a Docker secret.
 GITHUB_TOKEN=
+
+# --- Series-map sync (optional) ---------------------------------------------
+# Once a week, core-api writes the tracked_manga table back into each
+# extension's manga_id_map.json in GITHUB_EXTENSIONS_REPOS, so the file
+# contributors read matches what is actually tracked. See
+# docs/operations.md §"Series-map sync".
+#
+# It is inert without a Contents:write token, it never creates a file and never
+# empties one, it refuses a write that would delete more than half a file's
+# mappings, and it does not sync on the first boot after being enabled — the
+# first automatic commit is one interval later. Preview any time with
+# `publoader-admin maps sync --dry-run`.
+#
+# Turn this OFF in any environment that shares these repos with another
+# deployment; two of them writing the same files is a fight, not a sync.
+MAP_SYNC_ENABLED=true
+# Weekly. Minimum 1 hour.
+MAP_SYNC_INTERVAL_HOURS=168

--- a/docker/core/.env.staging.example
+++ b/docker/core/.env.staging.example
@@ -107,3 +107,9 @@ GITHUB_REPO_OWNER=publoader
 GITHUB_EXTENSIONS_REPOS=publoader-extensions,publoader-extensions-private
 GITHUB_CORE_REPO=publoader
 GITHUB_TOKEN=
+
+# Series-map write-back, off here on purpose: staging and production share the
+# extensions repos, and both writing manga_id_map.json would have them
+# overwriting each other with whichever database is stale. See
+# docs/operations.md §"Series-map sync".
+MAP_SYNC_ENABLED=false

--- a/docker/core/docker-compose.yml
+++ b/docker/core/docker-compose.yml
@@ -239,6 +239,14 @@ services:
       GITHUB_CORE_REPO: ${GITHUB_CORE_REPO:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       GITHUB_API_URL: ${GITHUB_API_URL:-https://api.github.com}
+      # --- series-map write-back (core-api only) ---------------------------
+      # Once a week, writes tracked_manga back into each extension's
+      # manga_id_map.json so the files contributors read stop going stale.
+      # Needs GITHUB_TOKEN to have Contents:WRITE; inert without it. It never
+      # syncs on the first boot after being enabled, so a deploy cannot produce
+      # commits. Set false on any second environment pointed at the same repos.
+      MAP_SYNC_ENABLED: ${MAP_SYNC_ENABLED:-true}
+      MAP_SYNC_INTERVAL_HOURS: ${MAP_SYNC_INTERVAL_HOURS:-168}
       DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID:-}
       DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET:-}
     expose:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -353,6 +353,7 @@ Pausing stops new leases (`routes/worker.ts:110`), scheduled run creation
 | `GET` | `/extensions/:name/tracked` | `tracked:read` | Every publisher-id → MangaDex-title mapping |
 | `PUT` | `/extensions/:name/tracked` | `tracked:append` | `{mangaId, mdMangaId}`; upsert, records the actor as `source`. **403** when the mapping already exists and points somewhere else and the caller lacks `tracked:write` — repointing a series is an edit, and a silent one |
 | `POST` | `/extensions/:name/tracked/batch` | `tracked:append` | Bulk curation — see below |
+| `POST` | `/maps/sync` | `tracked:write` | Write the tracked map back to `manga_id_map.json` in GitHub — see below |
 | `DELETE` | `/extensions/:name/tracked/:mangaId` | `tracked:write` | → `{ok, removed}`. Does **not** touch MangaDex |
 | `GET` | `/extensions/:name/config` | `extensions:read` | `{extension, overrideOptions}` |
 | `PUT` | `/extensions/:name/config` | `extensions:write` | `{overrideOptions: {…}}` — replaces wholesale |
@@ -384,6 +385,36 @@ Rows are judged and reported **individually** — a contributor pasting 200 line
 needs to know which three were wrong, not that "the batch failed". The response
 carries `parseErrors` plus a per-row outcome. `remove` still requires
 `tracked:write`, per the same append-versus-edit rule as the single-row route.
+
+#### Series-map write-back
+
+`POST /maps/sync`, scope `tracked:write`. Runs the same job the weekly timer
+runs, which is what makes `dryRun` an honest preview:
+
+```json
+{ "dryRun": false, "force": false, "extensions": ["mangaplus"] }
+```
+
+`extensions` empty means every extension with tracked mappings. `force` bypasses
+the guard that refuses a write deleting more than half of a file's mappings —
+operator-only, and never set by the timer. The response is the run report:
+
+```json
+{
+  "ok": true, "ranAt": "…", "dryRun": false, "written": 1, "failed": 0,
+  "outcomes": [{
+    "extension": "mangaplus", "status": "write", "repo": "publoader-extensions",
+    "path": "src/mangaplus/manga_id_map.json", "commit": "<sha>",
+    "added": 3, "removed": 1, "mappings": 412
+  }]
+}
+```
+
+`status` is `write`, `unchanged`, `skipped` (no file, no repo, or two repos
+claim the extension), `refused` (a guard fired — `detail` says which) or
+`failed`. `skippedReason` on the report means the whole run did nothing, most
+often "`GITHUB_TOKEN` is unset; writing to a repo needs Contents: write".
+Behaviour, guards and the weekly schedule: docs/operations.md §"Series-map sync".
 
 ### Bundles
 
@@ -556,9 +587,11 @@ A push to the *core* repo is acknowledged with `action: "none"` and an explanati
 core deploys are image-based, so CI builds the image and
 `./scripts/publoader prod upgrade <tag>` rolls it out.
 
-Configuration (`src/config.ts:82-91`): `GITHUB_WEBHOOK_SECRET` (≥16 chars),
+Configuration (`src/config.ts`): `GITHUB_WEBHOOK_SECRET` (≥16 chars),
 `GITHUB_REPO_OWNER` (default `publoader`), `GITHUB_EXTENSIONS_REPOS`,
-`GITHUB_CORE_REPO`, `GITHUB_TOKEN`, `GITHUB_API_URL`.
+`GITHUB_CORE_REPO`, `GITHUB_TOKEN`, `GITHUB_API_URL`, plus `MAP_SYNC_ENABLED`
+(default true) and `MAP_SYNC_INTERVAL_HOURS` (default 168) for the series-map
+write-back below.
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -411,6 +411,12 @@ reaches the extension without republishing it (`routes/worker.ts:119-137`). Bund
 data files only *seed* missing rows and never overwrite existing ones
 (`store/bundles.ts:79-84`, `120`).
 
+The return trip runs weekly: `core/mapsync` writes this table back into each
+extension's `manga_id_map.json` on GitHub, so the file contributors read matches
+what is tracked and a mapping removed here is not re-seeded by the next publish.
+It never creates or empties a file and refuses a write that would delete more
+than half of one — see docs/operations.md §"Series-map sync".
+
 **Known limitation: a namespaced extension runs unpartitioned.** `jobs.segment_manga_ids`
 is a flat list of ids on the wire, so it cannot say which catalogue an id came
 from. For an extension with two, `709` is ambiguous — partitioning on it would

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -162,7 +162,10 @@ removed everything" (`src/core/scheduler/service.ts:123-125`).
 **tracked / untracked manga** — A series is *tracked* when a `tracked_manga` row
 maps its publisher-side id to a MangaDex title id; that table is the authority,
 and it is delivered to workers on lease as `mangaIdMap`
-(`src/core/api/routes/worker.ts:119-137`). A series an extension reports
+(`src/core/api/routes/worker.ts:119-137`). A weekly job writes that table back
+into each extension's `manga_id_map.json` on GitHub so the file contributors
+read does not drift from it (`src/core/mapsync`, docs/operations.md
+§"Series-map sync"). A series an extension reports
 that has no such mapping is *untracked*: it lands in `untracked_manga` with state
 `NEW` and either gets a MangaDex title created automatically (when the manifest
 sets `auto_create_titles`) or waits for an operator to approve it

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1336,6 +1336,65 @@ Both are audited, so `padmin audit` shows who repointed a mapping and when.
 
 ---
 
+## Series-map sync
+
+The database winning has one cost: the `manga_id_map.json` files in the
+extensions repos go stale. Every title the pipeline auto-creates and every
+mapping an operator repoints is invisible in git, so a contributor reads the
+file, sees a series missing, and opens a pull request adding something that has
+been tracked for months. A mapping deliberately *removed* from the database is
+worse — the file still has it, so the next publish seeds it straight back.
+
+Once a week core-api writes the table back:
+
+```bash
+padmin maps sync --dry-run     # what the next weekly run would commit
+padmin maps sync               # do it now
+padmin maps sync --extension mangaplus --extension viz
+```
+
+| | |
+| --- | --- |
+| **Where it runs** | core-api. It is the only core service with a GitHub token and egress; core-scheduler sits on the internal `data` network. |
+| **When** | Every `MAP_SYNC_INTERVAL_HOURS` (default 168 = weekly), tracked by the `map_sync_last_run` row in `settings` — so restarts, redeploys and a second replica cannot make it run twice. |
+| **Not on deploy** | The first boot after enabling it only *arms* the timer. The first automatic commit is one interval later. |
+| **Needs** | `GITHUB_TOKEN` with **Contents: write** on the repos in `GITHUB_EXTENSIONS_REPOS`. Without it the feature reports itself off at boot and does nothing. |
+| **Off switch** | `MAP_SYNC_ENABLED=false`. It also skips while the platform is paused (`padmin pause`). |
+
+What it will not do, because it commits unattended:
+
+- **Never creates a file.** An extension with no `manga_id_map.json` is skipped
+  with a note; add the file once by hand and the sync keeps it current.
+- **Never empties one.** No mappings in the database for an extension that has
+  some in git means *refused*, not a deletion.
+- **Refuses a big shrink.** A write that would drop more than half of a file's
+  mappings is refused and logged; `padmin maps sync --force` is the deliberate
+  override once you have looked at the dry run.
+- **Never guesses a repo.** An extension directory present in two configured
+  repos is skipped rather than written to whichever was listed first.
+- **Keeps each file's shape.** mangaplus's `{titleId: [ids]}`, alpha_manga's
+  `{id: titleId}` and viz's nested `{namespace: {…}}` all survive; only the
+  ordering is normalised (once), so a week with no changes makes no commit.
+
+Its commits carry `[map-sync]` in the subject, and the push webhook skips a
+delivery whose commits are *all* marked — otherwise the platform would answer
+its own data-file commit with a bundle republish every week. A push that mixes
+one of ours with a human's still publishes.
+
+Each write is audited as `map_sync.write`, with the commit sha and the counts:
+
+```bash
+curl -s "$PUBLOADER_API_URL/api/v1/admin/audit/search?action=map_sync" \
+  -H "authorization: Bearer $PUBLOADER_ADMIN_TOKEN" | jq '.events[]'
+```
+
+Run it manually in any environment that shares the extensions repos with
+another deployment, and leave `MAP_SYNC_ENABLED=false` there — two deployments
+writing the same files would overwrite each other with whichever database is
+staler.
+
+---
+
 ## Lease-expiry storms
 
 Symptom: `publoader_lease_expiries_total` climbing fast, jobs cycling

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -29,6 +29,13 @@ without anyone reading server logs.
 | core | `GITHUB_CORE_REPO` | **Nothing.** Answers 200 with "core deploys are image-based" |
 | anything else | — | 202 `untracked repo '<name>'` |
 
+One delivery is deliberately ignored on top of those rules: a push whose commits
+are **all** marked `[map-sync]`. Those are this platform's own weekly write-back
+of `manga_id_map.json`, and republishing a bundle for them would churn every
+extension's sha256 pin once a week for a data file the workers do not read from
+the bundle. A push mixing one of ours with a human's commit still publishes —
+the test is *every* commit, not any.
+
 Three conditions must all hold before anything is published, ported from the
 legacy `slot_for_push`:
 
@@ -76,7 +83,7 @@ push.
 | `GITHUB_REPO_OWNER` | yes | GitHub account/org that must own the pushing repo. Default `publoader` |
 | `GITHUB_EXTENSIONS_REPOS` | yes | Comma-separated repo names, e.g. `publoader-extensions,publoader-extensions-private` |
 | `GITHUB_CORE_REPO` | no | Repo name for the core service. Set it only to get the explanatory 200 instead of `untracked repo` |
-| `GITHUB_TOKEN` | for private repos | Read access used to download the repo archive. A fine-grained PAT with **Contents: read** on the extensions repos is enough |
+| `GITHUB_TOKEN` | for private repos | Access to the extensions repos. A fine-grained PAT with **Contents: read** is enough for the webhook; the weekly series-map sync (docs/operations.md §"Series-map sync") additionally needs **Contents: write** |
 | `GITHUB_API_URL` | no | Default `https://api.github.com` |
 
 All of these follow the platform's Docker-secrets convention: any `VAR` may be

--- a/src/cli/admin.ts
+++ b/src/cli/admin.ts
@@ -527,6 +527,61 @@ tracked
     );
   });
 
+// ---- series-map write-back (the return trip: database -> manga_id_map.json) ----
+const maps = program
+  .command("maps")
+  .description("write the tracked series map back to the extensions repos");
+
+maps
+  .command("sync")
+  .description("update manga_id_map.json in GitHub from the database (runs weekly on its own)")
+  .option("--dry-run", "report what would be committed and write nothing")
+  .option("--extension <name...>", "only these extensions (default: all tracked)")
+  .option(
+    "--force",
+    "commit even when the write would delete more than half of a file's mappings",
+  )
+  .action(async (opts: { dryRun?: boolean; extension?: string[]; force?: boolean }) => {
+    const res = await api<{
+      dryRun: boolean;
+      written: number;
+      failed: number;
+      skippedReason?: string;
+      outcomes: {
+        extension: string;
+        status: string;
+        repo?: string;
+        path?: string;
+        commit?: string;
+        detail?: string;
+        added: number;
+        removed: number;
+        mappings: number;
+      }[];
+    }>("/api/v1/admin/maps/sync", {
+      method: "POST",
+      json: {
+        dryRun: opts.dryRun === true,
+        force: opts.force === true,
+        extensions: opts.extension ?? [],
+      },
+    });
+    if (res.skippedReason) console.error(`  nothing to do: ${res.skippedReason}`);
+    table(res.outcomes, [
+      { header: "EXTENSION", get: (o) => o["extension"] },
+      { header: "STATUS", get: (o) => o["status"] },
+      { header: "REPO", get: (o) => o["repo"] ?? "-" },
+      { header: "MAPPINGS", get: (o) => o["mappings"] },
+      { header: "DELTA", get: (o) => `+${o["added"]} -${o["removed"]}` },
+      { header: "COMMIT", get: (o) => String(o["commit"] ?? "").slice(0, 7) || "-" },
+      { header: "DETAIL", get: (o) => o["detail"] ?? "" },
+    ], "no extensions have tracked mappings");
+    ok(
+      `${res.dryRun ? "would write" : "wrote"} ${res.written} file(s)` +
+        (res.failed > 0 ? `, ${res.failed} failed` : ""),
+    );
+  });
+
 // ---- extension config (the database replacement for override_options.json) ----
 const extConfig = program
   .command("ext-config")

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,9 +86,27 @@ const ConfigSchema = z.object({
   githubExtensionsRepos: z.string().default(""),
   /** Repo name for the core service; pushes to it are acknowledged, not acted on. */
   githubCoreRepo: z.string().default(""),
-  /** Read access to the extensions repos. Required for the private one. */
+  /**
+   * Access to the extensions repos. Read (archive download, commit lookup) is
+   * required for the private one; the series-map sync below also needs
+   * **Contents: write** on those repos, and is inert without it.
+   */
   githubToken: z.string().optional(),
   githubApiUrl: z.string().default("https://api.github.com"),
+
+  // Series-map write-back (core-api only). See docs/operations.md §"Series-map sync".
+  /**
+   * Whether to write `manga_id_map.json` back to the extensions repos on a
+   * timer. On by default, but it does nothing without a GITHUB_TOKEN that can
+   * write and at least one repo in GITHUB_EXTENSIONS_REPOS — and it never syncs
+   * on the first boot after it is enabled, so a deploy cannot produce commits.
+   */
+  mapSyncEnabled: z
+    .enum(["true", "false"])
+    .default("true")
+    .transform((v) => v === "true"),
+  /** Weekly. The floor is an hour so a typo cannot turn it into a busy loop. */
+  mapSyncIntervalHours: z.coerce.number().int().min(1).max(8760).default(168),
 
   // Operator self-service (core-api only). See docs/operations.md §"Self-service".
   /**
@@ -170,6 +188,8 @@ export function loadConfig(overrides: Partial<Record<string, string>> = {}): Con
     githubCoreRepo: get("GITHUB_CORE_REPO"),
     githubToken: get("GITHUB_TOKEN"),
     githubApiUrl: get("GITHUB_API_URL"),
+    mapSyncEnabled: get("MAP_SYNC_ENABLED"),
+    mapSyncIntervalHours: get("MAP_SYNC_INTERVAL_HOURS"),
     docsPath: get("DOCS_PATH"),
     sysopsRestartEnabled: get("SYSOPS_RESTART_ENABLED"),
     coreUrl: get("CORE_URL"),

--- a/src/core/api/context.ts
+++ b/src/core/api/context.ts
@@ -11,6 +11,7 @@ import { IngestService } from "../ingest/ingest.js";
 import { SchedulerService } from "../scheduler/service.js";
 import type { TitleService } from "../md/titleService.js";
 import type { RepoArchiveFetcher } from "../webhooks/repoArchive.js";
+import type { GithubContentsClient } from "../webhooks/repoContents.js";
 import { ApiTokenStore } from "../store/apiTokens.js";
 import { TrackedMangaStore } from "../store/trackedManga.js";
 import { ExtensionConfigStore } from "../store/extensionConfig.js";
@@ -44,6 +45,13 @@ export interface AppContext {
    * unconditionally while tests still avoid the network.
    */
   webhookFetchArchive?: RepoArchiveFetcher;
+  /**
+   * Test seam for the series-map sync's GitHub Contents calls, for the same
+   * reason as `webhookFetchArchive`: the admin route builds the service on
+   * demand, and a test must be able to hand it a client that never leaves the
+   * process.
+   */
+  mapSyncContents?: GithubContentsClient;
   enrollLimiter: RateLimiter;
   workerLimiter: RateLimiter;
   adminLimiter: RateLimiter;

--- a/src/core/api/routes/admin.ts
+++ b/src/core/api/routes/admin.ts
@@ -20,6 +20,7 @@ import { MANGADEX_LANGUAGES } from "../../../contracts/languages.js";
 const WORKER_IMAGE = process.env["PUBLOADER_WORKER_IMAGE"] ?? "ardax/publoader-worker:2.1.1";
 import { VALID_REMOVAL_MODES } from "../../store/settings.js";
 import { BundleRejectedError } from "../../store/bundles.js";
+import { MapSyncService } from "../../mapsync/service.js";
 import AdmZip from "adm-zip";
 
 const MAX_BUNDLE_BYTES = 64 * 1024 * 1024;
@@ -704,6 +705,51 @@ export function registerAdminRoutes(app: FastifyInstance, ctx: AppContext): void
         rejected: result.rejected.length,
       });
       return { ok: true, ...result };
+    });
+
+    /**
+     * Run the series-map write-back now instead of waiting for the weekly
+     * timer. Same code path the timer uses, so a dry run is an honest preview.
+     *
+     * `tracked:write` rather than `tracked:read`: this publishes the map to a
+     * git repository, and — with `force` — can delete mappings from a file that
+     * contributors read. Even the dry run is gated, because its output lists the
+     * full contents of a private repo's map.
+     */
+    scope.post("/api/v1/admin/maps/sync", { preHandler: requireScope("tracked:write") }, async (req) => {
+      const body = parseOrThrow(
+        z.object({
+          dryRun: z.boolean().default(false),
+          /** Bypass the shrink guard. Deliberately not exposed to the timer. */
+          force: z.boolean().default(false),
+          extensions: z.array(z.string().regex(EXTENSION_NAME_RE)).max(50).default([]),
+        }),
+        req.body ?? {},
+      );
+      const service = MapSyncService.fromConfig(ctx.config, {
+        prisma: ctx.prisma,
+        log: ctx.log,
+        audit: ctx.audit,
+        settings: ctx.settings,
+        ...(ctx.mapSyncContents ? { contents: ctx.mapSyncContents } : {}),
+      });
+      const report = await service.sync({
+        dryRun: body.dryRun,
+        force: body.force,
+        extensions: body.extensions,
+        actor: actor(req),
+      });
+      // A dry run is not an event; only a run that could write is audited, and
+      // the per-file writes audit themselves inside the service.
+      if (!body.dryRun) {
+        await ctx.audit.record(actor(req), "map_sync.run", "manual", {
+          written: report.written,
+          failed: report.failed,
+          force: body.force,
+          extensions: body.extensions,
+        });
+      }
+      return { ok: report.failed === 0, ...report };
     });
 
     // ---- untracked series pipeline ----

--- a/src/core/api/routes/webhooks.ts
+++ b/src/core/api/routes/webhooks.ts
@@ -22,12 +22,14 @@ import { RateLimiter } from "../ratelimit.js";
 import {
   MAX_WEBHOOK_BODY_BYTES,
   changedExtensions,
+  isMapSyncPush,
   roleForPush,
   verifySignature,
   type GithubWebhookConfig,
   type PushPayload,
 } from "../../webhooks/github.js";
 import { handleExtensionsPush, type PushHandlerDeps } from "../../webhooks/pushHandler.js";
+import { parseRepoList } from "../../webhooks/repoList.js";
 
 const PATHS = ["/webhook", "/api/v1/webhooks/github"] as const;
 
@@ -119,6 +121,17 @@ export function registerWebhookRoutes(
           });
         }
 
+        if (isMapSyncPush(payload)) {
+          // Our own weekly write-back of manga_id_map.json. Republishing a
+          // bundle for it would churn the sha256 pin every week for a file the
+          // workers do not read from the bundle.
+          return reply.code(200).send({
+            ok: true,
+            commit: decision.after,
+            ignored: "every commit in this push is a publoader series-map sync commit",
+          });
+        }
+
         const changed = changedExtensions(payload);
         if (changed.length === 0) {
           return reply.code(200).send({
@@ -158,10 +171,7 @@ export function registerWebhookRoutes(
   });
 }
 
-/** Comma- or whitespace-separated repo names, blanks dropped. */
-export function parseRepoList(raw: string): string[] {
-  return raw
-    .split(/[,\s]+/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-}
+// Re-exported so existing importers (and tests) keep finding it here, while
+// background jobs like the series-map sync read the same setting without
+// importing a route.
+export { parseRepoList };

--- a/src/core/mapsync/mapFile.ts
+++ b/src/core/mapsync/mapFile.ts
@@ -1,0 +1,236 @@
+/**
+ * Rendering the tracked series map back into a `manga_id_map.json` file, and
+ * deciding whether that file is worth rewriting.
+ *
+ * Direction matters here. Everywhere else in the platform the file flows INTO
+ * the database (`BundleStore.seedConfigFromBundle` seeds missing rows and never
+ * overwrites); this module is the return trip, and the database is the
+ * authority. The files in git are what contributors read and edit, and without
+ * a write-back they drift: every title the pipeline auto-creates and every
+ * operator repoint is invisible in the repo, so a contributor opens a pull
+ * request adding a series that has been tracked for months.
+ *
+ * Nothing here does I/O, so every decision — including every reason a file is
+ * left alone — is directly testable.
+ */
+import { parseMangaIdMapFile, type ParsedIdMapRow } from "../store/bundles.js";
+import { DEFAULT_NAMESPACE } from "../store/trackedManga.js";
+
+/** Where the map lives when the manifest's `data_files` does not say. */
+export const DEFAULT_MAP_FILENAME = "manga_id_map.json";
+
+/**
+ * The three shapes the real files use, as two independent axes. See
+ * `parseMangaIdMapFile` for the wild examples: mangaplus is flat+inverted,
+ * alpha_manga is flat+forward, viz is nested+forward.
+ */
+export interface MapShape {
+  /** `{namespace: {…}}` — one extension serving more than one catalogue. */
+  nested: boolean;
+  /** `forward` is `{externalId: mdId}`; `inverted` is `{mdId: [externalId, …]}`. */
+  inner: "forward" | "inverted";
+}
+
+/**
+ * What a brand-new file would look like. Inverted because that is the shape the
+ * worker receives on the wire (`buildMangaIdMap`), so a reader who knows one
+ * knows the other.
+ */
+export const DEFAULT_SHAPE: MapShape = { nested: false, inner: "inverted" };
+
+/**
+ * Guess the shape of a file we are about to overwrite.
+ *
+ * Preserving it is the difference between a diff a contributor can review and a
+ * diff that rewrites every line of a file they curated. The judgement is per
+ * entry and resolved by majority, because hand-edited files mix shapes — the
+ * same tolerance `parseMangaIdMapFile` already has. Null means "nothing here
+ * looks like a map", and the caller must not overwrite on a guess.
+ */
+export function detectMapShape(document: unknown): MapShape | null {
+  if (!isPlainObject(document)) return null;
+  let nested = 0;
+  let forward = 0;
+  let inverted = 0;
+
+  const tallyFlat = (entries: Record<string, unknown>): void => {
+    for (const value of Object.values(entries)) {
+      if (Array.isArray(value)) inverted += 1;
+      else if (typeof value === "string" || typeof value === "number") forward += 1;
+    }
+  };
+
+  for (const value of Object.values(document)) {
+    if (isPlainObject(value)) {
+      nested += 1;
+      tallyFlat(value);
+    } else {
+      tallyFlat({ _: value });
+    }
+  }
+  if (nested === 0 && forward === 0 && inverted === 0) return null;
+  return { nested: nested > 0, inner: inverted > forward ? "inverted" : "forward" };
+}
+
+/**
+ * Render tracked rows as the text of a `manga_id_map.json`.
+ *
+ * Deterministic to the byte: keys sorted, arrays sorted, two-space indent, one
+ * trailing newline. A weekly job that emitted a different-but-equivalent
+ * ordering would commit a churn diff every week forever, and "the file changed"
+ * would stop meaning "the map changed".
+ *
+ * Nesting is decided by the ROWS, not by `shape.nested`: an extension with a
+ * namespaced row must be written nested, because flattening viz's two
+ * catalogues into one object is exactly the collision the namespace column
+ * exists to prevent — and an extension with none must not be, because the
+ * alternative is a file with a meaningless `""` key at the top. Only
+ * `shape.inner` is taken from the existing file.
+ */
+export function renderMapFile(rows: ParsedIdMapRow[], shape: MapShape = DEFAULT_SHAPE): string {
+  const nest = rows.some((row) => row.namespace !== DEFAULT_NAMESPACE);
+
+  const flat = (subset: ParsedIdMapRow[]): Record<string, unknown> => {
+    if (shape.inner === "forward") {
+      const out: Record<string, string> = {};
+      for (const row of [...subset].sort(byMangaId)) out[row.mangaId] = row.mdMangaId;
+      return out;
+    }
+    const grouped = new Map<string, string[]>();
+    for (const row of subset) {
+      const bucket = grouped.get(row.mdMangaId);
+      if (bucket) bucket.push(row.mangaId);
+      else grouped.set(row.mdMangaId, [row.mangaId]);
+    }
+    const out: Record<string, string[]> = {};
+    for (const key of [...grouped.keys()].sort()) out[key] = grouped.get(key)!.sort(compareIds);
+    return out;
+  };
+
+  const document = nest
+    ? Object.fromEntries(
+        [...new Set(rows.map((row) => row.namespace))]
+          .sort()
+          .map((namespace) => [namespace, flat(rows.filter((row) => row.namespace === namespace))]),
+      )
+    : flat(rows);
+
+  return JSON.stringify(document, null, 2) + "\n";
+}
+
+/**
+ * The identity of a mapping, for counting and comparison. Deliberately the same
+ * triple the `tracked_manga` unique constraint uses.
+ */
+function rowKey(row: ParsedIdMapRow): string {
+  return JSON.stringify([row.namespace, row.mangaId, row.mdMangaId]);
+}
+
+/** Mappings in `a` that `b` does not have. */
+export function mappingsMissingFrom(a: ParsedIdMapRow[], b: ParsedIdMapRow[]): ParsedIdMapRow[] {
+  const have = new Set(b.map(rowKey));
+  return a.filter((row) => !have.has(rowKey(row)));
+}
+
+export type WriteAction = "write" | "unchanged" | "skipped" | "refused";
+
+export interface WritePlan {
+  action: WriteAction;
+  /** Operator-readable, and the audit detail when the action is `refused`. */
+  reason?: string;
+  /** Mappings the file has that the database does not. Non-empty means a deletion. */
+  removed: number;
+  /** Mappings the database has that the file does not. */
+  added: number;
+}
+
+/**
+ * Below this many mappings in the current file, a large proportional shrink is
+ * not evidence of anything — going from 3 rows to 1 is a normal edit.
+ */
+export const SHRINK_GUARD_MIN_ROWS = 8;
+
+/**
+ * Refuse a write that would delete more than this fraction of the file's
+ * mappings. The database is authoritative, but "authoritative" and "correct
+ * right now" are not the same claim: a half-run migration, a truncated table or
+ * a filter bug would otherwise be committed straight into the repo by a job
+ * nobody is watching. Git makes it recoverable; a refusal makes it unnecessary.
+ */
+export const SHRINK_GUARD_FRACTION = 0.5;
+
+/**
+ * Decide what to do with one file.
+ *
+ * `current` is null when the file is not in the repo. That case is SKIPPED
+ * rather than created: the extension's map location is a convention its author
+ * chose, and inventing the file (and its shape) in someone's repository is a
+ * bigger step than keeping an existing one current.
+ */
+export function planWrite(
+  current: { text: string; rows: ParsedIdMapRow[] } | null,
+  next: { text: string; rows: ParsedIdMapRow[] },
+  opts: { force?: boolean } = {},
+): WritePlan {
+  if (current === null) {
+    return {
+      action: "skipped",
+      reason: "the file is not in the repo; create it once by hand and the sync will keep it current",
+      removed: 0,
+      added: next.rows.length,
+    };
+  }
+
+  const removedRows = mappingsMissingFrom(current.rows, next.rows);
+  const addedRows = mappingsMissingFrom(next.rows, current.rows);
+  const counts = { removed: removedRows.length, added: addedRows.length };
+
+  if (current.text === next.text) return { action: "unchanged", ...counts };
+
+  if (next.rows.length === 0 && current.rows.length > 0) {
+    return {
+      action: "refused",
+      reason: "the database has no mappings for this extension; refusing to empty a file that has some",
+      ...counts,
+    };
+  }
+  if (
+    !opts.force &&
+    current.rows.length >= SHRINK_GUARD_MIN_ROWS &&
+    next.rows.length < current.rows.length * SHRINK_GUARD_FRACTION
+  ) {
+    return {
+      action: "refused",
+      reason:
+        `would drop ${counts.removed} of ${current.rows.length} mappings; refusing a shrink of more than ` +
+        `${Math.round((1 - SHRINK_GUARD_FRACTION) * 100)}% without --force`,
+      ...counts,
+    };
+  }
+  return { action: "write", ...counts };
+}
+
+/** Parse a file's text the way the platform already reads these files. */
+export function parseMapText(text: string): { rows: ParsedIdMapRow[]; shape: MapShape | null } {
+  let document: unknown;
+  try {
+    document = JSON.parse(text);
+  } catch {
+    return { rows: [], shape: null };
+  }
+  return { rows: parseMangaIdMapFile(document), shape: detectMapShape(document) };
+}
+
+/**
+ * Numeric-aware ordering, so `10` sorts after `9` rather than after `1`. These
+ * ids are numbers in a string in most extensions, and a lexicographic list is
+ * unreadable to the humans who edit these files.
+ */
+const compareIds = (a: string, b: string): number =>
+  a.localeCompare(b, "en", { numeric: true, sensitivity: "base" }) || (a < b ? -1 : a > b ? 1 : 0);
+
+const byMangaId = (a: ParsedIdMapRow, b: ParsedIdMapRow): number => compareIds(a.mangaId, b.mangaId);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/core/mapsync/service.ts
+++ b/src/core/mapsync/service.ts
@@ -1,0 +1,503 @@
+/**
+ * The weekly write-back of the tracked series map to GitHub.
+ *
+ * `tracked_manga` is the authority for publisher-id → MangaDex-title-id, and it
+ * moves constantly: the title pipeline auto-creates titles, operators repoint
+ * and untrack series from the dashboard. The `manga_id_map.json` files in the
+ * extensions repos only ever SEED that table (see
+ * `BundleStore.seedConfigFromBundle`), so nothing has been putting those changes
+ * back — the files in git go stale, and a contributor reading one cannot tell
+ * what is actually tracked. Worse, a mapping an operator deliberately removed
+ * from the database is still in the file, so the next publish re-seeds it.
+ *
+ * This job closes that loop once a week. Every step is designed around the fact
+ * that it commits to someone's repository unattended:
+ *
+ *   - it never creates a file, only updates one that exists;
+ *   - it never empties a file, and refuses a large shrink without `force`;
+ *   - it preserves each file's existing shape and renders deterministically, so
+ *     a run with nothing to say produces no commit at all;
+ *   - it writes one commit per extension, marked so the push webhook does not
+ *     turn our own commit into a bundle republish;
+ *   - a failure is always scoped to one extension.
+ */
+import type { PrismaClient } from "@prisma/client";
+import type { Config } from "../../config.js";
+import type { Logger } from "../../logging.js";
+import { Manifest } from "../../contracts/manifest.js";
+import type { AuditLog, SettingsStore } from "../store/settings.js";
+import type { ParsedIdMapRow } from "../store/bundles.js";
+import { BundleStore } from "../store/bundles.js";
+import { MAP_SYNC_COMMIT_MARKER } from "../webhooks/github.js";
+import { GithubApiError, type GithubApiConfig } from "../webhooks/repoMeta.js";
+import {
+  githubContents,
+  isSafeRepoPath,
+  type GithubContentsClient,
+} from "../webhooks/repoContents.js";
+import { parseRepoList } from "../webhooks/repoList.js";
+import {
+  DEFAULT_MAP_FILENAME,
+  DEFAULT_SHAPE,
+  parseMapText,
+  planWrite,
+  renderMapFile,
+  type WriteAction,
+} from "./mapFile.js";
+
+/** Timestamp of the last completed (or claimed) run, ISO-8601, in `settings`. */
+export const MAP_SYNC_LAST_RUN_KEY = "map_sync_last_run";
+
+/** Where extension directories live in both extensions repos. */
+const EXTENSIONS_DIR = "src";
+
+/**
+ * Total wall clock for one run. Well under the weekly interval by three orders
+ * of magnitude — the cap is not about scheduling, it is so a GitHub that has
+ * started timing out cannot leave the run half-done for hours.
+ */
+export const MAP_SYNC_BUDGET_MS = 120_000;
+
+export interface MapSyncOutcome {
+  extension: string;
+  status: WriteAction | "failed";
+  repo?: string;
+  path?: string;
+  /** Commit sha, when one was made. */
+  commit?: string;
+  detail?: string;
+  /** Mappings the database has that the file did not. */
+  added: number;
+  /** Mappings the file had that the database does not. */
+  removed: number;
+  /** Total mappings the database holds for this extension. */
+  mappings: number;
+}
+
+export interface MapSyncReport {
+  ranAt: string;
+  dryRun: boolean;
+  written: number;
+  failed: number;
+  outcomes: MapSyncOutcome[];
+  /** Set when the run did nothing at all, e.g. the feature is not configured. */
+  skippedReason?: string;
+}
+
+export interface MapSyncOptions {
+  dryRun?: boolean;
+  /** Bypass the shrink guard. Operator-only; never set by the timer. */
+  force?: boolean;
+  /** Limit the run to these extensions. Empty/absent means all of them. */
+  extensions?: string[];
+  /** Audit actor. Defaults to the scheduler's own name. */
+  actor?: string;
+}
+
+export interface MapSyncDeps {
+  prisma: PrismaClient;
+  log: Logger;
+  audit: AuditLog;
+  settings: SettingsStore;
+  /** Overridden in tests; the default is the real GitHub Contents API. */
+  contents?: GithubContentsClient;
+  now?: () => number;
+}
+
+export interface MapSyncConfig {
+  enabled: boolean;
+  intervalHours: number;
+  owner: string;
+  apiUrl: string;
+  token?: string;
+  repos: string[];
+}
+
+export class MapSyncService {
+  private readonly contents: GithubContentsClient;
+  private readonly now: () => number;
+  private readonly bundles: BundleStore;
+
+  constructor(
+    private readonly cfg: MapSyncConfig,
+    private readonly deps: MapSyncDeps,
+  ) {
+    this.contents = deps.contents ?? githubContents;
+    this.now = deps.now ?? Date.now;
+    this.bundles = new BundleStore(deps.prisma);
+  }
+
+  static fromConfig(config: Config, deps: MapSyncDeps): MapSyncService {
+    return new MapSyncService(
+      {
+        enabled: config.mapSyncEnabled,
+        intervalHours: config.mapSyncIntervalHours,
+        owner: config.githubRepoOwner,
+        apiUrl: config.githubApiUrl,
+        ...(config.githubToken ? { token: config.githubToken } : {}),
+        repos: parseRepoList(config.githubExtensionsRepos),
+      },
+      deps,
+    );
+  }
+
+  /**
+   * Why the job cannot run, or null when it can.
+   *
+   * A write needs a token: without one every PUT is a 401, so the honest answer
+   * is "not configured" rather than a weekly failure report.
+   */
+  unavailableReason(): string | null {
+    if (!this.cfg.enabled) return "MAP_SYNC_ENABLED is false";
+    if (this.cfg.repos.length === 0) return "GITHUB_EXTENSIONS_REPOS is unset";
+    if (!this.cfg.token) return "GITHUB_TOKEN is unset; writing to a repo needs Contents: write";
+    return null;
+  }
+
+  /** When the next automatic run is due, given the recorded last run. */
+  nextDueAt(lastRun: Date): Date {
+    return new Date(lastRun.getTime() + this.cfg.intervalHours * 3_600_000);
+  }
+
+  /**
+   * Run if a week has passed since the last run, otherwise do nothing.
+   *
+   * On the very first call nothing is synced: the timestamp is seeded and the
+   * first automatic write happens one interval later. Deploying a release must
+   * not push commits to the extensions repos within thirty seconds of starting —
+   * an operator who wants it now has `publoader-admin maps sync`, which is a
+   * deliberate act with a `--dry-run` in front of it.
+   *
+   * Claiming the slot is a compare-and-set on the stored timestamp, so two
+   * core-api replicas cannot both sync: the loser sees zero rows updated and
+   * returns. Claiming happens BEFORE the work, so a crash mid-run costs one
+   * interval rather than looping on restart.
+   */
+  async runIfDue(): Promise<MapSyncReport | null> {
+    const unavailable = this.unavailableReason();
+    if (unavailable) return null;
+    if (await this.deps.settings.isPaused()) {
+      this.deps.log.debug("map sync skipped: the platform is paused");
+      return null;
+    }
+
+    const now = new Date(this.now());
+    const raw = await this.deps.settings.getSetting(MAP_SYNC_LAST_RUN_KEY);
+    if (raw === null) {
+      const armed = await this.seedFirstRun(now);
+      if (armed) {
+        this.deps.log.info(
+          { nextSyncAt: this.nextDueAt(now).toISOString() },
+          "series-map sync armed; the first automatic sync is one interval from now " +
+            "(preview it with `publoader-admin maps sync --dry-run`)",
+        );
+      }
+      return null;
+    }
+
+    const lastRun = new Date(raw);
+    if (Number.isNaN(lastRun.getTime())) {
+      // Unparseable timestamp: reset it rather than syncing on every tick.
+      await this.deps.settings.setSetting(MAP_SYNC_LAST_RUN_KEY, now.toISOString());
+      this.deps.log.warn({ value: raw }, `${MAP_SYNC_LAST_RUN_KEY} is not a timestamp; reset`);
+      return null;
+    }
+    if (now < this.nextDueAt(lastRun)) return null;
+    if (!(await this.claim(raw, now))) {
+      this.deps.log.debug("another replica claimed this series-map sync");
+      return null;
+    }
+
+    this.deps.log.info({ since: raw }, "series-map sync starting");
+    const report = await this.sync({ actor: "scheduler" });
+    this.deps.log.info(
+      { written: report.written, failed: report.failed, extensions: report.outcomes.length },
+      "series-map sync finished",
+    );
+    return report;
+  }
+
+  /**
+   * Write every extension's map file. Safe to call by hand at any time — it is
+   * idempotent, and a run with nothing to say makes no commits.
+   */
+  async sync(opts: MapSyncOptions = {}): Promise<MapSyncReport> {
+    const ranAt = new Date(this.now()).toISOString();
+    const dryRun = opts.dryRun === true;
+    const unavailable = this.unavailableReason();
+    if (unavailable && !dryRun) {
+      return { ranAt, dryRun, written: 0, failed: 0, outcomes: [], skippedReason: unavailable };
+    }
+
+    const wanted = new Set((opts.extensions ?? []).filter((name) => name.length > 0));
+    const byExtension = await this.trackedByExtension(wanted);
+    if (byExtension.size === 0) {
+      return {
+        ranAt,
+        dryRun,
+        written: 0,
+        failed: 0,
+        outcomes: [],
+        skippedReason:
+          wanted.size > 0 ? "no tracked mappings for the named extensions" : "no tracked mappings",
+      };
+    }
+
+    const paths = await this.mapFilePaths();
+    const index = await this.repoIndex();
+    const deadline = this.now() + MAP_SYNC_BUDGET_MS;
+    const outcomes: MapSyncOutcome[] = [];
+
+    for (const [extension, rows] of [...byExtension].sort(([a], [b]) => (a < b ? -1 : 1))) {
+      if (this.now() >= deadline) {
+        outcomes.push({
+          extension,
+          status: "skipped",
+          detail: "the run reached its time budget before this extension",
+          added: 0,
+          removed: 0,
+          mappings: rows.length,
+        });
+        continue;
+      }
+      outcomes.push(
+        await this.syncOne(extension, rows, paths.get(extension) ?? DEFAULT_MAP_FILENAME, index, {
+          dryRun,
+          ...(opts.force === true ? { force: true } : {}),
+          actor: opts.actor ?? "scheduler",
+        }),
+      );
+    }
+
+    // The repos that could not be listed are reported once, not once per
+    // extension: "GitHub is unreachable" is one fact.
+    for (const [repo, reason] of index.unreadable) {
+      outcomes.push({
+        extension: `(repo ${repo})`,
+        status: "failed",
+        repo,
+        detail: reason,
+        added: 0,
+        removed: 0,
+        mappings: 0,
+      });
+    }
+
+    return {
+      ranAt,
+      dryRun,
+      written: outcomes.filter((o) => o.status === "write").length,
+      failed: outcomes.filter((o) => o.status === "failed").length,
+      outcomes,
+      ...(unavailable ? { skippedReason: `${unavailable} (dry run only)` } : {}),
+    };
+  }
+
+  private async syncOne(
+    extension: string,
+    rows: ParsedIdMapRow[],
+    filename: string,
+    index: RepoIndex,
+    opts: { dryRun: boolean; force?: boolean; actor: string },
+  ): Promise<MapSyncOutcome> {
+    const base: Pick<MapSyncOutcome, "extension" | "added" | "removed" | "mappings"> = {
+      extension,
+      added: 0,
+      removed: 0,
+      mappings: rows.length,
+    };
+
+    const repos = index.byExtension.get(extension) ?? [];
+    if (repos.length === 0) {
+      return {
+        ...base,
+        status: "skipped",
+        detail:
+          index.unreadable.size > 0
+            ? "not found in any readable extensions repo"
+            : `no ${EXTENSIONS_DIR}/${extension} directory in ${this.cfg.repos.join(" or ")}`,
+      };
+    }
+    if (repos.length > 1) {
+      // Two repos both claiming the extension is a real configuration problem
+      // (a fork left in GITHUB_EXTENSIONS_REPOS, or a half-finished move).
+      // Writing to the wrong one would look like it worked.
+      return {
+        ...base,
+        status: "skipped",
+        detail: `${EXTENSIONS_DIR}/${extension} exists in more than one repo (${repos.join(", ")}); refusing to guess`,
+      };
+    }
+    const repo = repos[0]!;
+    const path = `${EXTENSIONS_DIR}/${extension}/${filename}`;
+    if (!isSafeRepoPath(path)) {
+      return { ...base, status: "failed", repo, detail: `${filename} is not a usable repo path` };
+    }
+
+    try {
+      const existing = await this.contents.getFile(this.githubConfig(), repo, path);
+      const parsed = existing ? parseMapText(existing.text) : null;
+      const text = renderMapFile(rows, parsed?.shape ?? DEFAULT_SHAPE);
+      const plan = planWrite(
+        existing && parsed ? { text: existing.text, rows: parsed.rows } : null,
+        { text, rows },
+        opts.force === true ? { force: true } : {},
+      );
+      const outcome: MapSyncOutcome = {
+        ...base,
+        status: plan.action,
+        repo,
+        path,
+        added: plan.added,
+        removed: plan.removed,
+        ...(plan.reason ? { detail: plan.reason } : {}),
+      };
+
+      if (plan.action !== "write") {
+        if (plan.action === "refused") {
+          this.deps.log.warn({ extension, repo, path, detail: plan.reason }, "series-map write refused");
+        }
+        return outcome;
+      }
+      if (opts.dryRun) return { ...outcome, detail: "would write" };
+
+      const put = await this.contents.putFile(this.githubConfig(), repo, {
+        path,
+        text,
+        message: commitMessage(extension, filename, plan.added, plan.removed),
+        sha: existing!.sha,
+      });
+      await this.deps.audit.record(opts.actor, "map_sync.write", `${extension}@${repo}`, {
+        path,
+        commit: put.commit,
+        added: plan.added,
+        removed: plan.removed,
+        mappings: rows.length,
+      });
+      this.deps.log.info(
+        { extension, repo, path, commit: put.commit, added: plan.added, removed: plan.removed },
+        "wrote the series map to GitHub",
+      );
+      return { ...outcome, commit: put.commit };
+    } catch (err) {
+      // Scoped to this extension: one unreachable file must not stop the rest.
+      const detail = err instanceof GithubApiError ? err.message : "GitHub request failed";
+      this.deps.log.error({ err, extension, repo, path }, "series-map sync failed for an extension");
+      return { ...base, status: "failed", repo, path, detail };
+    }
+  }
+
+  private githubConfig(): GithubApiConfig {
+    return {
+      apiUrl: this.cfg.apiUrl,
+      owner: this.cfg.owner,
+      ...(this.cfg.token ? { token: this.cfg.token } : {}),
+    };
+  }
+
+  /** Tracked rows grouped by extension, in the file's own row shape. */
+  private async trackedByExtension(only: Set<string>): Promise<Map<string, ParsedIdMapRow[]>> {
+    const rows = await this.deps.prisma.trackedManga.findMany({
+      ...(only.size > 0 ? { where: { extension: { in: [...only] } } } : {}),
+      select: { extension: true, namespace: true, mangaId: true, mdMangaId: true },
+      orderBy: [{ extension: "asc" }, { namespace: "asc" }, { mangaId: "asc" }],
+    });
+    const out = new Map<string, ParsedIdMapRow[]>();
+    for (const row of rows) {
+      const bucket = out.get(row.extension);
+      const entry = { namespace: row.namespace, mangaId: row.mangaId, mdMangaId: row.mdMangaId };
+      if (bucket) bucket.push(entry);
+      else out.set(row.extension, [entry]);
+    }
+    return out;
+  }
+
+  /**
+   * Each extension's map filename, from the manifest of its latest bundle.
+   * Extensions whose manifest does not name one keep the convention.
+   */
+  private async mapFilePaths(): Promise<Map<string, string>> {
+    const out = new Map<string, string>();
+    for (const bundle of await this.bundles.listLatest()) {
+      const parsed = Manifest.safeParse(bundle.manifest);
+      if (!parsed.success) continue;
+      const named = parsed.data.data_files["manga_id_map"];
+      if (named) out.set(bundle.extension, named);
+    }
+    return out;
+  }
+
+  /** Which repo holds each extension, discovered from the repos' `src/` listing. */
+  private async repoIndex(): Promise<RepoIndex> {
+    const byExtension = new Map<string, string[]>();
+    const unreadable = new Map<string, string>();
+    for (const repo of this.cfg.repos) {
+      let names: string[];
+      try {
+        names = await this.contents.listDirs(this.githubConfig(), repo, EXTENSIONS_DIR);
+      } catch (err) {
+        const detail = err instanceof GithubApiError ? err.message : `could not list ${repo}`;
+        this.deps.log.error({ err, repo }, "series-map sync could not list an extensions repo");
+        unreadable.set(repo, detail);
+        continue;
+      }
+      for (const name of names) {
+        const bucket = byExtension.get(name);
+        if (bucket) bucket.push(repo);
+        else byExtension.set(name, [repo]);
+      }
+    }
+    return { byExtension, unreadable };
+  }
+
+  /** Create the timestamp row, losing gracefully to a replica that got there first. */
+  private async seedFirstRun(now: Date): Promise<boolean> {
+    try {
+      await this.deps.prisma.setting.create({
+        data: { key: MAP_SYNC_LAST_RUN_KEY, value: now.toISOString() },
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Compare-and-set the timestamp. False means another replica claimed the slot. */
+  private async claim(expected: string, now: Date): Promise<boolean> {
+    const { count } = await this.deps.prisma.setting.updateMany({
+      where: { key: MAP_SYNC_LAST_RUN_KEY, value: expected },
+      data: { value: now.toISOString() },
+    });
+    return count > 0;
+  }
+}
+
+interface RepoIndex {
+  byExtension: Map<string, string[]>;
+  /** Repos GitHub would not list, with the reason. */
+  unreadable: Map<string, string>;
+}
+
+/**
+ * The commit message, carrying the marker that stops the push webhook from
+ * rebuilding a bundle for a data-file change we ourselves made (see
+ * `isMapSyncPush`). The counts are in the subject on purpose: `git log --oneline`
+ * in the extensions repo should say what a week of drift amounted to.
+ */
+export function commitMessage(
+  extension: string,
+  filename: string,
+  added: number,
+  removed: number,
+): string {
+  const delta = [added > 0 ? `+${added}` : null, removed > 0 ? `-${removed}` : null]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    `chore(${extension}): sync ${filename}${delta ? ` (${delta})` : ""} ${MAP_SYNC_COMMIT_MARKER}\n` +
+    "\n" +
+    "Written by the publoader series-map sync. The tracked_manga table is the\n" +
+    "authority for this mapping; this file is the readable copy contributors edit,\n" +
+    "and new entries added here are still imported on the next publish.\n"
+  );
+}

--- a/src/core/mapsync/timer.ts
+++ b/src/core/mapsync/timer.ts
@@ -1,0 +1,64 @@
+/**
+ * The clock behind the weekly series-map sync.
+ *
+ * It lives in core-api rather than core-scheduler for one concrete reason:
+ * core-scheduler sits on the `data` network with no egress and no GitHub
+ * credentials, while core-api already holds `GITHUB_TOKEN` and reaches GitHub
+ * for every webhook publish. Moving the job would mean opening the scheduler to
+ * the internet, which is a much larger change than a timer.
+ *
+ * The timer is deliberately dumb: it asks "is it due?" often and cheaply, and
+ * the answer is a row in `settings`, not a variable in this process. That is
+ * what makes a restart, a redeploy or a second replica harmless — see
+ * `MapSyncService.runIfDue`.
+ */
+import type { Logger } from "../../logging.js";
+import type { MapSyncService } from "./service.js";
+
+/** How often to ask. An hour of slack on a weekly job is not worth a finer tick. */
+export const MAP_SYNC_CHECK_INTERVAL_MS = 3_600_000;
+
+/**
+ * Delay before the first check, so a boot storm (a redeploy restarting every
+ * service at once) does not put the first question to GitHub while migrations
+ * are still settling.
+ */
+export const MAP_SYNC_FIRST_CHECK_MS = 60_000;
+
+export interface MapSyncTimer {
+  stop(): void;
+}
+
+export function startMapSyncTimer(
+  service: MapSyncService,
+  log: Logger,
+  opts: { checkIntervalMs?: number; firstCheckMs?: number } = {},
+): MapSyncTimer {
+  const unavailable = service.unavailableReason();
+  if (unavailable) {
+    log.info({ reason: unavailable }, "series-map sync is off");
+    return { stop: () => {} };
+  }
+
+  const check = (): void => {
+    void service.runIfDue().catch((err) => {
+      // Never fatal: this is a bookkeeping job, and core-api's actual work is
+      // serving requests.
+      log.error({ err }, "series-map sync failed");
+    });
+  };
+
+  const first = setTimeout(check, opts.firstCheckMs ?? MAP_SYNC_FIRST_CHECK_MS);
+  const repeat = setInterval(check, opts.checkIntervalMs ?? MAP_SYNC_CHECK_INTERVAL_MS);
+  // Neither timer should hold the process open on its own; the HTTP server is
+  // what keeps core-api alive.
+  first.unref();
+  repeat.unref();
+
+  return {
+    stop: () => {
+      clearTimeout(first);
+      clearInterval(repeat);
+    },
+  };
+}

--- a/src/core/webhooks/github.ts
+++ b/src/core/webhooks/github.ts
@@ -70,9 +70,30 @@ export interface PushPayload {
     full_name?: string;
     default_branch?: string;
   };
-  commits?: { added?: string[]; modified?: string[]; removed?: string[] }[];
-  head_commit?: { added?: string[]; modified?: string[]; removed?: string[] } | null;
+  commits?: PushCommit[];
+  head_commit?: PushCommit | null;
 }
+
+export interface PushCommit {
+  message?: string;
+  added?: string[];
+  modified?: string[];
+  removed?: string[];
+}
+
+/**
+ * Marker the weekly series-map sync puts in its commit subjects (see
+ * `core/mapsync/service.ts`).
+ *
+ * Without it the platform answers its own commit: the sync writes
+ * `src/<extension>/manga_id_map.json`, the push webhook sees a changed path
+ * under an extension directory and republishes the bundle — a new sha256 pin
+ * every week for a data file the workers do not read from the bundle anyway
+ * (`tracked_manga` is delivered on lease). The marker is only trusted for
+ * *skipping* work, so a forged one costs nothing an attacker could not get by
+ * simply not pushing.
+ */
+export const MAP_SYNC_COMMIT_MARKER = "[map-sync]";
 
 export type RoleDecision =
   | { role: RepoRole; repo: string; after: string }
@@ -140,6 +161,23 @@ const EXTENSION_PATH_RE = /^src\/([a-z0-9_]+)\//;
  * surfaces as that extension's per-extension error rather than being guessed
  * at here.
  */
+/**
+ * True when EVERY commit in the push is one the series-map sync made.
+ *
+ * Every, not any: a push that carries our map commit alongside a human's commit
+ * still contains code that has to be published. Erring the other way — treating
+ * a mixed push as ours — would silently drop a contributor's change, which is a
+ * far worse failure than one redundant republish.
+ *
+ * A push with no commit list at all is not ours: the fallback must be to
+ * publish, never to skip.
+ */
+export function isMapSyncPush(payload: PushPayload): boolean {
+  const commits = [...(payload.commits ?? []), ...(payload.head_commit ? [payload.head_commit] : [])];
+  if (commits.length === 0) return false;
+  return commits.every((commit) => (commit.message ?? "").includes(MAP_SYNC_COMMIT_MARKER));
+}
+
 export function changedExtensions(payload: PushPayload): string[] {
   const found = new Set<string>();
   const commits = [...(payload.commits ?? []), ...(payload.head_commit ? [payload.head_commit] : [])];

--- a/src/core/webhooks/repoContents.ts
+++ b/src/core/webhooks/repoContents.ts
@@ -1,0 +1,174 @@
+/**
+ * The GitHub Contents API: read a directory listing, read one file, write one
+ * file back.
+ *
+ * This is the only place in the platform that WRITES to GitHub. Everything else
+ * here reads (archives, commit metadata), so the asymmetry is deliberate and
+ * worth stating: `putFile` creates a commit on the repo's default branch, which
+ * is an outward-facing side effect. It is used by the weekly series-map sync
+ * (core/mapsync) and by nothing else.
+ *
+ * It shares repoMeta.ts's headers, body cap and error vocabulary rather than
+ * growing a second one — an operator reading "GITHUB_TOKEN may lack access to
+ * this repo" should get the same sentence whichever call produced it.
+ */
+import {
+  GithubApiError,
+  GITHUB_API_TIMEOUT_MS,
+  describeGithubFailure,
+  githubHeaders,
+  readGithubJson,
+  repoApiUrl,
+  type GithubApiConfig,
+} from "./repoMeta.js";
+
+/**
+ * The contents API embeds file bytes as base64 in the JSON response and stops
+ * doing so past 1 MB, answering with an empty `content` and a download URL
+ * instead. A series map that big is not something to rewrite blindly, so the
+ * limit is treated as a hard refusal rather than worked around.
+ */
+export const MAX_CONTENTS_FILE_BYTES = 1024 * 1024;
+
+export interface RepoFile {
+  path: string;
+  /** Blob sha. Required to update the file; it is GitHub's optimistic lock. */
+  sha: string;
+  text: string;
+}
+
+export interface PutFileRequest {
+  path: string;
+  text: string;
+  message: string;
+  /** Omit to create a new file; supply the blob sha to update an existing one. */
+  sha?: string;
+  /** Defaults to the repo's default branch. */
+  branch?: string;
+}
+
+export interface PutFileResult {
+  commit: string;
+  path: string;
+}
+
+/** Injected in tests so nothing here reaches the network. */
+export interface GithubContentsClient {
+  /** Names of the sub-directories of `dir`. Empty for a path that is not there. */
+  listDirs(cfg: GithubApiConfig, repo: string, dir: string): Promise<string[]>;
+  /** Null when the file does not exist. Throws for every other failure. */
+  getFile(cfg: GithubApiConfig, repo: string, path: string): Promise<RepoFile | null>;
+  putFile(cfg: GithubApiConfig, repo: string, req: PutFileRequest): Promise<PutFileResult>;
+}
+
+/**
+ * Percent-encode a repo-relative path for a URL without destroying its slashes.
+ *
+ * `encodeURIComponent` on the whole path would turn `src/viz/manga_id_map.json`
+ * into one literal filename; encoding per segment keeps the hierarchy and still
+ * escapes anything odd in a single name.
+ */
+export function encodeRepoPath(path: string): string {
+  return path.split("/").filter(Boolean).map(encodeURIComponent).join("/");
+}
+
+/**
+ * Reject a path that is not a plain repo-relative file path.
+ *
+ * The map file's location comes from the extension's own manifest
+ * (`data_files.manga_id_map`), which is repo-controlled text. It is interpolated
+ * into a contents-API URL and then WRITTEN to, so `../../.github/workflows/x.yml`
+ * has to be impossible rather than unlikely.
+ */
+export function isSafeRepoPath(path: string): boolean {
+  if (path.length === 0 || path.length > 512) return false;
+  if (path.startsWith("/") || path.includes("\\")) return false;
+  if (path.includes("//")) return false;
+  return path.split("/").every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+const contentsUrl = (cfg: GithubApiConfig, repo: string, path: string): string =>
+  repoApiUrl(cfg, repo, `/contents/${encodeRepoPath(path)}`);
+
+export const githubContents: GithubContentsClient = {
+  async listDirs(cfg, repo, dir) {
+    const res = await fetch(contentsUrl(cfg, repo, dir), {
+      headers: githubHeaders(cfg),
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+    // A repo with no `src/` is a configuration mistake, not an outage: report
+    // it as "no extensions here" and let the caller say so per extension.
+    if (res.status === 404) return [];
+    if (!res.ok) throw describeGithubFailure(res, cfg, `listing ${dir} in ${repo}`);
+    const body = await readGithubJson(res);
+    if (!Array.isArray(body)) {
+      throw new GithubApiError(`${dir} in ${repo} is a file, not a directory`);
+    }
+    return body
+      .filter(
+        (entry): entry is { name: string; type: string } =>
+          typeof entry === "object" &&
+          entry !== null &&
+          typeof (entry as { name?: unknown }).name === "string" &&
+          (entry as { type?: unknown }).type === "dir",
+      )
+      .map((entry) => entry.name);
+  },
+
+  async getFile(cfg, repo, path) {
+    const res = await fetch(contentsUrl(cfg, repo, path), {
+      headers: githubHeaders(cfg),
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) throw describeGithubFailure(res, cfg, `reading ${path} in ${repo}`);
+    const body = await readGithubJson(res);
+    if (Array.isArray(body)) {
+      throw new GithubApiError(`${path} in ${repo} is a directory, not a file`);
+    }
+    const file = body as { sha?: unknown; size?: unknown; content?: unknown; encoding?: unknown };
+    if (typeof file.sha !== "string") {
+      throw new GithubApiError(`GitHub returned no blob sha for ${path} in ${repo}`);
+    }
+    if (typeof file.size === "number" && file.size > MAX_CONTENTS_FILE_BYTES) {
+      throw new GithubApiError(
+        `${path} in ${repo} is ${file.size} bytes, over the ${MAX_CONTENTS_FILE_BYTES} byte contents-API limit`,
+      );
+    }
+    if (file.encoding !== "base64" || typeof file.content !== "string") {
+      throw new GithubApiError(`GitHub did not return readable content for ${path} in ${repo}`);
+    }
+    return { path, sha: file.sha, text: Buffer.from(file.content, "base64").toString("utf8") };
+  },
+
+  async putFile(cfg, repo, req) {
+    const body = JSON.stringify({
+      message: req.message,
+      content: Buffer.from(req.text, "utf8").toString("base64"),
+      ...(req.sha ? { sha: req.sha } : {}),
+      ...(req.branch ? { branch: req.branch } : {}),
+    });
+    const res = await fetch(contentsUrl(cfg, repo, req.path), {
+      method: "PUT",
+      headers: { ...githubHeaders(cfg), "content-type": "application/json" },
+      body,
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+    if (res.status === 409 || res.status === 422) {
+      // The blob sha we read is stale: someone pushed between the read and the
+      // write. Nothing is retried here — the next run reads the new file and
+      // decides again, which is the whole point of making this idempotent.
+      throw new GithubApiError(
+        `${req.path} in ${repo} changed while it was being written (HTTP ${res.status}); it will be retried on the next sync`,
+        res.status,
+      );
+    }
+    if (!res.ok) throw describeGithubFailure(res, cfg, `writing ${req.path} in ${repo}`);
+    const parsed = (await readGithubJson(res)) as { commit?: { sha?: unknown } };
+    const sha = parsed.commit?.sha;
+    return {
+      path: req.path,
+      commit: typeof sha === "string" ? sha : "",
+    };
+  },
+};

--- a/src/core/webhooks/repoList.ts
+++ b/src/core/webhooks/repoList.ts
@@ -1,0 +1,15 @@
+/**
+ * Parsing the repo-name list that `GITHUB_EXTENSIONS_REPOS` carries.
+ *
+ * Its own module because both an HTTP route (the push webhook) and a background
+ * job (the series-map sync) need it, and a background job must not import a
+ * Fastify route to get one string split.
+ */
+
+/** Comma- or whitespace-separated repo names, blanks dropped. */
+export function parseRepoList(raw: string): string[] {
+  return raw
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/src/core/webhooks/repoMeta.ts
+++ b/src/core/webhooks/repoMeta.ts
@@ -75,7 +75,7 @@ export interface GithubMetaClient {
   resolveRef(cfg: GithubApiConfig, repo: string, ref: string): Promise<string>;
 }
 
-function headers(cfg: GithubApiConfig): Record<string, string> {
+export function githubHeaders(cfg: GithubApiConfig): Record<string, string> {
   const out: Record<string, string> = {
     accept: "application/vnd.github+json",
     "user-agent": "publoader-core",
@@ -91,7 +91,7 @@ function headers(cfg: GithubApiConfig): Record<string, string> {
  * `res.json()` would buffer whatever GitHub sends; this process runs under a
  * 768 MiB limit, so a large compare must fail rather than be absorbed.
  */
-async function readJson(res: Response): Promise<unknown> {
+export async function readGithubJson(res: Response): Promise<unknown> {
   const declared = Number(res.headers.get("content-length") ?? "");
   if (Number.isFinite(declared) && declared > MAX_JSON_BYTES) {
     throw new GithubApiError(`GitHub response is ${declared} bytes, over the cap`);
@@ -122,7 +122,7 @@ async function readJson(res: Response): Promise<unknown> {
  * "the token is wrong or unset" versus "this repo name is wrong or the token
  * cannot see it".
  */
-function describeFailure(res: Response, cfg: GithubApiConfig, what: string): GithubApiError {
+export function describeGithubFailure(res: Response, cfg: GithubApiConfig, what: string): GithubApiError {
   const rateLimited =
     res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0";
   if (rateLimited) {
@@ -144,7 +144,7 @@ function describeFailure(res: Response, cfg: GithubApiConfig, what: string): Git
   return new GithubApiError(`GitHub ${what} failed with HTTP ${res.status}`, res.status);
 }
 
-const path = (cfg: GithubApiConfig, repo: string, rest: string): string =>
+export const repoApiUrl = (cfg: GithubApiConfig, repo: string, rest: string): string =>
   `${cfg.apiUrl.replace(/\/+$/, "")}/repos/${encodeURIComponent(cfg.owner)}/${encodeURIComponent(repo)}${rest}`;
 
 /**
@@ -154,9 +154,9 @@ const path = (cfg: GithubApiConfig, repo: string, rest: string): string =>
 export const githubMeta: GithubMetaClient = {
   async head(cfg, repo) {
     const signal = AbortSignal.timeout(GITHUB_API_TIMEOUT_MS);
-    const repoRes = await fetch(path(cfg, repo, ""), { headers: headers(cfg), signal });
-    if (!repoRes.ok) throw describeFailure(repoRes, cfg, `lookup of ${repo}`);
-    const meta = (await readJson(repoRes)) as { default_branch?: unknown };
+    const repoRes = await fetch(repoApiUrl(cfg, repo, ""), { headers: githubHeaders(cfg), signal });
+    if (!repoRes.ok) throw describeGithubFailure(repoRes, cfg, `lookup of ${repo}`);
+    const meta = (await readGithubJson(repoRes)) as { default_branch?: unknown };
     const defaultBranch =
       typeof meta.default_branch === "string" && meta.default_branch.length > 0
         ? meta.default_branch
@@ -166,11 +166,11 @@ export const githubMeta: GithubMetaClient = {
     // resolved, so a mistaken default_branch is visible in the response instead
     // of producing a sha with no explanation attached.
     const branchRes = await fetch(
-      path(cfg, repo, `/branches/${encodeURIComponent(defaultBranch)}`),
-      { headers: headers(cfg), signal },
+      repoApiUrl(cfg, repo, `/branches/${encodeURIComponent(defaultBranch)}`),
+      { headers: githubHeaders(cfg), signal },
     );
-    if (!branchRes.ok) throw describeFailure(branchRes, cfg, `lookup of ${repo}@${defaultBranch}`);
-    const branch = (await readJson(branchRes)) as { commit?: { sha?: unknown } };
+    if (!branchRes.ok) throw describeGithubFailure(branchRes, cfg, `lookup of ${repo}@${defaultBranch}`);
+    const branch = (await readGithubJson(branchRes)) as { commit?: { sha?: unknown } };
     const sha = branch.commit?.sha;
     if (typeof sha !== "string" || !/^[0-9a-f]{40}$/.test(sha)) {
       throw new GithubApiError(`GitHub returned no usable HEAD sha for ${repo}@${defaultBranch}`);
@@ -183,15 +183,15 @@ export const githubMeta: GithubMetaClient = {
     // commit it resolved to. A branch name in a bundle's `sourceCommit` would
     // make "is this behind?" unanswerable later, so the resolution happens once,
     // here, at install time.
-    const res = await fetch(path(cfg, repo, `/commits/${encodeURIComponent(ref)}`), {
-      headers: headers(cfg),
+    const res = await fetch(repoApiUrl(cfg, repo, `/commits/${encodeURIComponent(ref)}`), {
+      headers: githubHeaders(cfg),
       signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
     });
     if (res.status === 404) {
       throw new GithubApiError(`${repo} has no ref '${ref}'`, 404);
     }
-    if (!res.ok) throw describeFailure(res, cfg, `lookup of ${repo}@${ref}`);
-    const body = (await readJson(res)) as { sha?: unknown };
+    if (!res.ok) throw describeGithubFailure(res, cfg, `lookup of ${repo}@${ref}`);
+    const body = (await readGithubJson(res)) as { sha?: unknown };
     if (typeof body.sha !== "string" || !/^[0-9a-f]{40}$/.test(body.sha)) {
       throw new GithubApiError(`GitHub returned no usable commit sha for ${repo}@${ref}`);
     }
@@ -200,18 +200,18 @@ export const githubMeta: GithubMetaClient = {
 
   async compare(cfg, repo, base, head) {
     const signal = AbortSignal.timeout(GITHUB_API_TIMEOUT_MS);
-    const url = path(
+    const url = repoApiUrl(
       cfg,
       repo,
       `/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`,
     );
-    const res = await fetch(url, { headers: headers(cfg), signal });
+    const res = await fetch(url, { headers: githubHeaders(cfg), signal });
     // 404 is not an error here: it is how GitHub says "one of these commits is
     // not in this repo", which is exactly the question being asked when a
     // published bundle has to be matched to one of several repos.
     if (res.status === 404) return null;
-    if (!res.ok) throw describeFailure(res, cfg, `compare in ${repo}`);
-    const body = (await readJson(res)) as {
+    if (!res.ok) throw describeGithubFailure(res, cfg, `compare in ${repo}`);
+    const body = (await readGithubJson(res)) as {
       ahead_by?: unknown;
       files?: { filename?: unknown }[];
     };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -7,6 +7,8 @@ import { MdClient } from "../core/md/client.js";
 import { DiscordNotifier } from "../core/md/webhook.js";
 import { TitleService } from "../core/md/titleService.js";
 import { startMetricsServer } from "../core/observability/metricsServer.js";
+import { MapSyncService } from "../core/mapsync/service.js";
+import { startMapSyncTimer } from "../core/mapsync/timer.js";
 
 const config = loadConfig();
 const log = createLogger("core-api", config.logLevel);
@@ -22,6 +24,25 @@ if (config.mdUsername && config.mdPassword) {
   ctx.titleService = new TitleService(prisma, md, notifier, log);
 }
 const server = buildServer(ctx);
+
+/**
+ * The weekly write-back of tracked_manga to each extension's manga_id_map.json.
+ *
+ * core-api hosts it because it is the only core service with a GitHub token and
+ * egress; core-scheduler runs on the internal `data` network. It is a timer, not
+ * a scheduler slot, and its dueness lives in the `settings` table — so replicas,
+ * restarts and redeploys cannot make it run twice or drift. See
+ * docs/operations.md §"Series-map sync".
+ */
+const mapSync = startMapSyncTimer(
+  MapSyncService.fromConfig(config, {
+    prisma,
+    log,
+    audit: ctx.audit,
+    settings: ctx.settings,
+  }),
+  log,
+);
 
 /**
  * Make sure there is always a way in. A fresh database has no accounts, so
@@ -64,6 +85,7 @@ const metricsServer = await startMetricsServer({
 
 const shutdown = async (signal: string) => {
   log.info({ signal }, "shutting down");
+  mapSync.stop();
   await server.close();
   await metricsServer.close();
   await prisma.$disconnect();

--- a/test/integration/mapSync.test.ts
+++ b/test/integration/mapSync.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { loadConfig } from "../../src/config.js";
+import { createLogger } from "../../src/logging.js";
+import { buildContext } from "../../src/core/api/context.js";
+import { buildServer } from "../../src/core/api/server.js";
+import type { GithubContentsClient } from "../../src/core/webhooks/repoContents.js";
+import { closeDb, dbReady, resetDb, testPrisma } from "./db.js";
+
+/**
+ * `POST /api/v1/admin/maps/sync` end to end: real auth, real scopes, real
+ * `tracked_manga` rows, and a GitHub that lives in this process.
+ *
+ * The unit tests cover what the job decides; what matters here is that the
+ * route reaches the database the operator thinks it does, that the scope gate
+ * holds (this endpoint commits to a git repository), and that a dry run really
+ * is dry.
+ */
+const ADMIN = "test-admin-token-0123456789";
+const MD_A = "aaaaaaaa-0000-4000-8000-000000000001";
+const MD_B = "bbbbbbbb-0000-4000-8000-000000000002";
+
+describe.skipIf(!dbReady())("admin series-map sync", () => {
+  const prisma = testPrisma();
+  const config = loadConfig({
+    DATABASE_URL: process.env.TEST_DATABASE_URL!,
+    ADMIN_TOKEN: ADMIN,
+    LOG_LEVEL: "error",
+    GITHUB_REPO_OWNER: "publoader",
+    GITHUB_EXTENSIONS_REPOS: "publoader-extensions",
+    GITHUB_TOKEN: "gh-token-for-tests",
+  });
+  const log = createLogger("test-map-sync-api", "silent");
+  let app: FastifyInstance;
+  let files: Map<string, string>;
+  let writes: { path: string; text: string; message: string }[];
+
+  beforeEach(async () => {
+    await resetDb(prisma);
+    files = new Map([["src/mangaplus/manga_id_map.json", `{"${MD_A}": ["100001"]}`]]);
+    writes = [];
+    const contents: GithubContentsClient = {
+      async listDirs() {
+        return ["mangaplus"];
+      },
+      async getFile(_cfg, _repo, path) {
+        const text = files.get(path);
+        return text === undefined ? null : { path, sha: "blob-sha", text };
+      },
+      async putFile(_cfg, _repo, req) {
+        writes.push({ path: req.path, text: req.text, message: req.message });
+        files.set(req.path, req.text);
+        return { path: req.path, commit: "c".repeat(40) };
+      },
+    };
+    const ctx = buildContext(prisma, config, log);
+    ctx.mapSyncContents = contents;
+    app = buildServer(ctx);
+    await app.ready();
+
+    await prisma.trackedManga.createMany({
+      data: [
+        { extension: "mangaplus", namespace: "", mangaId: "100001", mdMangaId: MD_A, source: "bundle-import" },
+        { extension: "mangaplus", namespace: "", mangaId: "100002", mdMangaId: MD_B, source: "auto" },
+      ],
+    });
+  });
+  afterAll(async () => {
+    await app?.close();
+    await closeDb();
+  });
+
+  const sync = (body: Record<string, unknown> = {}, token = ADMIN) =>
+    app.inject({
+      method: "POST",
+      url: "/api/v1/admin/maps/sync",
+      headers: { authorization: `Bearer ${token}`, "x-actor": "tester@example.com" },
+      payload: body,
+    });
+
+  it("commits the auto-created mapping the file never had", async () => {
+    const res = await sync();
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.written).toBe(1);
+    expect(body.outcomes[0]).toMatchObject({
+      extension: "mangaplus",
+      status: "write",
+      repo: "publoader-extensions",
+      added: 1,
+      removed: 0,
+      mappings: 2,
+    });
+    expect(JSON.parse(writes[0]!.text)).toEqual({ [MD_A]: ["100001"], [MD_B]: ["100002"] });
+  });
+
+  it("is idempotent: the second run has nothing to say", async () => {
+    await sync();
+    const res = await sync();
+    expect(res.json().outcomes[0].status).toBe("unchanged");
+    expect(writes).toHaveLength(1);
+  });
+
+  it("writes nothing on a dry run", async () => {
+    const res = await sync({ dryRun: true });
+    expect(res.json().outcomes[0]).toMatchObject({ status: "write", detail: "would write" });
+    expect(writes).toHaveLength(0);
+  });
+
+  it("audits a real run and its per-file write, but not a preview", async () => {
+    await sync({ dryRun: true });
+    expect(await prisma.auditEvent.count({ where: { action: { startsWith: "map_sync" } } })).toBe(0);
+
+    await sync();
+    const events = await prisma.auditEvent.findMany({
+      where: { action: { startsWith: "map_sync" } },
+      orderBy: { action: "asc" },
+    });
+    expect(events.map((e) => e.action)).toEqual(["map_sync.run", "map_sync.write"]);
+    // Attributed to the caller, not to "scheduler": a manual sync is somebody's
+    // decision and the audit trail has to name them.
+    expect(events[1]).toMatchObject({
+      actor: "admin:tester@example.com",
+      subject: "mangaplus@publoader-extensions",
+    });
+  });
+
+  it("limits the run to the named extensions", async () => {
+    await prisma.trackedManga.create({
+      data: { extension: "other", namespace: "", mangaId: "1", mdMangaId: MD_A, source: "auto" },
+    });
+    const res = await sync({ extensions: ["mangaplus"] });
+    expect(res.json().outcomes.map((o: { extension: string }) => o.extension)).toEqual(["mangaplus"]);
+  });
+
+  it("refuses a caller without tracked:write, because this publishes to a repo", async () => {
+    const minted = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/tokens",
+      headers: { authorization: `Bearer ${ADMIN}` },
+      payload: { name: "map-reader", scopes: ["tracked:read", "tracked:append"] },
+    });
+    expect(minted.statusCode).toBe(201);
+
+    const res = await sync({ dryRun: true }, minted.json().token);
+    expect(res.statusCode).toBe(403);
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/test/unit/mapSync.test.ts
+++ b/test/unit/mapSync.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, it } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { createLogger } from "../../src/logging.js";
+import { AuditLog, SettingsStore } from "../../src/core/store/settings.js";
+import { parseMangaIdMapFile } from "../../src/core/store/bundles.js";
+import { isMapSyncPush, MAP_SYNC_COMMIT_MARKER } from "../../src/core/webhooks/github.js";
+import { encodeRepoPath, isSafeRepoPath, type GithubContentsClient } from "../../src/core/webhooks/repoContents.js";
+import {
+  DEFAULT_SHAPE,
+  detectMapShape,
+  parseMapText,
+  planWrite,
+  renderMapFile,
+} from "../../src/core/mapsync/mapFile.js";
+import {
+  MapSyncService,
+  MAP_SYNC_LAST_RUN_KEY,
+  type MapSyncConfig,
+} from "../../src/core/mapsync/service.js";
+
+/**
+ * This job commits to somebody's git repository once a week with nobody
+ * watching, so the tests are mostly about what it must NOT do: rewrite a file
+ * into a different shape, produce a churn commit when nothing changed, empty a
+ * file because a query came back short, or answer its own commit with a bundle
+ * republish.
+ */
+
+const log = createLogger("test-map-sync", "silent");
+
+const MD_A = "aaaaaaaa-0000-4000-8000-000000000001";
+const MD_B = "bbbbbbbb-0000-4000-8000-000000000002";
+const MD_C = "cccccccc-0000-4000-8000-000000000003";
+
+const row = (mangaId: string, mdMangaId: string, namespace = "") => ({ namespace, mangaId, mdMangaId });
+
+describe("renderMapFile", () => {
+  it("writes mangaplus's inverted shape, sorted and stable", () => {
+    const text = renderMapFile([row("100002", MD_B), row("100001", MD_A), row("100003", MD_B)]);
+    expect(text).toBe(
+      `{\n  "${MD_A}": [\n    "100001"\n  ],\n  "${MD_B}": [\n    "100002",\n    "100003"\n  ]\n}\n`,
+    );
+    // Same rows in any order render byte-identically, which is what stops a
+    // weekly no-op run from producing a commit.
+    expect(renderMapFile([row("100003", MD_B), row("100001", MD_A), row("100002", MD_B)])).toBe(text);
+  });
+
+  it("keeps alpha_manga's forward shape when that is what the file uses", () => {
+    const text = renderMapFile([row("9", MD_B), row("10", MD_A)], { nested: false, inner: "forward" });
+    // Numeric-aware ordering: 9 before 10, not after it.
+    expect(text).toBe(`{\n  "9": "${MD_B}",\n  "10": "${MD_A}"\n}\n`);
+  });
+
+  it("nests a namespaced extension even when asked for a flat shape", () => {
+    const text = renderMapFile(
+      [row("709", MD_A, "vizmanga"), row("709", MD_B, "shonenjump")],
+      { nested: false, inner: "forward" },
+    );
+    expect(JSON.parse(text)).toEqual({ shonenjump: { "709": MD_B }, vizmanga: { "709": MD_A } });
+  });
+
+  it("does not invent an empty namespace key for rows that have none", () => {
+    // The file was nested; the rows are not. Writing `{"": {…}}` would be a
+    // valid parse and a nonsense file.
+    const text = renderMapFile([row("1", MD_A)], { nested: true, inner: "forward" });
+    expect(JSON.parse(text)).toEqual({ "1": MD_A });
+  });
+
+  it("round-trips through the parser the platform reads these files with", () => {
+    const rows = [row("709", MD_A, "vizmanga"), row("218", MD_B, "vizmanga"), row("1", MD_C, "shonenjump")];
+    const parsed = parseMangaIdMapFile(JSON.parse(renderMapFile(rows, { nested: true, inner: "forward" })));
+    expect(parsed.sort(byId)).toEqual(rows.sort(byId));
+  });
+});
+
+describe("detectMapShape", () => {
+  it("recognises each shape that exists in the wild", () => {
+    expect(detectMapShape({ [MD_A]: ["1", "2"] })).toEqual({ nested: false, inner: "inverted" });
+    expect(detectMapShape({ "1": MD_A })).toEqual({ nested: false, inner: "forward" });
+    expect(detectMapShape({ vizmanga: { "709": MD_A } })).toEqual({ nested: true, inner: "forward" });
+  });
+
+  it("returns null for something that is not a map, so nothing is overwritten on a guess", () => {
+    expect(detectMapShape([])).toBeNull();
+    expect(detectMapShape({})).toBeNull();
+    expect(parseMapText("not json").shape).toBeNull();
+  });
+});
+
+describe("planWrite", () => {
+  const current = (rows: ReturnType<typeof row>[], shape = DEFAULT_SHAPE) => ({
+    text: renderMapFile(rows, shape),
+    rows,
+  });
+
+  it("makes no commit when the file already says what the database says", () => {
+    const rows = [row("1", MD_A), row("2", MD_B)];
+    expect(planWrite(current(rows), { text: renderMapFile(rows), rows })).toMatchObject({
+      action: "unchanged",
+      added: 0,
+      removed: 0,
+    });
+  });
+
+  it("writes, and counts both directions, when the map moved on", () => {
+    const before = [row("1", MD_A)];
+    const after = [row("1", MD_A), row("2", MD_B)];
+    expect(planWrite(current(before), { text: renderMapFile(after), rows: after })).toEqual({
+      action: "write",
+      added: 1,
+      removed: 0,
+    });
+  });
+
+  it("does not create a file that is not in the repo", () => {
+    const rows = [row("1", MD_A)];
+    const plan = planWrite(null, { text: renderMapFile(rows), rows });
+    expect(plan.action).toBe("skipped");
+    expect(plan.reason).toMatch(/not in the repo/);
+  });
+
+  it("refuses to empty a file when the database has nothing for the extension", () => {
+    const plan = planWrite(current([row("1", MD_A)]), { text: renderMapFile([]), rows: [] });
+    expect(plan.action).toBe("refused");
+    expect(plan.reason).toMatch(/refusing to empty/);
+  });
+
+  it("refuses a write that would delete more than half the mappings", () => {
+    const before = Array.from({ length: 10 }, (_, i) => row(String(i), MD_A));
+    const after = before.slice(0, 3);
+    const plan = planWrite(current(before), { text: renderMapFile(after), rows: after });
+    expect(plan.action).toBe("refused");
+    expect(plan.removed).toBe(7);
+    // …and an operator who means it can say so.
+    expect(
+      planWrite(current(before), { text: renderMapFile(after), rows: after }, { force: true }).action,
+    ).toBe("write");
+  });
+
+  it("allows a small shrink, because untracking one series is routine", () => {
+    const before = Array.from({ length: 10 }, (_, i) => row(String(i), MD_A));
+    const after = before.slice(0, 9);
+    expect(planWrite(current(before), { text: renderMapFile(after), rows: after })).toMatchObject({
+      action: "write",
+      removed: 1,
+    });
+  });
+});
+
+describe("isMapSyncPush", () => {
+  const commit = (message: string) => ({ message, modified: ["src/mangaplus/manga_id_map.json"] });
+
+  it("recognises a push that is entirely our own commits", () => {
+    expect(isMapSyncPush({ commits: [commit(`chore(mangaplus): sync ${MAP_SYNC_COMMIT_MARKER}`)] })).toBe(true);
+  });
+
+  it("publishes a push that also carries a human's commit", () => {
+    expect(
+      isMapSyncPush({
+        commits: [commit(`chore(mangaplus): sync ${MAP_SYNC_COMMIT_MARKER}`), commit("fix parser")],
+      }),
+    ).toBe(false);
+  });
+
+  it("publishes when there is nothing to judge", () => {
+    expect(isMapSyncPush({})).toBe(false);
+    expect(isMapSyncPush({ commits: [] })).toBe(false);
+    expect(isMapSyncPush({ commits: [{ modified: ["src/mangaplus/index.ts"] }] })).toBe(false);
+  });
+});
+
+describe("repo paths", () => {
+  it("keeps the hierarchy while escaping each segment", () => {
+    expect(encodeRepoPath("src/mangaplus/manga_id_map.json")).toBe("src/mangaplus/manga_id_map.json");
+    expect(encodeRepoPath("src/a b/c.json")).toBe("src/a%20b/c.json");
+  });
+
+  it("rejects a manifest data-file path that could escape the extension directory", () => {
+    expect(isSafeRepoPath("src/mangaplus/manga_id_map.json")).toBe(true);
+    expect(isSafeRepoPath("../../.github/workflows/release.yml")).toBe(false);
+    expect(isSafeRepoPath("/etc/passwd")).toBe(false);
+    expect(isSafeRepoPath("src/x/..\\y.json")).toBe(false);
+    expect(isSafeRepoPath("")).toBe(false);
+  });
+});
+
+// --- the service, against a GitHub that lives in this process ---------------
+
+interface FakeRepo {
+  files: Map<string, string>;
+  dirs: string[];
+}
+
+function fakeGithub(repos: Record<string, FakeRepo>) {
+  const writes: { repo: string; path: string; text: string; message: string; sha?: string }[] = [];
+  const client: GithubContentsClient = {
+    async listDirs(_cfg, repo) {
+      const found = repos[repo];
+      if (!found) throw new Error(`no such repo ${repo}`);
+      return found.dirs;
+    },
+    async getFile(_cfg, repo, path) {
+      const text = repos[repo]?.files.get(path);
+      return text === undefined ? null : { path, sha: `sha-${path}`, text };
+    },
+    async putFile(_cfg, repo, req) {
+      writes.push({ repo, ...req });
+      repos[repo]!.files.set(req.path, req.text);
+      return { path: req.path, commit: "0".repeat(40) };
+    },
+  };
+  return { client, writes };
+}
+
+/**
+ * The two tables this job reads plus the settings row it schedules itself with.
+ * A real Prisma is integration-test territory; the decisions worth testing here
+ * are the ones above and the wiring between them.
+ */
+function fakePrisma(opts: {
+  tracked: { extension: string; namespace: string; mangaId: string; mdMangaId: string }[];
+  bundles?: { extension: string; manifest: unknown }[];
+  settings?: Record<string, string>;
+}) {
+  const settings = new Map(Object.entries(opts.settings ?? {}));
+  return {
+    settings,
+    prisma: {
+      trackedManga: {
+        findMany: async ({ where }: { where?: { extension?: { in: string[] } } } = {}) =>
+          opts.tracked.filter((t) => !where?.extension || where.extension.in.includes(t.extension)),
+      },
+      bundle: {
+        findMany: async () =>
+          (opts.bundles ?? []).map((b, i) => ({
+            ...b,
+            id: String(i),
+            version: "1.0.0",
+            sha256: "x",
+            yanked: false,
+            publishedAt: new Date(),
+          })),
+      },
+      setting: {
+        findUnique: async ({ where }: { where: { key: string } }) =>
+          settings.has(where.key) ? { key: where.key, value: settings.get(where.key)! } : null,
+        create: async ({ data }: { data: { key: string; value: string } }) => {
+          if (settings.has(data.key)) throw new Error("unique violation");
+          settings.set(data.key, data.value);
+          return data;
+        },
+        updateMany: async ({
+          where,
+          data,
+        }: {
+          where: { key: string; value: string };
+          data: { value: string };
+        }) => {
+          if (settings.get(where.key) !== where.value) return { count: 0 };
+          settings.set(where.key, data.value);
+          return { count: 1 };
+        },
+        upsert: async ({ where, create }: { where: { key: string }; create: { key: string; value: string } }) => {
+          settings.set(where.key, create.value);
+          return create;
+        },
+        deleteMany: async ({ where }: { where: { key: string } }) => {
+          settings.delete(where.key);
+          return { count: 1 };
+        },
+      },
+      auditEvent: { create: async () => ({}) },
+    } as unknown as PrismaClient,
+  };
+}
+
+const service = (
+  prisma: PrismaClient,
+  contents: GithubContentsClient,
+  overrides: Partial<MapSyncConfig> = {},
+  now = () => Date.parse("2026-08-05T00:00:00Z"),
+) =>
+  new MapSyncService(
+    {
+      enabled: true,
+      intervalHours: 168,
+      owner: "publoader",
+      apiUrl: "https://api.github.com",
+      token: "gh-token",
+      repos: ["publoader-extensions"],
+      ...overrides,
+    },
+    {
+      prisma,
+      log,
+      audit: new AuditLog(prisma),
+      settings: new SettingsStore(prisma),
+      contents,
+      now,
+    },
+  );
+
+describe("MapSyncService.sync", () => {
+  it("commits the database's map into the extension's existing file", async () => {
+    const { client, writes } = fakeGithub({
+      "publoader-extensions": {
+        dirs: ["mangaplus", "viz"],
+        files: new Map([["src/mangaplus/manga_id_map.json", `{"${MD_A}": ["100001"]}`]]),
+      },
+    });
+    const { prisma } = fakePrisma({
+      tracked: [
+        { extension: "mangaplus", namespace: "", mangaId: "100001", mdMangaId: MD_A },
+        { extension: "mangaplus", namespace: "", mangaId: "100002", mdMangaId: MD_B },
+      ],
+    });
+
+    const report = await service(prisma, client).sync();
+    expect(report.written).toBe(1);
+    expect(report.outcomes[0]).toMatchObject({
+      extension: "mangaplus",
+      status: "write",
+      repo: "publoader-extensions",
+      path: "src/mangaplus/manga_id_map.json",
+      added: 1,
+      removed: 0,
+    });
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0]!.text)).toEqual({ [MD_A]: ["100001"], [MD_B]: ["100002"] });
+    // The marker is what stops this commit from triggering a republish.
+    expect(writes[0]!.message).toContain(MAP_SYNC_COMMIT_MARKER);
+    expect(writes[0]!.sha).toBe("sha-src/mangaplus/manga_id_map.json");
+  });
+
+  it("makes no commit at all when the file already matches", async () => {
+    const canonical = renderMapFile([{ namespace: "", mangaId: "100001", mdMangaId: MD_A }]);
+    const { client, writes } = fakeGithub({
+      "publoader-extensions": {
+        dirs: ["mangaplus"],
+        files: new Map([["src/mangaplus/manga_id_map.json", canonical]]),
+      },
+    });
+    const { prisma } = fakePrisma({
+      tracked: [{ extension: "mangaplus", namespace: "", mangaId: "100001", mdMangaId: MD_A }],
+    });
+
+    const report = await service(prisma, client).sync();
+    expect(report.outcomes[0]!.status).toBe("unchanged");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("uses the path the manifest names for its map", async () => {
+    const { client, writes } = fakeGithub({
+      "publoader-extensions": {
+        dirs: ["viz"],
+        files: new Map([["src/viz/data/ids.json", `{"vizmanga": {"1": "${MD_C}"}}`]]),
+      },
+    });
+    const { prisma } = fakePrisma({
+      tracked: [{ extension: "viz", namespace: "vizmanga", mangaId: "709", mdMangaId: MD_A }],
+      bundles: [
+        {
+          extension: "viz",
+          manifest: {
+            name: "viz",
+            version: "1.0.0",
+            publoader_api: "^2.0.0",
+            runtime: "node",
+            entrypoint: "index.mjs",
+            mangadex_group_id: "dddddddd-0000-4000-8000-000000000004",
+            languages: ["en"],
+            allowed_hosts: ["www.viz.com"],
+            data_files: { manga_id_map: "data/ids.json" },
+          },
+        },
+      ],
+    });
+
+    const report = await service(prisma, client).sync();
+    expect(report.outcomes[0]).toMatchObject({ status: "write", path: "src/viz/data/ids.json" });
+    // viz's file is nested+forward, and stays that way.
+    expect(JSON.parse(writes[0]!.text)).toEqual({ vizmanga: { "709": MD_A } });
+  });
+
+  it("writes nothing on a dry run but reports what it would do", async () => {
+    const { client, writes } = fakeGithub({
+      "publoader-extensions": {
+        dirs: ["mangaplus"],
+        files: new Map([["src/mangaplus/manga_id_map.json", "{}"]]),
+      },
+    });
+    const { prisma } = fakePrisma({
+      tracked: [{ extension: "mangaplus", namespace: "", mangaId: "1", mdMangaId: MD_A }],
+    });
+
+    const report = await service(prisma, client).sync({ dryRun: true });
+    expect(report.outcomes[0]).toMatchObject({ status: "write", detail: "would write" });
+    expect(writes).toHaveLength(0);
+  });
+
+  it("refuses to guess when two repos both have the extension", async () => {
+    const { client, writes } = fakeGithub({
+      "publoader-extensions": {
+        dirs: ["mangaplus"],
+        files: new Map([["src/mangaplus/manga_id_map.json", "{}"]]),
+      },
+      "publoader-extensions-private": {
+        dirs: ["mangaplus"],
+        files: new Map([["src/mangaplus/manga_id_map.json", "{}"]]),
+      },
+    });
+    const { prisma } = fakePrisma({
+      tracked: [{ extension: "mangaplus", namespace: "", mangaId: "1", mdMangaId: MD_A }],
+    });
+
+    const report = await service(prisma, client, {
+      repos: ["publoader-extensions", "publoader-extensions-private"],
+    }).sync();
+    expect(report.outcomes[0]!.status).toBe("skipped");
+    expect(report.outcomes[0]!.detail).toMatch(/more than one repo/);
+    expect(writes).toHaveLength(0);
+  });
+
+  it("keeps going when one extension's file cannot be read", async () => {
+    const { client, writes } = fakeGithub({
+      "publoader-extensions": {
+        dirs: ["broken", "mangaplus"],
+        files: new Map([["src/mangaplus/manga_id_map.json", "{}"]]),
+      },
+    });
+    const failing: GithubContentsClient = {
+      ...client,
+      getFile: async (cfg, repo, path) => {
+        if (path.startsWith("src/broken/")) throw new Error("GitHub is having a day");
+        return client.getFile(cfg, repo, path);
+      },
+    };
+    const { prisma } = fakePrisma({
+      tracked: [
+        { extension: "broken", namespace: "", mangaId: "1", mdMangaId: MD_A },
+        { extension: "mangaplus", namespace: "", mangaId: "2", mdMangaId: MD_B },
+      ],
+    });
+
+    const report = await service(prisma, failing).sync();
+    expect(report.failed).toBe(1);
+    expect(report.written).toBe(1);
+    expect(writes.map((w) => w.path)).toEqual(["src/mangaplus/manga_id_map.json"]);
+  });
+
+  it("does nothing when it has no token to write with", async () => {
+    const { client, writes } = fakeGithub({
+      "publoader-extensions": { dirs: ["mangaplus"], files: new Map() },
+    });
+    const { prisma } = fakePrisma({
+      tracked: [{ extension: "mangaplus", namespace: "", mangaId: "1", mdMangaId: MD_A }],
+    });
+    const svc = service(prisma, client, { token: undefined });
+
+    expect(svc.unavailableReason()).toMatch(/GITHUB_TOKEN/);
+    const report = await svc.sync();
+    expect(report.skippedReason).toMatch(/GITHUB_TOKEN/);
+    expect(writes).toHaveLength(0);
+  });
+});
+
+describe("MapSyncService.runIfDue", () => {
+  const github = () =>
+    fakeGithub({
+      "publoader-extensions": {
+        dirs: ["mangaplus"],
+        files: new Map([["src/mangaplus/manga_id_map.json", "{}"]]),
+      },
+    });
+  const tracked = [{ extension: "mangaplus", namespace: "", mangaId: "1", mdMangaId: MD_A }];
+  const T0 = Date.parse("2026-08-05T00:00:00Z");
+
+  it("arms itself on the first run and syncs nothing, so a deploy makes no commits", async () => {
+    const { client, writes } = github();
+    const { prisma, settings } = fakePrisma({ tracked });
+
+    expect(await service(prisma, client, {}, () => T0).runIfDue()).toBeNull();
+    expect(writes).toHaveLength(0);
+    expect(settings.get(MAP_SYNC_LAST_RUN_KEY)).toBe(new Date(T0).toISOString());
+  });
+
+  it("stays quiet until the interval has passed, then syncs", async () => {
+    const { client, writes } = github();
+    const { prisma, settings } = fakePrisma({
+      tracked,
+      settings: { [MAP_SYNC_LAST_RUN_KEY]: new Date(T0).toISOString() },
+    });
+
+    const sixDays = T0 + 6 * 86_400_000;
+    expect(await service(prisma, client, {}, () => sixDays).runIfDue()).toBeNull();
+    expect(writes).toHaveLength(0);
+
+    const eightDays = T0 + 8 * 86_400_000;
+    const report = await service(prisma, client, {}, () => eightDays).runIfDue();
+    expect(report?.written).toBe(1);
+    expect(settings.get(MAP_SYNC_LAST_RUN_KEY)).toBe(new Date(eightDays).toISOString());
+  });
+
+  it("lets only one replica run: the slot is claimed before the work", async () => {
+    const { client, writes } = github();
+    const { prisma } = fakePrisma({
+      tracked,
+      settings: { [MAP_SYNC_LAST_RUN_KEY]: new Date(T0).toISOString() },
+    });
+    const due = T0 + 8 * 86_400_000;
+
+    const [a, b] = await Promise.all([
+      service(prisma, client, {}, () => due).runIfDue(),
+      service(prisma, client, {}, () => due).runIfDue(),
+    ]);
+    expect([a, b].filter((r) => r !== null)).toHaveLength(1);
+    expect(writes).toHaveLength(1);
+  });
+
+  it("does not sync while the platform is paused", async () => {
+    const { client, writes } = github();
+    const { prisma } = fakePrisma({
+      tracked,
+      settings: {
+        [MAP_SYNC_LAST_RUN_KEY]: new Date(T0).toISOString(),
+        pause_until: "inf",
+      },
+    });
+
+    expect(await service(prisma, client, {}, () => T0 + 8 * 86_400_000).runIfDue()).toBeNull();
+    expect(writes).toHaveLength(0);
+  });
+});
+
+const byId = (a: { mangaId: string }, b: { mangaId: string }) => (a.mangaId < b.mangaId ? -1 : 1);


### PR DESCRIPTION
## What

`tracked_manga` is the authority for publisher-id → MangaDex-title-id, but each extension's `manga_id_map.json` only ever *seeds* it. Nothing put the changes back, so the files in the extensions repos drift: auto-created titles and operator repoints are invisible in git, and a mapping deliberately removed from the database gets re-seeded from the stale file on the next publish.

core-api now writes the table back once a week (`MAP_SYNC_INTERVAL_HOURS`, default 168).

## Why core-api and not core-scheduler

core-scheduler sits on the internal `data` network with no egress and no GitHub credentials. core-api already holds `GITHUB_TOKEN` and reaches GitHub for every webhook publish. Dueness lives in a `settings` row claimed with a compare-and-set, so replicas, restarts and redeploys cannot double-run or drift.

## Guards (it commits unattended)

- Never **creates** a file — an extension without one is skipped with a note.
- Never **empties** one; a large shrink (>50% of a file's mappings) is refused without `--force`.
- Never guesses when two configured repos both hold the extension.
- Preserves each file's own shape (mangaplus inverted, alpha_manga forward, viz nested) and renders deterministically — a week with no changes makes **no commit**.
- The first boot after enabling only *arms* the timer; a deploy produces no commits.
- Skips while the platform is paused; inert without a Contents:write token.

## No feedback loop

Commits carry `[map-sync]`; the push webhook ignores a delivery whose commits are *all* marked, so the platform doesn't answer its own data-file commit with a bundle republish. A push mixing one of ours with a human's still publishes.

## Operator surface

```bash
padmin maps sync --dry-run      # preview the next weekly run
padmin maps sync                # run it now
padmin maps sync --force --extension viz
```

`POST /api/v1/admin/maps/sync`, scope `tracked:write` (it publishes to a git repo). Each write is audited as `map_sync.write` with the commit sha and counts.

## Note for deployers

`GITHUB_TOKEN` now wants **Contents: write** on the extensions repos. Staging ships `MAP_SYNC_ENABLED=false` — two deployments writing the same files would overwrite each other with whichever database is staler.

## Tests

606 unit (29 new) and 253 integration (6 new) pass; typecheck and lint clean. Integration run against a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)