### PR TITLE
Show chapters as chapters: per run, in the queue, and after upload

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -319,14 +319,22 @@ served to workers, not to admin clients.
 | Method | Path | Scope | Notes |
 | --- | --- | --- | --- |
 | `POST` | `/runs` | `runs:write` | `{extension, kind?, idempotencyKey?}`. `kind` defaults to `FORCE`. `201` created / `200` already existed → `{runId, created, segments}`. **`409` platform is paused**; `404` no bundle published for that extension |
-| `GET` | `/runs` | `runs:read` | `?limit=1..200` (25), `?extension=` |
+| `GET` | `/runs` | `runs:read` | `?limit=1..200` (25), `?extension=`. Each row carries `chaptersFound` (new or changed) and `chaptersSeen` (catalogue snapshot), aggregated over the page in one statement. **Both are `null` when no segment has committed an envelope yet** — which is not the same as a run that found nothing |
 | `GET` | `/runs/:id` | `runs:read` | Run plus all its jobs; `404` unknown |
+| `GET` | `/runs/:id/chapters` | `runs:read` | What the run's extension reported, read back out of the stored envelopes. `?set=updated\|all` (updated), `?q=`, `?mdMangaId=`, `?language=`, `?segmentIndex=`, `?limit=1..500` (100), `?offset=`. Ordered `segmentIndex, position` — the extension's own order. Offset paging is safe here because a committed envelope never changes |
+| `GET` | `/runs/:id/chapters/summary` | `runs:read` | Per-segment coverage and a per-series breakdown. A segment with no committed envelope reports `updated: null`, **not `0`**, and `complete` says whether the chapter list can be read as the whole run |
 | `POST` | `/jobs/:id/cancel` | `runs:write` | → `{ok, result: "cancelled"\|"flagged"}`. `PENDING` cancels immediately; a live lease is flagged and the worker aborts on its next renew. **`409`** if the job is in neither state |
 | `POST` | `/jobs/:id/retry` | `runs:write` | Replay a dead letter with a fresh attempt budget. **`409` job is not dead-lettered** |
 | `GET` | `/dead-letter` | `runs:read` | Up to 100 `DEAD_LETTER` jobs, newest first |
 | `GET` | `/quarantine` | `runs:read` | Up to 100 quarantined submissions — id, jobId, workerId, rejectReason, createdAt. **The envelope body is not returned** |
 
-`routes/admin.ts:100-187`. There is no run-level cancel; cancel the jobs.
+`routes/admin.ts:100-187`; the two chapter endpoints are `routes/chapters.ts`,
+backed by `store/runChapters.ts`. There is no run-level cancel; cancel the jobs.
+
+The chapters a run found are **not** copied into a table on ingest: they are
+unnested from `result_submissions.envelope` on demand
+(`jsonb_array_elements … WITH ORDINALITY`), so the envelope stays the single
+source of truth and paging happens in Postgres rather than in the API process.
 
 ### Pause gate
 
@@ -425,7 +433,43 @@ is logged even if the publish then fails for another reason).
 | `POST` | `/upload-tasks/:id/cancel` | `runs:write` | `PENDING`/`FAILED`/`DEAD_LETTER` → `DONE` with the reason in `lastError`. **`409` for a `LEASED` task** — an uploader owns it mid-flight and forcing it would race into a duplicate upload or a lost result |
 | `POST` | `/upload-tasks/requeue-stale` | `runs:write` | Manual lease sweep → `{ok, requeued}` |
 
-`routes/ops.ts:103-217`, tested at `test/integration/ops.test.ts`.
+| `GET` | `/queues/chapters` | `runs:read` | The queue read as chapters rather than as rows: series, number, volume, title, language, and an EDIT task's `editPayload`. `?kind=`, `?state=` (**defaults to `PENDING`**), `?q=` (searches the payload's series name, title and number — not the dedupe key), `?dedupeKey=`, `?limit=1..500` (100), `?cursor=`. `position` is the place in the claim order across **everything matching the filter**, not within the page |
+
+`routes/ops.ts:103-217`, tested at `test/integration/ops.test.ts`;
+`/queues/chapters` is `routes/chapters.ts`, tested at
+`test/integration/chapters.test.ts`.
+
+### Chapters on MangaDex
+
+| Method | Path | Scope | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/chapters` | `runs:read` | One of the four chapter archives. `?table=uploaded\|edited\|unavailable\|deleted` (uploaded), `?extension=`, `?q=`, `?mdMangaId=`, `?language=`, `?limit=1..500` (50), `?offset=`. Newest first by the instant that table records (`updated_at`, `last_edited_at`, `unavailable_at`, `deleted_at`) |
+| `GET` | `/chapters/extensions` | `runs:read` | Which extensions have rows in an archive, with counts — for a filter picker |
+| `GET` | `/chapters/:mdChapterId` | `runs:read` | One chapter across all four tables: the canonical row, `present` (which archives hold it), `edits` (append-only history), `queued` (upload tasks keyed on this id), `mdFields` (the MangaDex-shaped starting point for an edit) and `editable`. `404` when no table has it |
+| `POST` | `/chapters/:mdChapterId/edit` | `runs:write` **+ ADMIN role, session only** | Queue a metadata correction. Body: any of `{volume, chapter, title, translatedLanguage, groups, notBefore}` → `201 {ok, task, payload, oldInfo}` |
+
+`routes/chapters.ts`, backed by `store/chapters.ts`.
+
+**The edit endpoint does not talk to MangaDex.** It enqueues the same `EDIT`
+upload task `processor.ts` writes when it detects a metadata drift, so the write
+happens in the uploader — the only process holding the credentials — with the
+same lease, retry and audit treatment as everything else, and is visible and
+amendable on the Queues page until it is claimed.
+
+Five refusals, each protecting something that is awkward or impossible to undo:
+
+| Answer | When | Why |
+|---|---|---|
+| `403` | an `pa_…` api token, or a non-ADMIN session | `runs:write` is held by the Discord bot so it can trigger scrapes; rewriting a published chapter is a different authority, so this is session-only |
+| `400` | every field already holds the value asked for | A "change" to an unchanged value would be written into that chapter's permanent edit history |
+| `409` | an `EDIT` for this chapter is already queued | The unique `(kind, dedupe_key)` row is what stops one chapter being edited twice in flight. Amend the existing task instead — the response names it |
+| `409` | the chapter is in the `deleted` archive | It is not on MangaDex any more; the task would fail at the API after a lease, five attempts and a dead letter |
+| `422` | `groups` omits our own upload group | MangaDex **replaces** attribution wholesale; dropping the uploading group detaches the chapter from this platform's catalogue and nothing here could find it again |
+
+Unchanged fields are dropped from `payload`. The task carries the **new** values
+on its chapter as well as the diff, because the uploader mirrors that chapter
+into `uploaded_chapters` on success — a payload carrying the old values would
+land the edit and leave the mirror describing what the chapter used to say.
 
 ### MangaDex session
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -81,7 +81,7 @@ you are doing rather than by which endpoint serves them:
 |---|---|
 | — | Overview |
 | **Work** | Runs, Queues, Activity, Errors |
-| **Catalogue** | Extensions, Tracked, Untracked |
+| **Catalogue** | Extensions, Chapters, Tracked, Untracked |
 | **Fleet** | Workers |
 | **Admin** | Users, Tokens, Audit, System, Maintenance, Docs |
 
@@ -114,7 +114,10 @@ Routing is hash-based, `#/<destination>[/<thing>][/<tab>]`:
 ```
 #/overview/platform                      the default landing view
 #/runs/dead-letter                       a tab within a destination
-#/runs/<runId>                           one run and all its segments
+#/runs/<runId>                           one run, its segments, and what it found
+#/queues/chapters                        what is about to be uploaded, in order
+#/chapters                               every chapter we have put on MangaDex
+#/chapters/<mdChapterId>                 one chapter, its history, its edit form
 #/extensions/mangaplus/series-map        one extension, one of its tabs
 #/untracked/<id>                         one untracked series, editable
 #/audit/<id>                             one audit event
@@ -138,11 +141,12 @@ leak an id into an access log.
 | View | Needs | Answers |
 |---|---|---|
 | **Overview** | `stats:read` | *Platform*: paused or running, with pause-for-N-minutes / pause indefinitely / resume; jobs by state, workers by status, upload tasks, and the quarantine count. *MangaDex*: the upload side's saved session and its expiry, with "clear saved session". The first screen in an incident. |
-| **Runs** | `runs:read` | *Recent*: the last 50 runs, each linking to its own page — every segment with attempts, lease holder, lease expiry and last error, plus per-job cancel and retry. *Dead letter*: jobs that exhausted their attempt budget, with replay. |
-| **Queues** | `runs:read` | *Tasks*: the MangaDex upload queues filtered by kind and state, with retry, cancel, and "requeue stale leases" (which only touches leases that have already expired). *Depth*: the same queues counted by kind and state. |
+| **Runs** | `runs:read` | *Recent*: the last 50 runs with how many chapters each found, linking to its own page — every segment with attempts, lease holder, lease expiry and last error, plus per-job cancel and retry, and **the chapters that run actually reported**: coverage per segment, a breakdown per series, and the chapter list itself, searchable. *Dead letter*: jobs that exhausted their attempt budget, with replay. |
+| **Queues** | `runs:read` | *Chapters* (the default): what is about to be sent to MangaDex, **numbered in the order the uploader will claim it** — series, number, volume, title, language, and for an EDIT the fields it will change. Correct one or move it to the front from here. *Tasks*: the same rows keyed on queue mechanics — dedupe key, attempts, last error — with retry, remove, purge, reorder and hand-enqueue. *Depth*: the queues counted by kind and state. |
 | **Activity** | `runs:read` | One time-ordered feed merged across runs, jobs, upload tasks, quarantine and the audit log, filtered by severity, time window, extension and free text. Every row links to the thing it is about and offers a permalink. |
 | **Errors** | `runs:read` | *Failures*: everything that failed, newest first, across all three sources. *Quarantine*: result envelopes the core refused to believe — the security-relevant queue, not just an error queue. A non-zero quarantine count also shows as a red badge on Errors in the sidebar. |
 | **Extensions** | `extensions:read` | The published-bundle list, the chapter removal mode, and the publish drop zone. Opening one gives *Overview* (its bundle, its curation counts, and its runs, jobs, upload tasks and quarantine on one screen — the join is the point: green runs beside red upload tasks is the diagnosis), *Series map*, *Schedule*, *Config*, and *Versions* (every version ever published, with yank). |
+| **Chapters** | `runs:read` | Every chapter this platform has put on MangaDex, filtered by extension, language and free text, across four archives: on MangaDex, edited, marked unavailable, and deleted. Opening one gives its metadata, which archives hold it, its edit history, any queued work for it — and, for an operator, **the metadata correction form**. |
 | **Tracked** | `tracked:read` | The series map across every extension: how many mappings each has and the most recent one, linking into the map that can be edited. There is no cross-extension endpoint, so this is an index rather than a merged table. |
 | **Untracked** | `untracked:read` | Series an extension reported that have no mapping yet, filtered by state. Opening one gives its details **editable** — see below. Approve creates the MangaDex title; skip never does. |
 | **Workers** | `workers:read` | *Fleet*: status, trust tier, heartbeat, agent version, which extensions each worker takes, with drain / activate / revoke. *Enrolment*: mint a one-time token and copy the compose snippet that uses it. |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -782,7 +782,22 @@ curl -fsS "$API/api/v1/admin/queues/tasks?state=FAILED&state=DEAD_LETTER" -H "$A
 
 # one series' worth: dedupeKey is a case-insensitive substring
 curl -fsS "$API/api/v1/admin/queues/tasks?dedupeKey=1234%7C&attemptMin=3" -H "$AUTH"
+
+# the same queue read as CHAPTERS, numbered in claim order — which series,
+# which chapter, and what an EDIT is going to change
+curl -fsS "$API/api/v1/admin/queues/chapters?limit=50" -H "$AUTH"
+
+# ...searched by series name rather than by dedupe key
+curl -fsS "$API/api/v1/admin/queues/chapters?q=sakamoto" -H "$AUTH"
 ```
+
+`GET /queues/chapters` is the same rows and the same ordering as
+`/queues/tasks`, projected through the chapter payload. Reach for it when the
+question is *what is about to be published* — a dedupe key of `1015117|142|en`
+identifies a chapter only to someone willing to decode it — and for
+`/queues/tasks` when the question is *what is stuck and why*. It defaults to
+`PENDING`, and its `position` is the place in the whole filtered claim order, so
+"14th" survives paging.
 
 This list is ordered by `notBefore` — the same ordering `core-uploader` claims
 in — so it answers *what runs next*. `GET /api/v1/admin/upload-tasks` (the older
@@ -1018,6 +1033,62 @@ superseded and is not going away:
 | Abandon a chapter, keeping its dedupe slot | `POST /admin/upload-tasks/<id>/cancel` |
 | Reclaim expired leases now | `POST /admin/upload-tasks/requeue-stale` |
 | Everything else on this page | `/admin/queues/*` |
+| What is about to be published, as chapters | `GET /admin/queues/chapters` |
+| What a run actually found | `GET /admin/runs/<id>/chapters` |
+| What is on MangaDex now, and its history | `GET /admin/chapters` |
+
+---
+
+## Correct a published chapter's metadata
+
+A wrong chapter number, a volume the source only supplied later, a title that a
+regex mangled: these are on MangaDex already, so the queue endpoints above cannot
+help — the chapter is not queued, it is published.
+
+```bash
+# find it: search runs across series name, title, number and both ids
+curl -fsS "$API/api/v1/admin/chapters?q=sakamoto&extension=mangaplus" -H "$AUTH"
+
+# everything known about one chapter, including its edit history and whether a
+# correction is already queued for it
+curl -fsS "$API/api/v1/admin/chapters/<mdChapterId>" -H "$AUTH"
+
+# queue the correction (dashboard session, ADMIN or OWNER — not an api token)
+curl -fsS -X POST "$API/api/v1/admin/chapters/<mdChapterId>/edit" \
+  -H "content-type: application/json" -H "x-requested-with: publoader-dash" \
+  -b "$COOKIE" \
+  -d '{"chapter": "142.5", "volume": "17"}'
+```
+
+**Nothing is sent to MangaDex by that call.** It writes an `EDIT` row onto the
+upload queue — the same row the processor writes when it detects drift — which
+`core-uploader` picks up, applies with the platform's credentials, and records in
+`edited_chapters`. Until it is claimed the correction is an ordinary queue row:
+it shows up on `GET /queues/chapters?kind=EDIT`, can be amended with
+`PATCH /queues/tasks/<id>`, and can be removed.
+
+Pass `notBefore` to hold it for review, or pause the platform, which holds the
+whole queue.
+
+Five things it will refuse, and each is worth knowing before you hit it:
+
+- **an api token**, however scoped. This is session-only and ADMIN-or-above: the
+  Discord bot holds `runs:write` so it can trigger scrapes, and that is not the
+  same authority as rewriting a published chapter.
+- **a no-op**, where every field already holds the value you asked for. An
+  unchanged "change" would be written into that chapter's history forever.
+- **a second correction** while one is queued (`409`, naming the existing task).
+  The unique `(kind, dedupe_key)` row is what stops a chapter being edited twice
+  in flight — amend the queued task instead.
+- **a deleted chapter** (`409`). It is not on MangaDex any more, so the task
+  would fail at the API after a lease, five attempts and a dead letter.
+- **a `groups` list that omits our own upload group** (`422`). MangaDex replaces
+  attribution wholesale; dropping the uploading group detaches the chapter from
+  this platform's catalogue and nothing here could find it again.
+
+On the dashboard this is the Chapters destination: find the chapter, open it,
+"Edit metadata". The form starts from what our mirror holds and sends only the
+fields you actually changed.
 
 ---
 

--- a/src/core/api/context.ts
+++ b/src/core/api/context.ts
@@ -7,6 +7,8 @@ import { BundleStore } from "../store/bundles.js";
 import { ArtifactStore } from "../store/artifacts.js";
 import { SettingsStore, AuditLog } from "../store/settings.js";
 import { UploadTaskStore } from "../store/uploadTasks.js";
+import { RunChapterStore } from "../store/runChapters.js";
+import { ChapterStore } from "../store/chapters.js";
 import { IngestService } from "../ingest/ingest.js";
 import { SchedulerService } from "../scheduler/service.js";
 import type { TitleService } from "../md/titleService.js";
@@ -28,6 +30,10 @@ export interface AppContext {
   artifacts: ArtifactStore;
   settings: SettingsStore;
   uploadTasks: UploadTaskStore;
+  /** What each run reported, read back out of the stored result envelopes. */
+  runChapters: RunChapterStore;
+  /** The four chapter archives: uploaded, edited, unavailable, deleted. */
+  chapters: ChapterStore;
   audit: AuditLog;
   /** Scoped per-client `pa_…` credentials. */
   apiTokens: ApiTokenStore;
@@ -67,6 +73,8 @@ export function buildContext(prisma: PrismaClient, config: Config, log: Logger):
     artifacts: new ArtifactStore(prisma),
     settings: new SettingsStore(prisma),
     uploadTasks: new UploadTaskStore(prisma),
+    runChapters: new RunChapterStore(prisma),
+    chapters: new ChapterStore(prisma),
     audit: new AuditLog(prisma),
     apiTokens: new ApiTokenStore(prisma),
     trackedManga: new TrackedMangaStore(prisma),

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -67,6 +67,27 @@ const store = {
     queueAttemptMax: "",
     /** Keyset cursors already walked, so "Back" does not need a second scheme. */
     queueCursors: [],
+    /**
+     * The queue read as chapters. Separate keys from the row view above rather
+     * than shared ones: the two answer different questions ("what is stuck" vs
+     * "what is about to be published") and an operator switching tabs to check
+     * the other should not find their filter rewritten.
+     */
+    queueChapterKind: "",
+    queueChapterState: "PENDING",
+    queueChapterQuery: "",
+    queueChapterCursors: [],
+    /** What a run found, on the run detail page. */
+    runChapterSet: "updated",
+    runChapterQuery: "",
+    runChapterSegment: "",
+    runChapterPage: 0,
+    /** The chapter archives (uploaded / edited / unavailable / deleted). */
+    chapterTable: "uploaded",
+    chapterExtension: "",
+    chapterQuery: "",
+    chapterLanguage: "",
+    chapterPage: 0,
     untrackedState: "NEW",
     activitySeverity: "all",
     activityHours: 72,
@@ -373,6 +394,7 @@ const ICONS = {
   errors: "M12 4l9 16H3l9-16Zm0 5v6m0 3v.5",
   extensions: "M4 4h7v7H4V4Zm9 0h7v7h-7V4ZM4 13h7v7H4v-7Zm12.5 0v7m-3.5-3.5h7",
   tracked: "M6 4h12v16l-6-4-6 4V4Z",
+  chapters: "M4 5.5A2.5 2.5 0 0 1 6.5 3H19v15H6.5A2.5 2.5 0 0 0 4 20.5V5.5Zm4 3.5h7m-7 3.5h7",
   untracked: "M12 3l9 5v8l-9 5-9-5V8l9-5Zm0 6v4m0 3v.5",
   workers: "M4 17h16M6 17V9l6-4 6 4v8M10 17v-4h4v4",
   users: "M12 11a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm-7 9c0-3.3 3.1-6 7-6s7 2.7 7 6",
@@ -894,11 +916,16 @@ const NAV = [
     group: "Work",
     icon: "queues",
     scope: "runs:read",
+    // Chapters first, and that ordering is the default landing tab: the question
+    // asked of this page far more often than any other is "what is about to go
+    // up, and in what order". Tasks is the same rows keyed on queue mechanics —
+    // one click away, and where incident work still happens.
     tabs: [
+      ["chapters", "Chapters"],
       ["tasks", "Tasks"],
       ["depth", "Depth"],
     ],
-    blurb: "The MangaDex upload queues: every unit of work is a durable row.",
+    blurb: "What is about to be sent to MangaDex, and the durable rows behind it.",
   },
   {
     id: "activity",
@@ -940,6 +967,20 @@ const NAV = [
       ["versions", "Versions"],
     ],
     blurb: "Published bundles, and everything about one extension.",
+  },
+  // Reads `runs:read` rather than a scope of its own: these are the four
+  // chapter tables the run/queue pipeline writes, and anyone who may look at
+  // what the platform is doing may look at what it has done. Queueing a
+  // correction is guarded separately — `runs:write` AND the ADMIN role, the same
+  // bar as hand-enqueueing a task, because it ends in a write to MangaDex.
+  {
+    id: "chapters",
+    label: "Chapters",
+    group: "Catalogue",
+    icon: "chapters",
+    scope: "runs:read",
+    param: true,
+    blurb: "Every chapter this platform has put on MangaDex — and its metadata, correctable.",
   },
   {
     id: "tracked",
@@ -2002,11 +2043,23 @@ VIEWS.runs = (route) => {
       [runs],
       ({ runs: rows }) =>
         table(
-          ["Extension", "Kind", "State", "Segments", "Triggered by", "Created", "Error"],
+          ["Extension", "Kind", "State", "Chapters found", "Segments", "Triggered by", "Created", "Error"],
           rows.map((run) => [
             routeLink(routeTo("runs", run.id, null), run.extension),
             run.kind,
             chip(run.state),
+            // null means no segment has committed an envelope yet, which is not
+            // the same as a run that found nothing — so it reads "—", not "0".
+            run.chaptersFound == null
+              ? "—"
+              : el(
+                  "span",
+                  {},
+                  el("strong", { text: String(run.chaptersFound) }),
+                  run.chaptersSeen == null
+                    ? null
+                    : el("span", { class: "dim small", text: ` of ${run.chaptersSeen} seen` }),
+                ),
             String(run.segmentsTotal),
             run.triggeredBy,
             fmtTime(run.createdAt),
@@ -2014,7 +2067,7 @@ VIEWS.runs = (route) => {
           ]),
           { empty: "No run has been created yet. Trigger one from an extension." },
         ),
-      { reserve: 260, skeleton: () => skeletonTable(6, 7) },
+      { reserve: 260, skeleton: () => skeletonTable(6, 8) },
     ),
   );
 };
@@ -2121,8 +2174,272 @@ function runDetail(runId) {
             { empty: "This run produced no segments." },
           ),
         ),
+        runChaptersCard(runId),
       ),
     { reserve: 400, skeleton: () => el("div", {}, skeletonTable(8, 2), skeletonTable(4, 6)) },
+  );
+}
+
+// ------------------------------------------------- what a run actually found
+
+const RUN_CHAPTER_PAGE = 100;
+
+/**
+ * The chapters an extension reported on one run.
+ *
+ * This is the envelope the worker submitted, read back — not a copy of it. The
+ * run/job/segment model above says whether the scrape WORKED; this says what it
+ * FOUND, which is the question that used to require a `jsonb` path in psql.
+ *
+ * Two sets, because an envelope carries two different things and conflating
+ * them would misreport both. `updated` is what the extension flagged as new or
+ * changed, and is the set the processor turns into upload and edit tasks. `all`
+ * is the optional whole-catalogue snapshot that drives removal detection; many
+ * extensions do not send one, and the summary says so rather than showing an
+ * empty list that reads as "found nothing".
+ */
+/**
+ * Which run's filters are currently in the store. Opening a DIFFERENT run must
+ * not inherit the last one's search and page number (page 4 of a run with one
+ * page is an empty table), but a redraw of the SAME run — a job cancel refreshes
+ * the detail resource — must not wipe what the operator just typed.
+ */
+let runChapterFilterFor = null;
+
+function runChaptersCard(runId) {
+  if (runChapterFilterFor !== runId) {
+    runChapterFilterFor = runId;
+    // Assigned directly rather than through setFilter: this runs inside a
+    // render, and notifying subscribers mid-render would redraw the region
+    // currently being built.
+    Object.assign(store.filters, { runChapterQuery: "", runChapterSegment: "", runChapterPage: 0 });
+  }
+
+  const f = () => store.filters;
+  const set = () => f().runChapterSet;
+
+  const summary = new Resource(`run-chapters-summary:${runId}`, () =>
+    api(`/runs/${encodeURIComponent(runId)}/chapters/summary?set=${encodeURIComponent(set())}`),
+  );
+
+  const listQuery = () => {
+    const q = new URLSearchParams({
+      set: set(),
+      limit: String(RUN_CHAPTER_PAGE),
+      offset: String(f().runChapterPage * RUN_CHAPTER_PAGE),
+    });
+    if (f().runChapterQuery) q.set("q", f().runChapterQuery);
+    if (f().runChapterSegment !== "") q.set("segmentIndex", f().runChapterSegment);
+    return q;
+  };
+  const chapters = new Resource(`run-chapters:${runId}`, () =>
+    api(`/runs/${encodeURIComponent(runId)}/chapters?${listQuery()}`),
+  );
+
+  const reload = () => {
+    void summary.load({ force: true });
+    void chapters.load({ force: true });
+  };
+  /** Any change to what is being asked for invalidates the page number. */
+  const refilter = (patch) => {
+    setFilter({ ...patch, runChapterPage: 0 });
+    reload();
+  };
+
+  const setPicker = el(
+    "select",
+    {
+      id: "run-chapter-set",
+      onchange: (event) => refilter({ runChapterSet: event.target.value }),
+    },
+    el("option", { value: "updated", text: "New or changed", selected: set() === "updated" }),
+    el("option", { value: "all", text: "Full catalogue snapshot", selected: set() === "all" }),
+  );
+
+  const search = el("input", {
+    id: "run-chapter-q",
+    type: "search",
+    value: f().runChapterQuery,
+    placeholder: "series, title, number or source id",
+    onchange: (event) => refilter({ runChapterQuery: event.target.value.trim() }),
+  });
+
+  return card(
+    "Chapters found",
+    el("p", {
+      class: "dim small",
+      text:
+        "Read straight out of the result envelopes this run's workers submitted — the extension's own " +
+        "report, in the order it reported it, before the processor decided anything.",
+    }),
+    live([summary], (data) => runChapterSummary(data, refilter), {
+      reserve: 120,
+      skeleton: () => skeletonGrid(4),
+    }),
+    row(
+      el("span", { class: "row tight" }, el("label", { class: "inline", for: "run-chapter-set", text: "Set" }), setPicker),
+      el("span", { class: "row tight" }, el("label", { class: "inline", for: "run-chapter-q", text: "Search" }), search),
+      el("button", {
+        type: "button",
+        text: "Clear",
+        onclick: () => refilter({ runChapterQuery: "", runChapterSegment: "" }),
+      }),
+    ),
+    live(
+      [chapters],
+      (data) => {
+        const rows = data.chapters ?? [];
+        return el(
+          "div",
+          {},
+          table(
+            ["#", "Series", "Chapter", "Volume", "Title", "Lang", "Released", "Segment", ""],
+            rows.map((entry) => {
+              const c = entry.chapter ?? {};
+              return [
+                String(entry.position),
+                c.mdMangaId
+                  ? mdTitleLink(c.mdMangaId, c.mangaName || c.mangaId || c.mdMangaId)
+                  : (c.mangaName ?? c.mangaId ?? "—"),
+                c.chapterNumber ?? "—",
+                c.chapterVolume ?? "—",
+                truncate(c.chapterTitle, 80),
+                c.chapterLanguage ?? "—",
+                fmtTime(c.chapterTimestamp),
+                String(entry.segmentIndex + 1),
+                [
+                  c.chapterUrl
+                    ? el("a", {
+                        href: c.chapterUrl,
+                        target: "_blank",
+                        rel: "noreferrer noopener",
+                        class: "button-link inline",
+                        text: "Source",
+                      })
+                    : null,
+                  // Present only once the chapter exists on MangaDex — an
+                  // envelope reports what the source has, not what we uploaded.
+                  c.mdChapterId
+                    ? routeLink(routeTo("chapters", c.mdChapterId, null), "On MangaDex", {
+                        class: "button-link inline",
+                      })
+                    : null,
+                ],
+              ];
+            }),
+            {
+              empty:
+                set() === "all"
+                  ? "This run's extension sent no full-catalogue snapshot. Only some extensions do; removal detection is skipped without one."
+                  : "No chapter in this run matches. A completed run with nothing here found nothing new.",
+            },
+          ),
+          pager(data.total ?? 0, f().runChapterPage, RUN_CHAPTER_PAGE, (page) => {
+            setFilter({ runChapterPage: page });
+            void chapters.load({ force: true });
+          }),
+        );
+      },
+      { reserve: 300, skeleton: () => skeletonTable(6, 9) },
+    ),
+  );
+}
+
+/** Coverage and the per-series breakdown, above the chapter list. */
+function runChapterSummary(data, refilter) {
+  const totals = data.totals ?? {};
+  const segments = data.segments ?? [];
+  const byManga = data.byManga ?? [];
+
+  return el(
+    "div",
+    {},
+    el(
+      "div",
+      { class: "grid tight" },
+      el(
+        "div",
+        { class: "stat" },
+        el("div", { class: "n", text: String(totals.updated ?? 0) }),
+        el("div", { class: "k", text: "new or changed" }),
+      ),
+      el(
+        "div",
+        { class: "stat" },
+        el("div", { class: "n", text: totals.all == null ? "—" : String(totals.all) }),
+        el("div", { class: "k", text: "seen in catalogue" }),
+      ),
+      el(
+        "div",
+        { class: "stat" },
+        el("div", { class: "n", text: String(data.mangaTitles ?? 0) }),
+        el("div", { class: "k", text: data.mangaCapped ? "titles (capped)" : "titles" }),
+      ),
+      el(
+        "div",
+        { class: "stat" },
+        el("div", { class: "n", text: `${data.segmentsReported ?? 0}/${data.segmentsTotal ?? 0}` }),
+        el("div", { class: "k", text: "segments reported" }),
+      ),
+    ),
+    // The one line that decides whether the list below can be trusted as whole.
+    data.complete
+      ? null
+      : el("p", {
+          class: "warn-text small",
+          text:
+            `${(data.segmentsTotal ?? 0) - (data.segmentsReported ?? 0)} segment(s) have not committed a ` +
+            "result yet, so this is a partial picture of the run.",
+        }),
+    segments.length > 1
+      ? el(
+          "details",
+          {},
+          el("summary", { text: "By segment" }),
+          table(
+            ["Segment", "Key", "Job state", "New or changed", "Seen", "Submitted"],
+            segments.map((segment) => [
+              el("button", {
+                type: "button",
+                class: "linkish",
+                text: String(segment.segmentIndex + 1),
+                title: "Show only this segment's chapters",
+                onclick: () => refilter({ runChapterSegment: String(segment.segmentIndex) }),
+              }),
+              segment.segmentKey ?? "—",
+              chip(segment.jobState),
+              segment.updated == null ? "not reported" : String(segment.updated),
+              segment.all == null ? "—" : String(segment.all),
+              fmtTime(segment.submittedAt),
+            ]),
+            { empty: "This run has no segments." },
+          ),
+        )
+      : null,
+    byManga.length
+      ? el(
+          "details",
+          {},
+          el("summary", { text: `By series (${byManga.length})` }),
+          table(
+            ["Series", "Chapters", ""],
+            byManga.map((entry) => [
+              entry.mdMangaId
+                ? mdTitleLink(entry.mdMangaId, entry.mangaName || entry.mangaId || entry.mdMangaId)
+                : (entry.mangaName ?? entry.mangaId ?? "—"),
+              String(entry.count),
+              [
+                el("button", {
+                  type: "button",
+                  text: "Filter",
+                  onclick: () => refilter({ runChapterQuery: entry.mangaName ?? entry.mangaId ?? "" }),
+                }),
+              ],
+            ]),
+            { empty: "No series." },
+          ),
+        )
+      : null,
   );
 }
 
@@ -2204,6 +2521,7 @@ VIEWS.queues = (route) => {
   );
 
   if (route.tab === "depth") return queueDepthPanel();
+  if (route.tab === "chapters") return queueChaptersPanel();
 
   // Selection is by id and survives a refresh, but only for rows still present:
   // acting on an id that has drained away is how a bulk action reports failures
@@ -2279,6 +2597,214 @@ function queueDepthPanel() {
       },
       { reserve: 120, skeleton: () => skeletonGrid(6) },
     ),
+  );
+}
+
+/**
+ * The queue as chapters: what is about to be published, in the order it will
+ * be.
+ *
+ * The Tasks tab shows the same rows keyed on queue mechanics — dedupe key,
+ * attempt count, last error — which is the right view during an incident and
+ * the wrong one for the question asked far more often: what is going up next,
+ * and is any of it wrong? A dedupe key of `1015117|142|en` names a chapter only
+ * to someone willing to decode it.
+ *
+ * `position` comes from the server and is the place in the claim order across
+ * everything matching the filter, so "14" means fourteenth in the queue, not
+ * fourteenth on this page. Ordering is the uploader's own: `not_before ASC`,
+ * which is literally the ORDER BY of the claim query.
+ */
+function queueChaptersPanel() {
+  const f = () => store.filters;
+
+  const cursorNow = () => {
+    const walked = f().queueChapterCursors;
+    return walked.length ? walked[walked.length - 1] : null;
+  };
+
+  const queryString = () => {
+    const q = new URLSearchParams({ limit: "100" });
+    if (f().queueChapterKind) q.set("kind", f().queueChapterKind);
+    if (f().queueChapterState) q.set("state", f().queueChapterState);
+    if (f().queueChapterQuery) q.set("q", f().queueChapterQuery);
+    const cursor = cursorNow();
+    if (cursor) q.set("cursor", cursor);
+    return q;
+  };
+
+  const chapters = new Resource("queue-chapters", () => api(`/queues/chapters?${queryString()}`));
+  const reload = () => void chapters.load({ force: true });
+  const refilter = (patch) => {
+    setFilter({ ...patch, queueChapterCursors: [] });
+    reload();
+  };
+
+  const picker = (id, label, values, key, { all = "all" } = {}) =>
+    el(
+      "span",
+      { class: "row tight" },
+      el("label", { class: "inline", for: id, text: label }),
+      el(
+        "select",
+        { id, onchange: (event) => refilter({ [key]: event.target.value }) },
+        el("option", { value: "", text: all, selected: store.filters[key] === "" }),
+        values.map((value) => el("option", { value, text: value, selected: value === store.filters[key] })),
+      ),
+    );
+
+  const search = el("input", {
+    id: "queue-chapter-q",
+    type: "search",
+    value: f().queueChapterQuery,
+    placeholder: "series, title or chapter number",
+    onchange: (event) => refilter({ queueChapterQuery: event.target.value.trim() }),
+  });
+
+  return el(
+    "div",
+    {},
+    card(
+      "Filter",
+      row(
+        picker("queue-chapter-kind", "Kind", UPLOAD_TASK_KINDS, "queueChapterKind"),
+        picker("queue-chapter-state", "State", UPLOAD_TASK_STATES, "queueChapterState", { all: "any state" }),
+        el(
+          "span",
+          { class: "row tight" },
+          el("label", { class: "inline", for: "queue-chapter-q", text: "Search" }),
+          search,
+        ),
+        el("button", {
+          type: "button",
+          text: "Reset",
+          onclick: () =>
+            refilter({ queueChapterKind: "", queueChapterState: "PENDING", queueChapterQuery: "" }),
+        }),
+      ),
+      el("p", {
+        class: "dim small",
+        text:
+          "PENDING by default, because “what is going to be uploaded” is the question. Rows are in the " +
+          "order the uploader will claim them — earliest due first — which is the same order a reorder " +
+          "on the Tasks tab rewrites.",
+      }),
+    ),
+    card(
+      null,
+      live(
+        [chapters],
+        (data) => {
+          const rows = data.chapters ?? [];
+          return el(
+            "div",
+            {},
+            table(
+              ["#", "Kind", "Series", "Chapter", "Volume", "Title", "Lang", "Due", "State", ""],
+              rows.map((row_) => {
+                const editable = row_.state === "PENDING";
+                const leased = row_.state === "LEASED";
+                return [
+                  String(row_.position),
+                  row_.kind,
+                  row_.mdMangaId
+                    ? mdTitleLink(row_.mdMangaId, row_.mangaName || row_.mangaId || row_.mdMangaId)
+                    : (row_.mangaName ?? row_.mangaId ?? "—"),
+                  row_.chapterNumber ?? "—",
+                  row_.chapterVolume ?? "—",
+                  // An EDIT task's interest is what it CHANGES, so show that
+                  // rather than the title it happens to be carrying.
+                  row_.kind === "EDIT" && row_.editPayload
+                    ? el("span", {
+                        class: "small",
+                        text: Object.entries(row_.editPayload)
+                          .map(([key, value]) => `${key} → ${value === null ? "(cleared)" : String(value)}`)
+                          .join(", "),
+                      })
+                    : truncate(row_.chapterTitle, 60),
+                  row_.chapterLanguage ?? "—",
+                  fmtTime(row_.notBefore),
+                  chip(row_.state),
+                  [
+                    gatedButton("runs:write", {
+                      text: "Edit",
+                      disabled: !editable,
+                      title: leased
+                        ? "An uploader holds this task; it cannot be edited while it is leased"
+                        : editable
+                          ? "Correct the chapter before it is sent"
+                          : `${row_.state} tasks cannot be edited`,
+                      onclick: () => queueEditDialog(row_, chapters, reload),
+                    }),
+                    gatedButton("runs:write", {
+                      text: "Run next",
+                      disabled: !editable,
+                      title: "Move to the front of the claim order",
+                      onclick: (event) =>
+                        void act(
+                          "queue.reorder",
+                          () =>
+                            api("/queues/reorder", {
+                              method: "POST",
+                              body: { ids: [row_.id], mode: "front" },
+                            }),
+                          { button: event.currentTarget, refresh: [chapters] },
+                        ),
+                    }),
+                    // The chapter's own page, when it already exists on
+                    // MangaDex — every kind but UPLOAD acts on a live chapter.
+                    row_.mdChapterId
+                      ? routeLink(routeTo("chapters", row_.mdChapterId, null), "History", {
+                          class: "button-link inline",
+                        })
+                      : null,
+                  ],
+                ];
+              }),
+              {
+                empty:
+                  f().queueChapterState === "PENDING"
+                    ? "Nothing is queued for MangaDex. The uploader has drained everything it was given."
+                    : "No queued chapter matches this filter.",
+              },
+            ),
+            queueChapterPager(data, chapters),
+          );
+        },
+        { reserve: 320, skeleton: () => skeletonTable(8, 10) },
+      ),
+    ),
+  );
+}
+
+/** Keyset paging, same scheme as the Tasks tab and for the same reason. */
+function queueChapterPager(data, chapters) {
+  const walked = store.filters.queueChapterCursors;
+  const go = (cursors) => {
+    setFilter({ queueChapterCursors: cursors });
+    void chapters.load({ force: true });
+  };
+
+  return el(
+    "div",
+    { class: "row pager" },
+    el("span", {
+      class: "dim small",
+      text: `${data.chapters?.length ?? 0} shown of ${data.total ?? 0} matching · claim order: ${data.order ?? "unknown"}`,
+    }),
+    el("span", { class: "grow" }),
+    el("button", {
+      type: "button",
+      text: "← Back",
+      disabled: walked.length === 0,
+      onclick: () => go(walked.slice(0, -1)),
+    }),
+    el("button", {
+      type: "button",
+      text: "Next →",
+      disabled: !data.nextCursor,
+      onclick: () => go([...walked, data.nextCursor]),
+    }),
   );
 }
 
@@ -3078,6 +3604,447 @@ function toLocalInput(value) {
   return (
     `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
     `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+}
+
+// ------------------------------------------------------------------- chapters
+
+const CHAPTER_PAGE = 50;
+
+/**
+ * The four chapter archives, and what each one means. The labels are the whole
+ * documentation an operator gets in the picker, so they say what the table IS
+ * rather than repeating its name.
+ */
+const CHAPTER_TABLES = [
+  ["uploaded", "On MangaDex", "The live mirror: what exists under our group right now."],
+  ["edited", "Edited", "Chapters whose metadata has been corrected, with the history of each change."],
+  ["unavailable", "Marked unavailable", "Chapters the source withdrew, flagged rather than deleted."],
+  ["deleted", "Deleted", "Removed from MangaDex. Archived here because deletion is the one irreversible action."],
+];
+
+/**
+ * Every chapter this platform has put on MangaDex.
+ *
+ * The rest of the dashboard follows the pipeline — runs produce jobs produce
+ * queue rows — and drops the thread the moment a chapter is published. This view
+ * picks it up: what is out there, under which series, in what language, and what
+ * has happened to it since.
+ *
+ * The one write here is a metadata correction, and it does not touch MangaDex.
+ * It enqueues the same EDIT task the processor writes when it detects drift, so
+ * the write happens in the uploader — the only process with the credentials —
+ * and sits on the Queues page, amendable, until it is claimed.
+ */
+VIEWS.chapters = (route) => {
+  if (route.param) return chapterDetail(route.param);
+
+  const f = () => store.filters;
+
+  const queryString = () => {
+    const q = new URLSearchParams({
+      table: f().chapterTable,
+      limit: String(CHAPTER_PAGE),
+      offset: String(f().chapterPage * CHAPTER_PAGE),
+    });
+    if (f().chapterExtension) q.set("extension", f().chapterExtension);
+    if (f().chapterQuery) q.set("q", f().chapterQuery);
+    if (f().chapterLanguage) q.set("language", f().chapterLanguage);
+    return q;
+  };
+
+  const chapters = new Resource("chapters", () => api(`/chapters?${queryString()}`));
+  const extensions = new Resource("chapter-extensions", () =>
+    api(`/chapters/extensions?table=${encodeURIComponent(f().chapterTable)}`),
+  );
+
+  const refilter = (patch) => {
+    setFilter({ ...patch, chapterPage: 0 });
+    void chapters.load({ force: true });
+    if (patch.chapterTable !== undefined) void extensions.load({ force: true });
+  };
+
+  const tablePicker = el(
+    "select",
+    { id: "chapter-table", onchange: (event) => refilter({ chapterTable: event.target.value, chapterExtension: "" }) },
+    CHAPTER_TABLES.map(([value, label]) =>
+      el("option", { value, text: label, selected: value === f().chapterTable }),
+    ),
+  );
+
+  const search = el("input", {
+    id: "chapter-q",
+    type: "search",
+    value: f().chapterQuery,
+    placeholder: "series, title, number, source id or MangaDex id",
+    onchange: (event) => refilter({ chapterQuery: event.target.value.trim() }),
+  });
+
+  const language = el("input", {
+    id: "chapter-lang",
+    type: "text",
+    value: f().chapterLanguage,
+    placeholder: "en",
+    size: "5",
+    onchange: (event) => refilter({ chapterLanguage: event.target.value.trim().toLowerCase() }),
+  });
+
+  const blurbFor = (table) => CHAPTER_TABLES.find(([value]) => value === table)?.[2] ?? "";
+
+  return el(
+    "div",
+    {},
+    card(
+      "Filter",
+      row(
+        el("span", { class: "row tight" }, el("label", { class: "inline", for: "chapter-table", text: "Archive" }), tablePicker),
+        live(
+          [extensions],
+          (data) =>
+            el(
+              "span",
+              { class: "row tight" },
+              el("label", { class: "inline", for: "chapter-extension", text: "Extension" }),
+              el(
+                "select",
+                { id: "chapter-extension", onchange: (event) => refilter({ chapterExtension: event.target.value }) },
+                el("option", { value: "", text: "all", selected: f().chapterExtension === "" }),
+                (data.extensions ?? []).map((entry) =>
+                  el("option", {
+                    value: entry.extension,
+                    text: `${entry.extension} (${entry.count})`,
+                    selected: entry.extension === f().chapterExtension,
+                  }),
+                ),
+              ),
+            ),
+          { reserve: 32, skeleton: () => el("span", { class: "skeleton skeleton-line", text: "extension" }) },
+        ),
+        el("span", { class: "row tight" }, el("label", { class: "inline", for: "chapter-lang", text: "Language" }), language),
+        el("span", { class: "row tight" }, el("label", { class: "inline", for: "chapter-q", text: "Search" }), search),
+        el("button", {
+          type: "button",
+          text: "Clear",
+          onclick: () => refilter({ chapterExtension: "", chapterQuery: "", chapterLanguage: "" }),
+        }),
+      ),
+      liveState(["filters"], () => el("p", { class: "dim small", text: blurbFor(f().chapterTable) })),
+    ),
+    card(
+      null,
+      live(
+        [chapters],
+        (data) => {
+          const rows = data.chapters ?? [];
+          return el(
+            "div",
+            {},
+            table(
+              ["Series", "Chapter", "Volume", "Title", "Lang", "Extension", "Last change", ""],
+              rows.map((c) => [
+                c.mdMangaId
+                  ? mdTitleLink(c.mdMangaId, c.mangaName || c.mangaId || c.mdMangaId)
+                  : (c.mangaName ?? c.mangaId ?? "—"),
+                c.chapterNumber ?? "—",
+                c.chapterVolume ?? "—",
+                truncate(c.chapterTitle, 70),
+                c.chapterLanguage ?? "—",
+                c.extensionName ?? "—",
+                fmtTime(c.at),
+                [
+                  c.mdChapterId
+                    ? routeLink(routeTo("chapters", c.mdChapterId, null), "Open", { class: "button-link inline" })
+                    : null,
+                  c.mdChapterId
+                    ? el("a", {
+                        href: `https://mangadex.org/chapter/${encodeURIComponent(c.mdChapterId)}`,
+                        target: "_blank",
+                        rel: "noreferrer noopener",
+                        class: "button-link inline",
+                        text: "MangaDex",
+                      })
+                    : null,
+                ],
+              ]),
+              { empty: "No chapter in this archive matches." },
+            ),
+            pager(data.total ?? 0, f().chapterPage, CHAPTER_PAGE, (page) => {
+              setFilter({ chapterPage: page });
+              void chapters.load({ force: true });
+            }),
+          );
+        },
+        { reserve: 320, skeleton: () => skeletonTable(8, 8) },
+      ),
+    ),
+  );
+};
+
+/** One chapter: where it is, what it says, what has been done to it. */
+function chapterDetail(mdChapterId) {
+  const detail = new Resource(`chapter:${mdChapterId}`, () =>
+    api(`/chapters/${encodeURIComponent(mdChapterId)}`),
+  );
+
+  return live(
+    [detail],
+    (data) => {
+      const c = data.chapter ?? {};
+      const md = data.mdFields ?? {};
+      const queued = data.queued ?? [];
+      // A queued EDIT already owns the (EDIT, mdChapterId) slot; a second one is
+      // refused by the unique constraint, so the honest offer is to amend that
+      // task rather than to open a form that will 409.
+      const pendingEdit = queued.find((task) => task.kind === "EDIT" && task.state === "PENDING");
+
+      return el(
+        "div",
+        {},
+        card(
+          null,
+          row(
+            ...(data.present ?? []).map((table_) => chip(table_.toUpperCase())),
+            el("span", {
+              class: "dim",
+              text: `${c.extensionName ?? "unattributed"} · ${c.chapterLanguage ?? "no language"}`,
+            }),
+          ),
+          defs([
+            ["Series", c.mdMangaId ? mdTitleLink(c.mdMangaId, c.mangaName || c.mdMangaId) : (c.mangaName ?? "—")],
+            ["Chapter", c.chapterNumber ?? "—"],
+            ["Volume", c.chapterVolume ?? "—"],
+            ["Title", c.chapterTitle ?? "—"],
+            ["Language", c.chapterLanguage ?? "—"],
+            [
+              "MangaDex chapter",
+              el("a", {
+                href: `https://mangadex.org/chapter/${encodeURIComponent(mdChapterId)}`,
+                target: "_blank",
+                rel: "noreferrer noopener",
+                text: mdChapterId,
+              }),
+            ],
+            ["Group", c.mdGroupId ? el("code", { text: c.mdGroupId }) : "—"],
+            ["Source chapter", c.chapterUrl ? el("a", { href: c.chapterUrl, target: "_blank", rel: "noreferrer noopener", text: c.chapterId ?? c.chapterUrl }) : (c.chapterId ?? "—")],
+            ["Released", fmtTime(c.chapterTimestamp)],
+            ["Uploaded", fmtTime(data.uploadedAt)],
+            ["Mirror updated", fmtTime(data.updatedAt)],
+            data.lastEditedAt ? ["Last edited", fmtTime(data.lastEditedAt)] : null,
+            data.unavailableAt ? ["Marked unavailable", fmtTime(data.unavailableAt)] : null,
+            data.deletedAt ? ["Deleted", fmtTime(data.deletedAt)] : null,
+          ]),
+          row(
+            isOperator()
+              ? gatedButton("runs:write", {
+                  class: "primary",
+                  text: "Edit metadata",
+                  disabled: !data.editable || Boolean(pendingEdit),
+                  title: !data.editable
+                    ? "This chapter was deleted from MangaDex; an edit would fail at the API"
+                    : pendingEdit
+                      ? "A correction for this chapter is already queued — amend that task instead"
+                      : "Queue a metadata correction for the uploader to apply",
+                  onclick: () => chapterEditDialog(mdChapterId, c, md, detail),
+                })
+              : null,
+            pendingEdit
+              ? routeLink(routeTo("queues", null, "chapters"), "Open the queued correction", {
+                  class: "button-link inline",
+                })
+              : null,
+            copyLinkButton(routeTo("chapters", mdChapterId, null)),
+          ),
+          data.editable
+            ? null
+            : el("p", {
+                class: "warn-text small",
+                text:
+                  "This chapter is in the deleted archive: it is no longer on MangaDex, so there is nothing " +
+                  "to edit. Re-uploading is the only way back.",
+              }),
+        ),
+        queued.length
+          ? card(
+              "Queued for this chapter",
+              el("p", {
+                class: "dim small",
+                text:
+                  "Upload tasks keyed on this MangaDex id. Until the uploader claims one it can be amended " +
+                  "or removed on the Queues page.",
+              }),
+              table(
+                ["Kind", "State", "Attempts", "Due", "Last error"],
+                queued.map((task) => [
+                  task.kind,
+                  chip(task.state),
+                  `${task.attempt}/${task.maxAttempts}`,
+                  fmtTime(task.notBefore),
+                  truncate(task.lastError, 120),
+                ]),
+                { empty: "Nothing queued." },
+              ),
+            )
+          : null,
+        card(
+          "Edit history",
+          (data.edits ?? []).length
+            ? table(
+                ["When", "Changed", "From"],
+                [...(data.edits ?? [])].reverse().map((edit) => [
+                  fmtTime(edit?.editedAt),
+                  el("span", {
+                    class: "small",
+                    text: Object.entries(edit?.new ?? {})
+                      .map(([key, value]) => `${key} → ${value === null ? "(cleared)" : JSON.stringify(value)}`)
+                      .join(", "),
+                  }),
+                  el("span", {
+                    class: "dim small",
+                    text: Object.keys(edit?.new ?? {})
+                      .map((key) => `${key}: ${JSON.stringify(edit?.old?.[key] ?? null)}`)
+                      .join(", "),
+                  }),
+                ]),
+              )
+            : emptyState("This chapter's metadata has never been corrected."),
+        ),
+      );
+    },
+    { reserve: 420, skeleton: () => el("div", {}, skeletonTable(10, 2), skeletonTable(3, 5)) },
+  );
+}
+
+/**
+ * The chapter fields MangaDex will accept an edit for, named as MangaDex names
+ * them because that is what the request body becomes.
+ */
+const MD_EDIT_FIELDS = [
+  ["chapter", "Chapter number", "e.g. 12, 12.5, or blank for a oneshot"],
+  ["volume", "Volume", "blank if the series has none"],
+  ["title", "Title", "blank for an untitled chapter"],
+  ["translatedLanguage", "Language", "MangaDex code, e.g. en or pt-br"],
+];
+
+/**
+ * Correct a published chapter's metadata.
+ *
+ * Nothing here writes to MangaDex. The save queues an EDIT upload task, and the
+ * dialog says so — an operator who thinks they have just changed a live chapter
+ * and then does not see it change would reasonably click again, which is exactly
+ * what the unique (EDIT, mdChapterId) constraint is there to refuse.
+ *
+ * Only fields that actually differ are sent. The server drops unchanged ones
+ * anyway, but a form that submits all four writes "title → (unchanged)" into a
+ * chapter's permanent edit history.
+ */
+function chapterEditDialog(mdChapterId, chapter, current, detail) {
+  const fields = new Map();
+  for (const [key, label, hint] of MD_EDIT_FIELDS) {
+    fields.set(
+      key,
+      el("input", {
+        id: `md-edit-${key}`,
+        type: "text",
+        value: current[key] ?? "",
+        placeholder: hint,
+        "aria-label": label,
+      }),
+    );
+  }
+
+  const groups = el("input", {
+    id: "md-edit-groups",
+    type: "text",
+    value: (current.groups ?? []).join(", "),
+    placeholder: "comma-separated MangaDex group ids",
+  });
+
+  const status = el("p", { class: "field-error" });
+
+  openModal(
+    "Correct this chapter's metadata",
+    el(
+      "div",
+      {},
+      el("p", {
+        class: "dim small",
+        text:
+          `${chapter.mangaName ?? "This series"} · chapter ${chapter.chapterNumber ?? "?"} · ` +
+          `${chapter.chapterLanguage ?? "no language"}`,
+      }),
+      el("p", {
+        class: "dim small",
+        text:
+          "Saving does not change MangaDex directly. It queues an EDIT task for the uploader — the one " +
+          "process holding the credentials — which you can inspect, amend or remove on the Queues page " +
+          "until it is claimed. Only fields you actually change are sent.",
+      }),
+      ...MD_EDIT_FIELDS.flatMap(([key, label]) => [
+        el("label", { for: `md-edit-${key}`, text: label }),
+        fields.get(key),
+      ]),
+      el(
+        "details",
+        {},
+        el("summary", { text: "Group attribution" }),
+        el("p", {
+          class: "warn-text small",
+          text:
+            "MangaDex REPLACES a chapter's groups with this list. Removing the group that uploaded the " +
+            "chapter detaches it from this platform's catalogue and nothing here can find it again — the " +
+            "server refuses that specific change.",
+        }),
+        el("label", { for: "md-edit-groups", text: "Groups" }),
+        groups,
+      ),
+      status,
+      el(
+        "div",
+        { class: "row end" },
+        el("button", { type: "button", text: "Cancel", onclick: closeModal }),
+        gatedButton("runs:write", {
+          class: "primary",
+          text: "Queue the correction",
+          onclick: async (event) => {
+            const body = {};
+            for (const [key, input] of fields) {
+              const value = input.value.trim();
+              const before = current[key] ?? "";
+              if (value === String(before)) continue;
+              // An emptied field means "clear it", except for the language,
+              // which MangaDex requires — blanking it would be rejected there,
+              // so it is refused here where the message can say why.
+              if (value === "" && key === "translatedLanguage") {
+                status.textContent = "A chapter must have a language; MangaDex will not accept an empty one.";
+                return;
+              }
+              body[key] = value === "" ? null : value;
+            }
+
+            const wanted = groups.value
+              .split(",")
+              .map((id) => id.trim())
+              .filter(Boolean);
+            if (JSON.stringify(wanted) !== JSON.stringify(current.groups ?? [])) body.groups = wanted;
+
+            if (Object.keys(body).length === 0) {
+              status.textContent = "Nothing changed.";
+              return;
+            }
+
+            const result = await act(
+              "chapter.edit",
+              () => api(`/chapters/${encodeURIComponent(mdChapterId)}/edit`, { method: "POST", body }),
+              { button: event.currentTarget, refresh: [detail, summary] },
+            );
+            if (result) {
+              toast("correction queued for the uploader");
+              closeModal();
+            }
+          },
+        }),
+      ),
+    ),
   );
 }
 

--- a/src/core/api/dashboard/index.html
+++ b/src/core/api/dashboard/index.html
@@ -20,9 +20,9 @@
         <h2>JavaScript required</h2>
         <p>
           The control plane renders its views in the browser. The navigation offers Overview;
-          Runs, Queues, Activity and Errors under Work; Extensions, Tracked and Untracked under
-          Catalogue; Workers under Fleet; and Users, Tokens, Audit, System, Maintenance and Docs
-          under Admin.
+          Runs, Queues, Activity and Errors under Work; Extensions, Chapters, Tracked and
+          Untracked under Catalogue; Workers under Fleet; and Users, Tokens, Audit, System,
+          Maintenance and Docs under Admin.
           Enable scripting for this origin, or use the <code>publoader-admin</code> CLI instead.
         </p>
       </div>

--- a/src/core/api/dashboard/style.css
+++ b/src/core/api/dashboard/style.css
@@ -93,6 +93,45 @@ a {
   margin: 8px 0 0;
 }
 
+/*
+ * A caveat that has to be read but is not a failure — "3 of 4 segments have
+ * reported, so this list is partial". `.error` would be wrong (nothing broke)
+ * and `.dim` would be worse: this is the line that decides whether the numbers
+ * above it can be trusted, and dimming it hides exactly that.
+ */
+.warn-text {
+  color: var(--warn);
+  margin: 8px 0 0;
+}
+
+/*
+ * Collapsible detail inside a card (per-segment and per-series breakdowns).
+ * Closed by default so the panel it sits in stays scannable; the marker and
+ * padding exist because the browser default reads as an unstyled escapee among
+ * the cards.
+ */
+.card details {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  margin: 10px 0 0;
+  padding: 0 10px;
+}
+
+.card details[open] {
+  padding-bottom: 10px;
+}
+
+.card details > summary {
+  cursor: pointer;
+  padding: 8px 0;
+  color: var(--dim);
+  font-size: 13px;
+}
+
+.card details > summary:hover {
+  color: var(--text);
+}
+
 .ok-text {
   color: var(--ok);
   margin: 8px 0 0;

--- a/src/core/api/routes/admin.ts
+++ b/src/core/api/routes/admin.ts
@@ -274,7 +274,22 @@ export function registerAdminRoutes(app: FastifyInstance, ctx: AppContext): void
         orderBy: { createdAt: "desc" },
         take: query.limit,
       });
-      return { runs };
+      // How much each run actually found, aggregated in ONE statement over the
+      // page being returned. A run's state says whether it worked; this says
+      // whether it was worth running, which is the thing an operator scanning
+      // this list is usually after. `chaptersFound` is null for a run with no
+      // committed envelope yet — distinct from a run that found nothing.
+      const totals = await ctx.runChapters.totalsForRuns(runs.map((run) => run.id));
+      return {
+        runs: runs.map((run) => {
+          const found = totals.get(run.id);
+          return {
+            ...run,
+            chaptersFound: found ? found.updated : null,
+            chaptersSeen: found ? found.all : null,
+          };
+        }),
+      };
     });
 
     scope.get("/api/v1/admin/runs/:id", { preHandler: requireScope("runs:read") }, async (req, reply) => {

--- a/src/core/api/routes/chapters.ts
+++ b/src/core/api/routes/chapters.ts
@@ -1,0 +1,588 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { adminAuthHook, requireScope } from "../auth.js";
+import { sessionAuthenticator } from "../session.js";
+import { chapterFromJson, chapterToTaskPayload } from "../../md/chapterRows.js";
+import { CHAPTER_SETS, type ChapterSet } from "../../store/runChapters.js";
+import { CHAPTER_TABLES, type ChapterTable } from "../../store/chapters.js";
+import { decodeTaskCursor, taskDedupeKey, UPLOAD_TASK_KINDS, UPLOAD_TASK_STATES } from "../../store/uploadTasks.js";
+import { manualTaskProblems } from "./queues.js";
+import { MangadexLanguageCode } from "../../../contracts/languages.js";
+
+/**
+ * Chapters, as chapters — the three places one can be looked at.
+ *
+ *   1. `GET /runs/:id/chapters`   what an extension FOUND on a given run,
+ *                                 read back out of the stored result envelope.
+ *   2. `GET /queues/chapters`     what is ABOUT TO BE sent to MangaDex, in the
+ *                                 order the uploader will claim it.
+ *   3. `GET /chapters`            what IS on MangaDex already, and the archives
+ *                                 of what has been edited, marked unavailable
+ *                                 or deleted.
+ *
+ * The rest of the API models this pipeline as runs, jobs, envelopes and queue
+ * rows, which is the right model for operating it and the wrong one for reading
+ * it: "did mangaplus pick up chapter 142?" was three joins and a `jsonb` path.
+ * These endpoints are the same data keyed on the thing the operator actually
+ * cares about.
+ *
+ * Only one endpoint here writes anything — `POST /chapters/:id/edit`, which
+ * corrects the metadata of a chapter already on MangaDex. It does not talk to
+ * MangaDex: it enqueues the same EDIT upload task the processor would have
+ * written, so the correction goes through the one process holding the
+ * credentials, inherits its retry and audit behaviour, and can be inspected or
+ * pulled from the queue before it lands.
+ */
+
+/** Cap on a page of chapters. These rows are small; the cap is about the query. */
+const MAX_PAGE = 500;
+/** Titles shown in a run's per-series breakdown. */
+const MANGA_BREAKDOWN_LIMIT = 200;
+
+/** Validate, answering 400 rather than the error handler's "internal error". */
+function parseOrThrow<S extends z.ZodTypeAny>(schema: S, value: unknown): z.infer<S> {
+  const result = schema.safeParse(value);
+  if (result.success) return result.data;
+  const issue = result.error.issues[0];
+  const where = issue && issue.path.length > 0 ? issue.path.join(".") : "request";
+  throw Object.assign(new Error(`invalid ${where}: ${issue?.message ?? "validation failed"}`), {
+    statusCode: 400,
+  });
+}
+
+function oneOrMany<T extends readonly [string, ...string[]]>(values: T) {
+  return z
+    .union([z.enum(values), z.array(z.enum(values)).min(1)])
+    .transform((value) => (Array.isArray(value) ? [...new Set(value)] : [value]));
+}
+
+/**
+ * The MangaDex chapter fields an operator may correct, named exactly as the
+ * MangaDex chapter-edit body names them — because that is what this becomes.
+ *
+ * `groups` is here for completeness and is the one field with a footgun: it
+ * REPLACES the attribution rather than adding to it, and dropping our own group
+ * from a chapter we uploaded orphans it. The handler refuses that specific
+ * mistake below.
+ *
+ * Deliberately absent: `externalUrl`, `publishAt`, `version`. The first two are
+ * not what this platform manages, and `version` is optimistic-concurrency state
+ * that the uploader reads from MangaDex at the moment of the write — accepting
+ * one here would let an operator pin a stale version and lose someone else's
+ * edit.
+ */
+const EditBody = z
+  .object({
+    volume: z.string().max(64).nullable().optional(),
+    chapter: z.string().max(64).nullable().optional(),
+    title: z.string().max(1024).nullable().optional(),
+    // Case-insensitive on the way in and canonical out, so an operator typing
+    // "PT-BR" gets `pt-br` rather than a rejection.
+    translatedLanguage: MangadexLanguageCode.optional(),
+    groups: z.array(z.string().uuid()).max(10).optional(),
+    /** Held back so a correction can be reviewed on the Queues page first. */
+    notBefore: z.coerce.date().optional(),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.volume !== undefined ||
+      value.chapter !== undefined ||
+      value.title !== undefined ||
+      value.translatedLanguage !== undefined ||
+      value.groups !== undefined,
+    { message: "nothing to change: pass at least one of volume, chapter, title, translatedLanguage or groups" },
+  );
+
+/**
+ * Queueing a MangaDex write needs a human operator, not merely `runs:write`.
+ *
+ * Two checks, and the FIRST is the load-bearing one. `adminAuthHook` gives every
+ * scoped `pa_…` token `adminRole = "ADMIN"` (see auth.ts: scoped tokens are
+ * "never owner-equivalent", which sets ADMIN as the ceiling, not as a bar they
+ * have to clear). So a role test alone admits the Discord bot, which holds
+ * `runs:write` to trigger runs — and "trigger a scrape" is not the same
+ * authority as "rewrite a published chapter's metadata". Refusing api-tokens
+ * outright is what actually confines this, and it costs nothing: no shipped
+ * client calls it. Same construction as `requireApplyRole` in routes/ops.ts.
+ *
+ * A CONTRIBUTOR is then excluded twice over — by the role, and by `runs:write`
+ * which `scopesForRole` never grants them.
+ */
+async function requireAdminRole(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (req.principal?.kind === "api-token") {
+    await reply.code(403).send({
+      error:
+        "queueing a MangaDex write is an operator action: sign in to the dashboard rather than using a " +
+        "machine token. A token scoped for runs may trigger a scrape, which is a different authority.",
+      requiredRole: "ADMIN",
+    });
+    return;
+  }
+  if (req.adminRole !== "OWNER" && req.adminRole !== "ADMIN") {
+    await reply.code(403).send({
+      error: `admin role or above required; this credential is ${req.adminRole ?? "unauthenticated"}`,
+      requiredRole: "ADMIN",
+    });
+  }
+}
+
+/** The MangaDex-shaped view of a stored chapter — what an edit starts from. */
+function mdFieldsOf(chapter: {
+  chapterVolume: string | null;
+  chapterNumber: string | null;
+  chapterTitle: string | null;
+  chapterLanguage: string | null;
+  mdGroupId: string | null;
+}): Record<string, unknown> {
+  return {
+    volume: chapter.chapterVolume,
+    chapter: chapter.chapterNumber,
+    title: chapter.chapterTitle,
+    translatedLanguage: chapter.chapterLanguage,
+    groups: chapter.mdGroupId ? [chapter.mdGroupId] : [],
+  };
+}
+
+export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): void {
+  app.register(async (scope) => {
+    scope.addHook(
+      "preHandler",
+      adminAuthHook({
+        adminToken: ctx.config.adminToken,
+        session: sessionAuthenticator(ctx),
+        apiTokens: ctx.apiTokens,
+      }),
+    );
+    scope.addHook("preHandler", async (req, reply) => {
+      if (!ctx.adminLimiter.allow(req.ip)) {
+        await reply.code(429).send({ error: "rate limited" });
+      }
+    });
+
+    /** Same attribution rules as every other admin module. */
+    const actor = (req: FastifyRequest): string => {
+      const claimed = (req.headers["x-actor"] as string | undefined)?.slice(0, 64);
+      const principal = req.principal;
+      if (principal?.kind === "api-token") {
+        return claimed ? `${principal.name} for ${claimed}` : principal.name;
+      }
+      if (principal?.kind === "session") return principal.name;
+      return `admin:${claimed ?? "root"}`;
+    };
+
+    // ------------------------------------------------ 1. found, per run
+
+    const runIdParam = z.object({ id: z.string().uuid() });
+    const SetQuery = z.enum(CHAPTER_SETS).default("updated");
+
+    /**
+     * How much each segment of a run reported, and which titles it was for.
+     *
+     * Segments with no committed envelope come back with null counts rather than
+     * being absent: "3 of 4 segments reported" is what stops a chapter list being
+     * read as the whole picture when it is three quarters of one.
+     */
+    scope.get(
+      "/api/v1/admin/runs/:id/chapters/summary",
+      { preHandler: requireScope("runs:read") },
+      async (req, reply) => {
+        const { id } = parseOrThrow(runIdParam, req.params);
+        const query = parseOrThrow(z.object({ set: SetQuery }), req.query ?? {});
+        const run = await ctx.prisma.run.findUnique({
+          where: { id },
+          select: { id: true, extension: true, kind: true, state: true, createdAt: true },
+        });
+        if (!run) return reply.code(404).send({ error: "unknown run" });
+
+        const [segments, byManga] = await Promise.all([
+          ctx.runChapters.segmentCounts(id),
+          ctx.runChapters.byManga(id, query.set as ChapterSet, MANGA_BREAKDOWN_LIMIT),
+        ]);
+
+        const reported = segments.filter((segment) => segment.updated !== null);
+        return {
+          run,
+          set: query.set,
+          segments,
+          // Named rather than left to the client to sum: the difference between
+          // "found nothing" and "has not reported yet" is the whole point of
+          // this endpoint.
+          segmentsTotal: segments.length,
+          segmentsReported: reported.length,
+          complete: reported.length === segments.length && segments.length > 0,
+          totals: {
+            updated: reported.reduce((sum, segment) => sum + (segment.updated ?? 0), 0),
+            all: segments.some((segment) => segment.all !== null)
+              ? segments.reduce((sum, segment) => sum + (segment.all ?? 0), 0)
+              : null,
+            untrackedManga: reported.reduce((sum, segment) => sum + (segment.untrackedManga ?? 0), 0),
+          },
+          byManga,
+          mangaTitles: byManga.length,
+          mangaCapped: byManga.length === MANGA_BREAKDOWN_LIMIT,
+        };
+      },
+    );
+
+    /**
+     * The chapters one run found, in the order the extension reported them.
+     *
+     * `set=updated` (the default) is what the extension flagged as new or
+     * changed — the set the processor turns into upload and edit tasks.
+     * `set=all` is the optional full-catalogue snapshot, which only some
+     * extensions send and which drives removal detection; it is empty rather
+     * than absent when an extension does not send one, and the summary endpoint
+     * says which case a run is in.
+     */
+    scope.get(
+      "/api/v1/admin/runs/:id/chapters",
+      { preHandler: requireScope("runs:read") },
+      async (req, reply) => {
+        const { id } = parseOrThrow(runIdParam, req.params);
+        const query = parseOrThrow(
+          z.object({
+            set: SetQuery,
+            q: z.string().min(1).max(256).optional(),
+            mdMangaId: z.string().uuid().optional(),
+            language: z.string().min(2).max(16).optional(),
+            segmentIndex: z.coerce.number().int().min(0).max(10_000).optional(),
+            limit: z.coerce.number().int().min(1).max(MAX_PAGE).default(100),
+            offset: z.coerce.number().int().min(0).max(1_000_000).default(0),
+          }),
+          req.query ?? {},
+        );
+
+        const run = await ctx.prisma.run.findUnique({
+          where: { id },
+          select: { id: true, extension: true, state: true },
+        });
+        if (!run) return reply.code(404).send({ error: "unknown run" });
+
+        const page = await ctx.runChapters.list(
+          id,
+          query.set as ChapterSet,
+          {
+            q: query.q,
+            mdMangaId: query.mdMangaId,
+            language: query.language,
+            segmentIndex: query.segmentIndex,
+          },
+          { limit: query.limit, offset: query.offset },
+        );
+
+        return {
+          run,
+          set: query.set,
+          chapters: page.chapters,
+          total: page.total,
+          limit: query.limit,
+          offset: query.offset,
+          // Offset paging is safe here and the reason is worth stating on the
+          // wire: a committed envelope never changes, so page 2 is stable.
+          order: "segmentIndex,position",
+        };
+      },
+    );
+
+    // ------------------------------------------- 2. queued, in claim order
+
+    /**
+     * The upload queue read as chapters rather than as rows: which series, which
+     * chapter, in the order the uploader will claim them.
+     *
+     * `position` is the place in the claim order across everything matching the
+     * filter, not within the page — so an operator can say "this is 14th" and
+     * mean it. Ordering is `not_before ASC` because that is literally the claim
+     * query's ORDER BY; see the comment on `UploadTaskStore.listChapters`.
+     *
+     * Defaults to PENDING because "what is going to be uploaded" is the
+     * question; pass `state` explicitly to see what has already run or failed.
+     */
+    scope.get(
+      "/api/v1/admin/queues/chapters",
+      { preHandler: requireScope("runs:read") },
+      async (req) => {
+        const query = parseOrThrow(
+          z.object({
+            kind: oneOrMany(UPLOAD_TASK_KINDS).optional(),
+            state: oneOrMany(UPLOAD_TASK_STATES).optional(),
+            q: z.string().min(1).max(256).optional(),
+            dedupeKey: z.string().min(1).max(256).optional(),
+            limit: z.coerce.number().int().min(1).max(MAX_PAGE).default(100),
+            cursor: z.string().max(512).optional(),
+          }),
+          req.query ?? {},
+        );
+
+        const cursor = query.cursor ? decodeTaskCursor(query.cursor) : null;
+        if (query.cursor && !cursor) {
+          throw Object.assign(new Error("invalid cursor: not a cursor this endpoint issued"), {
+            statusCode: 400,
+          });
+        }
+
+        const filter = {
+          kinds: query.kind,
+          states: query.state ?? (["PENDING"] as const),
+          q: query.q,
+          dedupeKey: query.dedupeKey,
+        };
+        const [page, summary] = await Promise.all([
+          ctx.uploadTasks.listChapters(filter, { limit: query.limit, cursor }),
+          ctx.uploadTasks.depths(),
+        ]);
+
+        return {
+          chapters: page.chapters,
+          total: page.total,
+          limit: query.limit,
+          nextCursor: page.nextCursor,
+          order: "notBefore,createdAt,id",
+          states: filter.states,
+          summary,
+        };
+      },
+    );
+
+    // --------------------------------------- 3. already on MangaDex
+
+    const TableQuery = z.enum(CHAPTER_TABLES).default("uploaded");
+
+    /**
+     * The chapter archives. `table=uploaded` is the live mirror of what exists
+     * on MangaDex under our group; the other three are history.
+     */
+    scope.get("/api/v1/admin/chapters", { preHandler: requireScope("runs:read") }, async (req) => {
+      const query = parseOrThrow(
+        z.object({
+          table: TableQuery,
+          extension: z.string().max(128).optional(),
+          q: z.string().min(1).max(256).optional(),
+          mdMangaId: z.string().uuid().optional(),
+          language: z.string().min(2).max(16).optional(),
+          limit: z.coerce.number().int().min(1).max(MAX_PAGE).default(50),
+          offset: z.coerce.number().int().min(0).max(1_000_000).default(0),
+        }),
+        req.query ?? {},
+      );
+
+      const table = query.table as ChapterTable;
+      const page = await ctx.chapters.list(
+        table,
+        {
+          extension: query.extension,
+          q: query.q,
+          mdMangaId: query.mdMangaId,
+          language: query.language,
+        },
+        { limit: query.limit, offset: query.offset },
+      );
+
+      return {
+        table,
+        chapters: page.chapters,
+        total: page.total,
+        limit: query.limit,
+        offset: query.offset,
+        tables: CHAPTER_TABLES,
+      };
+    });
+
+    /** Which extensions have rows in a given archive, with counts. */
+    scope.get(
+      "/api/v1/admin/chapters/extensions",
+      { preHandler: requireScope("runs:read") },
+      async (req) => {
+        const query = parseOrThrow(z.object({ table: TableQuery }), req.query ?? {});
+        return { table: query.table, extensions: await ctx.chapters.extensions(query.table as ChapterTable) };
+      },
+    );
+
+    const mdChapterParam = z.object({ mdChapterId: z.string().uuid() });
+
+    /**
+     * One chapter, everything known about it: the canonical row, which archives
+     * hold it, its edit history, and whether a correction is already queued.
+     *
+     * The queued-task lookup is what stops the dashboard offering an edit form
+     * that will 409 — a pending EDIT already owns the (EDIT, mdChapterId) slot,
+     * and the right move then is to amend that task rather than queue a second.
+     */
+    scope.get(
+      "/api/v1/admin/chapters/:mdChapterId",
+      { preHandler: requireScope("runs:read") },
+      async (req, reply) => {
+        const { mdChapterId } = parseOrThrow(mdChapterParam, req.params);
+        const detail = await ctx.chapters.detail(mdChapterId);
+        if (!detail) return reply.code(404).send({ error: "no chapter with that MangaDex id is on record" });
+
+        const queued = await ctx.prisma.uploadTask.findMany({
+          where: { dedupeKey: mdChapterId },
+          select: {
+            id: true,
+            kind: true,
+            state: true,
+            attempt: true,
+            maxAttempts: true,
+            notBefore: true,
+            lastError: true,
+          },
+          orderBy: { notBefore: "asc" },
+        });
+
+        return {
+          ...detail,
+          queued,
+          /** The MangaDex-shaped fields an edit would start from. */
+          mdFields: mdFieldsOf(detail.chapter),
+          editable: !detail.present.includes("deleted"),
+        };
+      },
+    );
+
+    /**
+     * Correct the metadata of a chapter that is already on MangaDex.
+     *
+     * This does NOT write to MangaDex. It enqueues an EDIT upload task — byte
+     * for byte the row `processor.ts` writes when it detects a metadata drift —
+     * so the write happens in the uploader, which is the only process with the
+     * credentials, and is subject to the same lease, retry, dead-letter and
+     * upload-log treatment as everything else. Until the uploader claims it, the
+     * task is visible on the Queues page and can be amended or removed.
+     *
+     * Three things are enforced here rather than discovered later:
+     *
+     *  - A deleted chapter cannot be edited. The row is gone from MangaDex, so
+     *    the task would fail at `chapter … not found on MangaDex` after a lease,
+     *    five attempts and a dead-letter.
+     *  - The unique (EDIT, mdChapterId) constraint is reported as a 409 naming
+     *    the existing task, never worked around. That constraint is why a
+     *    correction cannot be queued twice.
+     *  - `groups` may not drop our own upload group. MangaDex's edit REPLACES
+     *    the attribution; removing the group that uploaded the chapter detaches
+     *    it from this platform's catalogue, after which nothing here can find or
+     *    fix it again.
+     *
+     * The task's chapter payload carries the NEW values as well as the diff.
+     * That is not redundancy: on success the uploader mirrors the task's chapter
+     * into `uploaded_chapters`, so a payload carrying the old values would land
+     * the edit on MangaDex and leave our mirror describing what it used to say.
+     */
+    scope.post(
+      "/api/v1/admin/chapters/:mdChapterId/edit",
+      { preHandler: [requireAdminRole, requireScope("runs:write")] },
+      async (req, reply) => {
+        const { mdChapterId } = parseOrThrow(mdChapterParam, req.params);
+        const body = parseOrThrow(EditBody, req.body ?? {});
+
+        const detail = await ctx.chapters.detail(mdChapterId);
+        if (!detail) return reply.code(404).send({ error: "no chapter with that MangaDex id is on record" });
+        if (detail.present.includes("deleted")) {
+          return reply.code(409).send({
+            error:
+              "this chapter was deleted from MangaDex; an edit would fail at the API. Re-upload it instead.",
+            deletedAt: detail.deletedAt,
+          });
+        }
+
+        const current = mdFieldsOf(detail.chapter);
+        const payload: Record<string, unknown> = {};
+        for (const field of ["volume", "chapter", "title", "translatedLanguage", "groups"] as const) {
+          const value = body[field];
+          if (value === undefined) continue;
+          // An unchanged field is dropped rather than sent: the payload is the
+          // record of what this edit meant to do, and a "change" to the value it
+          // already had is noise in the chapter's edit history forever.
+          if (JSON.stringify(value) === JSON.stringify(current[field])) continue;
+          payload[field] = value;
+        }
+        if (Object.keys(payload).length === 0) {
+          return reply.code(400).send({
+            error: "every field already holds the value you asked for; nothing was queued",
+            current,
+          });
+        }
+
+        if (Array.isArray(payload["groups"])) {
+          const groups = payload["groups"] as string[];
+          const ours = detail.chapter.mdGroupId;
+          if (ours && !groups.includes(ours)) {
+            return reply.code(422).send({
+              error:
+                `MangaDex replaces a chapter's group attribution wholesale, and this list omits ${ours}, ` +
+                "the group that uploaded the chapter. Dropping it detaches the chapter from this " +
+                "platform's catalogue and nothing here could find it again.",
+              uploadGroupId: ours,
+            });
+          }
+        }
+
+        // The chapter carried by the task, with the operator's changes applied
+        // to the canonical fields as well as to the MangaDex payload.
+        const edited = {
+          ...detail.chapter,
+          ...(payload["volume"] !== undefined ? { chapterVolume: payload["volume"] as string | null } : {}),
+          ...(payload["chapter"] !== undefined ? { chapterNumber: payload["chapter"] as string | null } : {}),
+          ...(payload["title"] !== undefined ? { chapterTitle: payload["title"] as string | null } : {}),
+          ...(payload["translatedLanguage"] !== undefined
+            ? { chapterLanguage: payload["translatedLanguage"] as string }
+            : {}),
+          mdChapterId,
+        };
+
+        const taskPayload = chapterToTaskPayload(
+          { ...(edited as unknown as Record<string, unknown>), payload, oldInfo: current },
+          detail.chapter.imageArtifacts,
+        );
+
+        const problems = manualTaskProblems("EDIT", taskPayload);
+        if (problems.length > 0) {
+          return reply.code(422).send({ error: "the edit cannot be executed", problems });
+        }
+
+        const dedupeKey = taskDedupeKey("EDIT", chapterFromJson(taskPayload));
+        if (dedupeKey === null) {
+          return reply.code(422).send({ error: "cannot derive a dedupe key for this chapter" });
+        }
+
+        const created = await ctx.uploadTasks.createManual("EDIT", dedupeKey, taskPayload, {
+          notBefore: body.notBefore,
+        });
+        if (!created) {
+          const existing = await ctx.prisma.uploadTask.findUnique({
+            where: { kind_dedupeKey: { kind: "EDIT", dedupeKey } },
+            select: { id: true, state: true, attempt: true, notBefore: true, createdAt: true },
+          });
+          return reply.code(409).send({
+            error:
+              "an EDIT for this chapter is already queued; amend that task rather than queueing a second " +
+              "(the unique (kind, dedupe_key) row is what stops one chapter being edited twice in flight)",
+            dedupeKey,
+            existing,
+          });
+        }
+
+        await ctx.audit.record(actor(req), "chapter.edit_queued", mdChapterId, {
+          taskId: created.id,
+          extension: detail.chapter.extensionName,
+          mdMangaId: detail.chapter.mdMangaId,
+          mangaName: detail.chapter.mangaName,
+          // Both halves, because after the uploader runs this is the only record
+          // of what the chapter said before.
+          old: current,
+          new: payload,
+        });
+
+        return reply.code(201).send({
+          ok: true,
+          task: created,
+          payload,
+          oldInfo: current,
+          note: "queued for the uploader; it is on the Queues page until it is claimed",
+        });
+      },
+    );
+  });
+}

--- a/src/core/api/server.ts
+++ b/src/core/api/server.ts
@@ -6,6 +6,7 @@ import { registerAdminRoutes } from "./routes/admin.js";
 import { registerTokenRoutes } from "./routes/tokens.js";
 import { registerOpsRoutes } from "./routes/ops.js";
 import { registerQueueRoutes } from "./routes/queues.js";
+import { registerChapterRoutes } from "./routes/chapters.js";
 import { registerSysopsRoutes } from "./routes/sysops.js";
 import { registerWebhookRoutes } from "./routes/webhooks.js";
 import { registerSessionRoutes } from "./session.js";
@@ -103,6 +104,7 @@ export function buildServer(ctx: AppContext): FastifyInstance {
   registerTokenRoutes(app, ctx);
   registerOpsRoutes(app, ctx);
   registerQueueRoutes(app, ctx);
+  registerChapterRoutes(app, ctx);
   registerSysopsRoutes(app, ctx);
   // Unauthenticated on purpose: the GitHub HMAC signature is the credential,
   // so this must NOT sit inside the admin scope.

--- a/src/core/store/chapters.ts
+++ b/src/core/store/chapters.ts
@@ -1,0 +1,192 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { chapterFromColumns, type StoredChapterRow } from "../md/chapterRows.js";
+import type { Chapter } from "../md/types.js";
+
+/**
+ * The catalogue of chapters this platform has put on MangaDex — read, searched,
+ * and (through an EDIT task) corrected.
+ *
+ * `uploaded_chapters` is the canonical mirror of what exists on MangaDex under
+ * our group; `edited_chapters` is the append-only history of corrections;
+ * `unavailable_chapters` and `deleted_chapters` are what has since been marked
+ * unavailable or removed. All four share one column layout (see
+ * md/chapterRows.ts), so one projection reads any of them.
+ *
+ * Nothing here writes to MangaDex. A metadata correction becomes an EDIT row on
+ * the upload queue — the same row the processor would have written — so it goes
+ * through the one process that holds the credentials, gets the same retry and
+ * audit treatment as every other write, and can be inspected or cancelled on the
+ * Queues page before it lands.
+ */
+
+/** The four chapter archives, by the name the API takes. */
+export const CHAPTER_TABLES = ["uploaded", "edited", "unavailable", "deleted"] as const;
+export type ChapterTable = (typeof CHAPTER_TABLES)[number];
+
+const TABLE_SQL: Record<ChapterTable, Prisma.Sql> = {
+  uploaded: Prisma.raw("uploaded_chapters"),
+  edited: Prisma.raw("edited_chapters"),
+  unavailable: Prisma.raw("unavailable_chapters"),
+  deleted: Prisma.raw("deleted_chapters"),
+};
+
+/**
+ * The instant each table sorts and pages by. Every one of the four records a
+ * different moment in a chapter's life, and ordering by the wrong one would put
+ * an archive in an order that means nothing (`created_at` on `deleted_chapters`
+ * is when the row was archived, which is what `deleted_at` already says).
+ */
+const ORDER_COLUMN: Record<ChapterTable, Prisma.Sql> = {
+  uploaded: Prisma.raw("updated_at"),
+  edited: Prisma.raw("last_edited_at"),
+  unavailable: Prisma.raw("unavailable_at"),
+  deleted: Prisma.raw("deleted_at"),
+};
+
+export interface ChapterFilter {
+  extension?: string;
+  /** Case-insensitive substring over manga name, chapter title, number and id. */
+  q?: string;
+  mdMangaId?: string;
+  language?: string;
+}
+
+/** A stored chapter, flattened for a list view. */
+export interface StoredChapter extends Chapter {
+  /** The row's own instant in the sense that table records — see ORDER_COLUMN. */
+  at: Date | null;
+  extra: unknown;
+}
+
+/** Everything known about one chapter across the four tables. */
+export interface ChapterDetail {
+  chapter: Chapter;
+  extra: unknown;
+  /** Which of the four tables hold a row for this MangaDex chapter id. */
+  present: ChapterTable[];
+  /** `{editedAt, old, new}` entries, oldest first. Empty when never edited. */
+  edits: unknown[];
+  uploadedAt: Date | null;
+  updatedAt: Date | null;
+  lastEditedAt: Date | null;
+  unavailableAt: Date | null;
+  deletedAt: Date | null;
+}
+
+export class ChapterStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * One page of a chapter archive, newest first.
+   *
+   * Offset paging is correct here in a way it is not for the queues: these
+   * tables are effectively append-only history, so a page does not shift under
+   * the reader the way a draining queue does. `updated_at DESC, id` keeps the
+   * ordering total so a tie cannot duplicate or drop a row across pages.
+   */
+  async list(
+    table: ChapterTable,
+    filter: ChapterFilter,
+    opts: { limit: number; offset: number },
+  ): Promise<{ chapters: StoredChapter[]; total: number }> {
+    const clause = where(filter);
+    const [rows, counted] = await Promise.all([
+      this.prisma.$queryRaw<(StoredChapterRow & { at: Date | null })[]>(Prisma.sql`
+        SELECT md_chapter_id AS "mdChapterId", extension, chapter_id AS "chapterId",
+               chapter_url AS "chapterUrl", chapter_number AS "chapterNumber",
+               chapter_title AS "chapterTitle", chapter_volume AS "chapterVolume",
+               chapter_language AS "chapterLanguage", chapter_timestamp AS "chapterTimestamp",
+               chapter_expire AS "chapterExpire", chapter_lookup AS "chapterLookup",
+               manga_id AS "mangaId", manga_name AS "mangaName", manga_url AS "mangaUrl",
+               md_manga_id AS "mdMangaId", md_group_id AS "mdGroupId", extra,
+               ${ORDER_COLUMN[table]} AS "at"
+        FROM ${TABLE_SQL[table]} t
+        ${clause}
+        ORDER BY ${ORDER_COLUMN[table]} DESC, t.id ASC
+        LIMIT ${opts.limit} OFFSET ${opts.offset}
+      `),
+      this.prisma.$queryRaw<{ total: bigint }[]>(Prisma.sql`
+        SELECT count(*) AS total FROM ${TABLE_SQL[table]} t ${clause}
+      `),
+    ]);
+
+    return {
+      chapters: rows.map((row) => ({
+        ...chapterFromColumns(row),
+        at: row.at,
+        extra: row.extra ?? null,
+      })),
+      total: Number(counted[0]?.total ?? 0),
+    };
+  }
+
+  /**
+   * One chapter across all four tables.
+   *
+   * The uploaded row is authoritative for "what is on MangaDex"; the others say
+   * what has happened to it. A chapter that appears in `deleted` is not there
+   * any more, and offering an edit form for it would queue a task that fails at
+   * MangaDex — so the caller needs all four before it can decide.
+   */
+  async detail(mdChapterId: string): Promise<ChapterDetail | null> {
+    const [uploaded, edited, unavailable, deleted] = await Promise.all([
+      this.prisma.uploadedChapter.findUnique({ where: { mdChapterId } }),
+      this.prisma.editedChapter.findUnique({ where: { mdChapterId } }),
+      this.prisma.unavailableChapter.findUnique({ where: { mdChapterId } }),
+      this.prisma.deletedChapter.findUnique({ where: { mdChapterId } }),
+    ]);
+
+    // Preference order is "most current first": the uploaded mirror, then the
+    // last edit, then the archives. A row missing from `uploaded` but present in
+    // `deleted` still has a full chapter to show.
+    const source = uploaded ?? edited ?? unavailable ?? deleted;
+    if (!source) return null;
+
+    const present: ChapterTable[] = [];
+    if (uploaded) present.push("uploaded");
+    if (edited) present.push("edited");
+    if (unavailable) present.push("unavailable");
+    if (deleted) present.push("deleted");
+
+    return {
+      chapter: { ...chapterFromColumns(source as StoredChapterRow), mdChapterId },
+      extra: source.extra ?? null,
+      present,
+      edits: Array.isArray(edited?.edits) ? (edited.edits as unknown[]) : [],
+      uploadedAt: uploaded?.createdAt ?? null,
+      updatedAt: uploaded?.updatedAt ?? null,
+      lastEditedAt: edited?.lastEditedAt ?? null,
+      unavailableAt: unavailable?.unavailableAt ?? null,
+      deletedAt: deleted?.deletedAt ?? null,
+    };
+  }
+
+  /** Distinct extensions that have uploaded something, for a filter picker. */
+  async extensions(table: ChapterTable): Promise<{ extension: string; count: number }[]> {
+    const rows = await this.prisma.$queryRaw<{ extension: string | null; count: bigint }[]>(Prisma.sql`
+      SELECT extension, count(*) AS count FROM ${TABLE_SQL[table]}
+      GROUP BY extension ORDER BY count DESC
+    `);
+    return rows
+      .filter((row) => row.extension !== null && row.extension !== "")
+      .map((row) => ({ extension: row.extension!, count: Number(row.count) }));
+  }
+}
+
+// ------------------------------------------------------------------ internals
+
+function where(filter: ChapterFilter): Prisma.Sql {
+  const parts: Prisma.Sql[] = [];
+  if (filter.extension) parts.push(Prisma.sql`t.extension = ${filter.extension}`);
+  if (filter.mdMangaId) parts.push(Prisma.sql`t.md_manga_id = ${filter.mdMangaId}`);
+  if (filter.language) parts.push(Prisma.sql`t.chapter_language = ${filter.language}`);
+  if (filter.q) {
+    const needle = `%${filter.q}%`;
+    parts.push(Prisma.sql`(
+      t.manga_name ILIKE ${needle} OR t.chapter_title ILIKE ${needle}
+      OR t.chapter_number ILIKE ${needle} OR t.chapter_id ILIKE ${needle}
+      OR t.md_chapter_id ILIKE ${needle}
+    )`);
+  }
+  return parts.length > 0 ? Prisma.sql`WHERE ${Prisma.join(parts, " AND ")}` : Prisma.empty;
+}

--- a/src/core/store/runChapters.ts
+++ b/src/core/store/runChapters.ts
@@ -1,0 +1,250 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+/**
+ * What a run actually found, read back out of the result envelopes.
+ *
+ * A worker's envelope is already the durable record of a scrape — it is stored
+ * verbatim in `result_submissions.envelope` and the processor reads it to decide
+ * what to upload. Nothing else ever exposed it, so "what did mangaplus find this
+ * morning?" was a question only answerable by `psql` and a `jsonb` path. This
+ * store is that question, one query.
+ *
+ * The chapters are NOT copied into a table on ingest. Doing so would duplicate
+ * up to 20 000 rows per segment (`MAX_CHAPTERS_PER_ENVELOPE`) whose only reader
+ * is a human looking at one run, and would need a second write path to stay
+ * honest with the envelope. Postgres unnests the array on demand instead, so the
+ * envelope stays the single source of truth and paging happens in the database
+ * rather than in the API process.
+ *
+ * `updatedChapters` is what the extension reported as new or changed this run —
+ * the set the processor turns into upload and edit tasks. `allChapters` is the
+ * optional full catalogue snapshot an extension may also send (it is what drives
+ * removal detection), and it is null for extensions that do not send one, which
+ * is why the two are separate `set` values rather than one list with a flag.
+ */
+
+/** Which array of the envelope to read. */
+export const CHAPTER_SETS = ["updated", "all"] as const;
+export type ChapterSet = (typeof CHAPTER_SETS)[number];
+
+const ENVELOPE_KEY: Record<ChapterSet, string> = {
+  updated: "updatedChapters",
+  all: "allChapters",
+};
+
+export interface RunChapterFilter {
+  /** Case-insensitive substring over the manga name, chapter title and number. */
+  q?: string;
+  /** Exact MangaDex title id. */
+  mdMangaId?: string;
+  /** Exact chapter language as the extension reported it. */
+  language?: string;
+  /** One segment of a fanned-out run, by its index. */
+  segmentIndex?: number;
+}
+
+/** One chapter as the extension reported it, plus where it came from. */
+export interface RunChapterRow {
+  jobId: string;
+  segmentIndex: number;
+  segmentKey: string | null;
+  /** 1-based position within that segment's array — the extension's own order. */
+  position: number;
+  chapter: Record<string, unknown>;
+}
+
+/** Per-segment coverage: how many chapters each job's envelope carried. */
+export interface RunSegmentCounts {
+  jobId: string;
+  segmentIndex: number;
+  segmentKey: string | null;
+  jobState: string;
+  /** Null when this segment has no committed envelope yet. */
+  updated: number | null;
+  /** Null when the segment sent no catalogue snapshot (or has not reported). */
+  all: number | null;
+  untrackedManga: number | null;
+  submittedAt: Date | null;
+}
+
+export class RunChapterStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Coverage for every segment of a run, reported or not.
+   *
+   * LEFT JOIN, so a segment that has not come back yet is a row with null
+   * counts rather than an absent row: "3 of 4 segments reported" is the thing an
+   * operator needs to see before reading a chapter list as complete.
+   */
+  async segmentCounts(runId: string): Promise<RunSegmentCounts[]> {
+    const rows = await this.prisma.$queryRaw<
+      {
+        jobId: string;
+        segmentIndex: number;
+        segmentKey: string | null;
+        jobState: string;
+        updated: number | null;
+        all: number | null;
+        untrackedManga: number | null;
+        submittedAt: Date | null;
+      }[]
+    >(Prisma.sql`
+      SELECT j.id AS "jobId", j.segment_index AS "segmentIndex", j.segment_key AS "segmentKey",
+             j.state::text AS "jobState",
+             CASE WHEN jsonb_typeof(rs.envelope -> 'updatedChapters') = 'array'
+                  THEN jsonb_array_length(rs.envelope -> 'updatedChapters') END AS "updated",
+             CASE WHEN jsonb_typeof(rs.envelope -> 'allChapters') = 'array'
+                  THEN jsonb_array_length(rs.envelope -> 'allChapters') END AS "all",
+             CASE WHEN jsonb_typeof(rs.envelope -> 'untrackedManga') = 'array'
+                  THEN jsonb_array_length(rs.envelope -> 'untrackedManga') END AS "untrackedManga",
+             rs.created_at AS "submittedAt"
+      FROM jobs j
+      LEFT JOIN result_submissions rs ON rs.job_id = j.id AND rs.state = 'COMMITTED'
+      WHERE j.run_id = ${runId}
+      ORDER BY j.segment_index ASC
+    `);
+    return rows;
+  }
+
+  /**
+   * One page of the chapters a run found, in the order the extension reported
+   * them within each segment.
+   *
+   * Offset paging, not keyset: the source is an immutable committed envelope, so
+   * page 2 describes exactly the rows page 2 described a minute ago. (The queue
+   * views cannot say that, which is why they page by cursor.)
+   */
+  async list(
+    runId: string,
+    set: ChapterSet,
+    filter: RunChapterFilter,
+    opts: { limit: number; offset: number },
+  ): Promise<{ chapters: RunChapterRow[]; total: number }> {
+    const source = Prisma.sql`
+      FROM jobs j
+      JOIN result_submissions rs ON rs.job_id = j.id AND rs.state = 'COMMITTED'
+      CROSS JOIN LATERAL jsonb_array_elements(
+        CASE WHEN jsonb_typeof(rs.envelope -> ${ENVELOPE_KEY[set]}) = 'array'
+             THEN rs.envelope -> ${ENVELOPE_KEY[set]} ELSE '[]'::jsonb END
+      ) WITH ORDINALITY AS c(value, position)
+      ${where(runId, filter)}
+    `;
+
+    const [chapters, counted] = await Promise.all([
+      this.prisma.$queryRaw<RunChapterRow[]>(Prisma.sql`
+        SELECT j.id AS "jobId", j.segment_index AS "segmentIndex", j.segment_key AS "segmentKey",
+               c.position::int AS "position", c.value AS "chapter"
+        ${source}
+        ORDER BY j.segment_index ASC, c.position ASC
+        LIMIT ${opts.limit} OFFSET ${opts.offset}
+      `),
+      this.prisma.$queryRaw<{ total: bigint }[]>(Prisma.sql`
+        SELECT count(*) AS total ${source}
+      `),
+    ]);
+
+    return { chapters, total: Number(counted[0]?.total ?? 0) };
+  }
+
+  /**
+   * Chapters-found totals for a set of runs, for the list view's column.
+   *
+   * Aggregated in one statement over the page of runs being drawn rather than
+   * one query per run: a 50-row runs list is the common case and 50 round trips
+   * to render one column is not.
+   */
+  async totalsForRuns(runIds: readonly string[]): Promise<Map<string, { updated: number; all: number | null }>> {
+    if (runIds.length === 0) return new Map();
+    const rows = await this.prisma.$queryRaw<
+      { runId: string; updated: bigint; all: bigint | null }[]
+    >(Prisma.sql`
+      SELECT j.run_id AS "runId",
+             coalesce(sum(
+               CASE WHEN jsonb_typeof(rs.envelope -> 'updatedChapters') = 'array'
+                    THEN jsonb_array_length(rs.envelope -> 'updatedChapters') ELSE 0 END
+             ), 0) AS "updated",
+             -- NULL when no segment sent a catalogue snapshot, so the column can
+             -- say "—" rather than a zero that reads as "found nothing".
+             sum(
+               CASE WHEN jsonb_typeof(rs.envelope -> 'allChapters') = 'array'
+                    THEN jsonb_array_length(rs.envelope -> 'allChapters') END
+             ) AS "all"
+      FROM jobs j
+      JOIN result_submissions rs ON rs.job_id = j.id AND rs.state = 'COMMITTED'
+      WHERE j.run_id = ANY(${[...runIds]}::text[])
+      GROUP BY j.run_id
+    `);
+    return new Map(
+      rows.map((row) => [
+        row.runId,
+        { updated: Number(row.updated), all: row.all === null ? null : Number(row.all) },
+      ]),
+    );
+  }
+
+  /**
+   * Per-title breakdown of one run: how many chapters were found for each
+   * series, newest reported first.
+   *
+   * This is the shape an operator actually reads a run in — "mangaplus found 41
+   * chapters across 9 titles" — and it is cheap enough to compute on demand
+   * because the grouping happens in Postgres over the same unnest the list uses.
+   */
+  async byManga(
+    runId: string,
+    set: ChapterSet,
+    limit: number,
+  ): Promise<{ mdMangaId: string | null; mangaId: string | null; mangaName: string | null; count: number }[]> {
+    const rows = await this.prisma.$queryRaw<
+      { mdMangaId: string | null; mangaId: string | null; mangaName: string | null; count: bigint }[]
+    >(Prisma.sql`
+      SELECT c.value ->> 'mdMangaId' AS "mdMangaId",
+             c.value ->> 'mangaId' AS "mangaId",
+             -- One title can arrive with the name on some rows and null on
+             -- others (the processor fills names in later), so take any non-null.
+             max(c.value ->> 'mangaName') AS "mangaName",
+             count(*) AS count
+      FROM jobs j
+      JOIN result_submissions rs ON rs.job_id = j.id AND rs.state = 'COMMITTED'
+      CROSS JOIN LATERAL jsonb_array_elements(
+        CASE WHEN jsonb_typeof(rs.envelope -> ${ENVELOPE_KEY[set]}) = 'array'
+             THEN rs.envelope -> ${ENVELOPE_KEY[set]} ELSE '[]'::jsonb END
+      ) AS c(value)
+      WHERE j.run_id = ${runId}
+      GROUP BY 1, 2
+      ORDER BY count DESC, 3 ASC
+      LIMIT ${limit}
+    `);
+    return rows.map((row) => ({
+      mdMangaId: row.mdMangaId,
+      mangaId: row.mangaId,
+      mangaName: row.mangaName,
+      count: Number(row.count),
+    }));
+  }
+}
+
+// ------------------------------------------------------------------ internals
+
+function where(runId: string, filter: RunChapterFilter): Prisma.Sql {
+  const parts: Prisma.Sql[] = [Prisma.sql`j.run_id = ${runId}`];
+  if (filter.segmentIndex !== undefined) {
+    parts.push(Prisma.sql`j.segment_index = ${filter.segmentIndex}`);
+  }
+  if (filter.mdMangaId) parts.push(Prisma.sql`c.value ->> 'mdMangaId' = ${filter.mdMangaId}`);
+  if (filter.language) parts.push(Prisma.sql`c.value ->> 'chapterLanguage' = ${filter.language}`);
+  if (filter.q) {
+    // Parameterised, so a `%` is a wildcard the operator meant and a quote is
+    // data. Spans the three fields a human searches by: which series, which
+    // chapter, and what it was called.
+    const needle = `%${filter.q}%`;
+    parts.push(Prisma.sql`(
+      c.value ->> 'mangaName' ILIKE ${needle}
+      OR c.value ->> 'chapterTitle' ILIKE ${needle}
+      OR c.value ->> 'chapterNumber' ILIKE ${needle}
+      OR c.value ->> 'chapterId' ILIKE ${needle}
+    )`);
+  }
+  return Prisma.sql`WHERE ${Prisma.join(parts, " AND ")}`;
+}

--- a/src/core/store/uploadTasks.ts
+++ b/src/core/store/uploadTasks.ts
@@ -87,6 +87,17 @@ export interface UploadTaskFilter {
   states?: readonly UploadTaskState[];
   /** Case-insensitive substring over `dedupe_key`. */
   dedupeKey?: string;
+  /**
+   * Case-insensitive substring over the chapter payload's human-readable
+   * fields — series name, chapter title, chapter number.
+   *
+   * A dedupe key is machine identity (`chapterId|number|language`, or a
+   * MangaDex uuid), so "everything queued for Sakamoto Days" was not expressible
+   * before this. It applies to every path the filter reaches, purge included,
+   * which is deliberate: pulling one series' worth of bad rows out of the queue
+   * is the case that used to mean `psql`.
+   */
+  q?: string;
   attemptMin?: number;
   attemptMax?: number;
 }
@@ -105,6 +116,30 @@ export interface UploadTaskRow {
   lastError: string | null;
   createdAt: Date;
   updatedAt: Date;
+}
+
+/**
+ * A queue row read as the chapter it will act on. Every chapter field is
+ * nullable because the payload is whatever the extension produced — a DELETE
+ * task, for instance, carries a MangaDex id and often little else.
+ */
+export interface QueuedChapterRow extends UploadTaskRow {
+  /** 1-based place in the claim order across everything matching the filter. */
+  position: number;
+  extension: string | null;
+  mangaName: string | null;
+  mdMangaId: string | null;
+  mangaId: string | null;
+  mdChapterId: string | null;
+  chapterId: string | null;
+  chapterNumber: string | null;
+  chapterVolume: string | null;
+  chapterTitle: string | null;
+  chapterLanguage: string | null;
+  chapterUrl: string | null;
+  /** The MangaDex PUT body an EDIT task carries; null for other kinds. */
+  editPayload: Record<string, unknown> | null;
+  pageCount: number;
 }
 
 /** Enough of a row to explain why a mutation refused it. */
@@ -296,6 +331,78 @@ export class UploadTaskStore {
     const last = page[page.length - 1];
     return {
       tasks: page,
+      total: Number(counted[0]?.total ?? 0),
+      nextCursor: rows.length > opts.limit && last ? encodeTaskCursor(last) : null,
+    };
+  }
+
+  /**
+   * The same page as `list`, but as CHAPTERS rather than as queue rows: the
+   * series, number, volume, title and language the uploader is about to send,
+   * with the row's position in the claim order.
+   *
+   * `list` answers "what is in the queue and what state is it in", which is the
+   * incident view. This answers "what is about to happen to the catalogue", and
+   * they are not the same question — a dedupe key of
+   * `1015117|142|en` names a chapter only to someone willing to decode it.
+   *
+   * The position comes from a window function over the whole filtered set in the
+   * same ordering the claim query uses, so "3rd" means third out of everything
+   * matching, not third on this page. Paging stays keyset for the reason `list`
+   * documents: the queue drains while it is being read.
+   */
+  async listChapters(
+    filter: UploadTaskFilter,
+    opts: { limit: number; cursor?: TaskCursor | null },
+  ): Promise<{ chapters: QueuedChapterRow[]; total: number; nextCursor: string | null }> {
+    const parts = taskWhere(filter);
+    const page: Prisma.Sql[] = [];
+    if (opts.cursor) {
+      page.push(
+        Prisma.sql`(o."notBefore", o."createdAt", o.id) > (${opts.cursor.notBefore}, ${opts.cursor.createdAt}, ${opts.cursor.id})`,
+      );
+    }
+
+    const rows = await this.prisma.$queryRaw<QueuedChapterRow[]>(Prisma.sql`
+      WITH ordered AS (
+        SELECT ${TASK_COLUMNS},
+               row_number() OVER (ORDER BY t.not_before ASC, t.created_at ASC, t.id ASC) AS position,
+               t.chapter ->> 'mangaName' AS "mangaName",
+               t.chapter ->> 'mdMangaId' AS "mdMangaId",
+               t.chapter ->> 'mangaId' AS "mangaId",
+               t.chapter ->> 'mdChapterId' AS "mdChapterId",
+               t.chapter ->> 'chapterId' AS "chapterId",
+               t.chapter ->> 'chapterNumber' AS "chapterNumber",
+               t.chapter ->> 'chapterVolume' AS "chapterVolume",
+               t.chapter ->> 'chapterTitle' AS "chapterTitle",
+               t.chapter ->> 'chapterLanguage' AS "chapterLanguage",
+               t.chapter ->> 'chapterUrl' AS "chapterUrl",
+               t.chapter ->> 'extensionName' AS "extension",
+               -- The fields an EDIT task will actually change, so the list can
+               -- show "title → …" without a second fetch per row.
+               CASE WHEN jsonb_typeof(t.chapter -> 'payload') = 'object'
+                    THEN t.chapter -> 'payload' END AS "editPayload",
+               coalesce(jsonb_array_length(
+                 CASE WHEN jsonb_typeof(t.chapter -> 'imageArtifacts') = 'array'
+                      THEN t.chapter -> 'imageArtifacts' ELSE '[]'::jsonb END
+               ), 0) AS "pageCount"
+        FROM upload_tasks t
+        ${combine(parts)}
+      )
+      SELECT o.* FROM ordered o
+      ${combine(page)}
+      ORDER BY o."notBefore" ASC, o."createdAt" ASC, o.id ASC
+      LIMIT ${opts.limit + 1}
+    `);
+
+    const counted = await this.prisma.$queryRaw<{ total: bigint }[]>(Prisma.sql`
+      SELECT count(*) AS total FROM upload_tasks t ${combine(taskWhere(filter))}
+    `);
+
+    const chapters = rows.slice(0, opts.limit).map((row) => ({ ...row, position: Number(row.position) }));
+    const last = chapters[chapters.length - 1];
+    return {
+      chapters,
       total: Number(counted[0]?.total ?? 0),
       nextCursor: rows.length > opts.limit && last ? encodeTaskCursor(last) : null,
     };
@@ -579,6 +686,14 @@ function taskWhere(filter: UploadTaskFilter): Prisma.Sql[] {
   // Parameterised, so a `%` an operator types is a wildcard they meant and a
   // quote is data either way.
   if (filter.dedupeKey) parts.push(Prisma.sql`t.dedupe_key ILIKE ${`%${filter.dedupeKey}%`}`);
+  if (filter.q) {
+    const needle = `%${filter.q}%`;
+    parts.push(Prisma.sql`(
+      t.chapter ->> 'mangaName' ILIKE ${needle}
+      OR t.chapter ->> 'chapterTitle' ILIKE ${needle}
+      OR t.chapter ->> 'chapterNumber' ILIKE ${needle}
+    )`);
+  }
   if (filter.attemptMin !== undefined) parts.push(Prisma.sql`t.attempt >= ${filter.attemptMin}`);
   if (filter.attemptMax !== undefined) parts.push(Prisma.sql`t.attempt <= ${filter.attemptMax}`);
   return parts;

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -1,0 +1,761 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { Prisma } from "@prisma/client";
+import { loadConfig } from "../../src/config.js";
+import { createLogger } from "../../src/logging.js";
+import { buildContext, type AppContext } from "../../src/core/api/context.js";
+import { buildServer } from "../../src/core/api/server.js";
+import { registerChapterRoutes } from "../../src/core/api/routes/chapters.js";
+import { closeDb, dbReady, resetDb, testPrisma } from "./db.js";
+
+/**
+ * Chapter visibility and correction: the three views of a chapter, and the one
+ * write.
+ *
+ * These need a real Postgres for the same reason the queue tests do, and for one
+ * more: two of the three read paths are `jsonb` unnests and window functions
+ * over live tables — `jsonb_array_elements … WITH ORDINALITY` on stored
+ * envelopes, and `row_number()` over the claim ordering. A mock would assert
+ * that the strings were assembled, not that they answer the question.
+ *
+ * What is worth proving here:
+ *
+ *  - a run's chapters come back in the extension's own order, and a segment that
+ *    has not reported reads as "not reported" rather than as zero chapters;
+ *  - the queue's `position` is the place in the WHOLE claim order, not on the
+ *    page, and it tracks a reorder;
+ *  - a metadata correction becomes an EDIT task that MangaDex would accept —
+ *    the diff in `payload`, the previous values in `oldInfo`, and the NEW values
+ *    on the chapter, since the uploader mirrors that chapter back into
+ *    `uploaded_chapters` on success;
+ *  - and the three refusals that each protect something irreversible: a second
+ *    queued edit, an edit to a deleted chapter, and an edit that would detach
+ *    the chapter from our own upload group.
+ */
+describe.skipIf(!dbReady())("chapter views and metadata correction", () => {
+  const prisma = testPrisma();
+  const ADMIN_TOKEN = "test-admin-token-0123456789";
+  const config = loadConfig({
+    DATABASE_URL: process.env.TEST_DATABASE_URL!,
+    ADMIN_TOKEN,
+    LOG_LEVEL: "error",
+  });
+  const log = createLogger("test-chapters", "error");
+  let app: FastifyInstance;
+  let ctx: AppContext;
+  const root = { authorization: `Bearer ${ADMIN_TOKEN}` };
+  const csrf = { "x-requested-with": "publoader-dash" };
+
+  const MD_MANGA = "9a1b1c1d-0000-4000-8000-000000000000";
+  const MD_GROUP = "4f1de6a2-f0c5-4ac5-bce5-02c7dbb67deb";
+  const MD_CHAPTER = "1c2d3e4f-0000-4000-8000-000000000001";
+
+  /**
+   * Same probe as queues.test.ts: register by hand only if `buildServer` has not
+   * wired these routes yet, since registering twice throws on duplicate routes.
+   */
+  async function buildApp(): Promise<FastifyInstance> {
+    const probe = buildServer(ctx);
+    await probe.ready();
+    if (probe.hasRoute({ method: "GET", url: "/api/v1/admin/chapters" })) return probe;
+    await probe.close();
+    const fresh = buildServer(ctx);
+    registerChapterRoutes(fresh, ctx);
+    await fresh.ready();
+    return fresh;
+  }
+
+  beforeEach(async () => {
+    await resetDb(prisma);
+    await prisma.apiToken.deleteMany({});
+    ctx = buildContext(prisma, config, log);
+    app = await buildApp();
+  });
+  afterAll(async () => {
+    await app?.close();
+    await closeDb();
+  });
+
+  /** A logged-in session cookie for a fresh account with `role`. */
+  async function sessionAs(role: "OWNER" | "ADMIN" | "CONTRIBUTOR", email: string): Promise<Record<string, string>> {
+    await ctx.adminUsers.ensureOwner("owner@example.com");
+    if (role === "OWNER") {
+      const login = await app.inject({
+        method: "POST",
+        url: "/api/v1/admin/session",
+        payload: { token: ADMIN_TOKEN, actor: "ardax" },
+      });
+      const value = login.cookies.find((c) => c.name === "publoader_session")!.value;
+      return { cookie: `publoader_session=${value}`, ...csrf };
+    }
+    const password = "correct-horse-battery-staple";
+    const user = await ctx.adminUsers.invite(email, role);
+    await ctx.adminUsers.setPassword(user.id, password);
+    const login = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/session",
+      payload: { email, password },
+    });
+    expect(login.statusCode).toBe(200);
+    const value = login.cookies.find((c) => c.name === "publoader_session")!.value;
+    return { cookie: `publoader_session=${value}`, ...csrf };
+  }
+
+  async function mint(scopes: string[]): Promise<Record<string, string>> {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/tokens",
+      headers: root,
+      payload: { name: `chapters-${scopes.join("-")}`, scopes },
+    });
+    expect(res.statusCode).toBe(201);
+    return { authorization: `Bearer ${res.json().token}` };
+  }
+
+  // ------------------------------------------------------ seeding helpers
+
+  const chapterRecord = (overrides: Record<string, unknown> = {}) => ({
+    chapterLookup: null,
+    chapterTimestamp: "2026-08-01T00:00:00.000Z",
+    chapterExpire: null,
+    chapterLanguage: "en",
+    chapterNumber: "1",
+    chapterTitle: null,
+    chapterVolume: null,
+    chapterId: "src-1",
+    chapterUrl: "https://example.test/1",
+    mdChapterId: null,
+    mangaId: "m-1",
+    mdMangaId: MD_MANGA,
+    mdGroupId: MD_GROUP,
+    mangaName: "Test Series",
+    mangaUrl: "https://example.test/series",
+    extensionName: "chaptertest",
+    imageArtifacts: [],
+    ...overrides,
+  });
+
+  /** A run with `segments` jobs, and a committed envelope for the first `reported`. */
+  async function seedRun(opts: {
+    segments: number;
+    reported: number;
+    chaptersPerSegment: Record<string, unknown>[][];
+    allChapters?: Record<string, unknown>[][] | null;
+  }) {
+    const run = await prisma.run.create({
+      data: {
+        idempotencyKey: `run-${Math.random()}`,
+        extension: "chaptertest",
+        extensionVersion: "1.0.0",
+        bundleSha256: "a".repeat(64),
+        kind: "UPDATE",
+        state: "PROCESSED",
+        segmentsTotal: opts.segments,
+      },
+    });
+    const jobs = [];
+    for (let index = 0; index < opts.segments; index++) {
+      const job = await prisma.job.create({
+        data: {
+          idempotencyKey: `job-${run.id}-${index}`,
+          runId: run.id,
+          extension: "chaptertest",
+          extensionVersion: "1.0.0",
+          bundleSha256: "a".repeat(64),
+          kind: "UPDATE",
+          segmentIndex: index,
+          segmentTotal: opts.segments,
+          segmentKey: `seg${index}`,
+          state: index < opts.reported ? "SUCCEEDED" : "PENDING",
+        },
+      });
+      jobs.push(job);
+      if (index >= opts.reported) continue;
+      await prisma.resultSubmission.create({
+        data: {
+          idempotencyKey: `res-${job.id}`,
+          jobId: job.id,
+          attempt: 1,
+          leaseId: "22222222-2222-4222-8222-222222222222",
+          workerId: "w1",
+          state: "COMMITTED",
+          // Cast at the boundary: Prisma's InputJsonValue does not accept a
+          // Record<string, unknown>[] (no index signature), and the shape here
+          // is a real envelope rather than something worth a type of its own.
+          envelope: {
+            envelopeVersion: 1,
+            extension: "chaptertest",
+            status: "ok",
+            updatedChapters: opts.chaptersPerSegment[index] ?? [],
+            allChapters: opts.allChapters ? (opts.allChapters[index] ?? []) : null,
+            untrackedManga: [],
+          } as unknown as Prisma.InputJsonValue,
+        },
+      });
+    }
+    return { run, jobs };
+  }
+
+  /** A chapter in the canonical `uploaded_chapters` mirror. */
+  const uploaded = (overrides: Record<string, unknown> = {}) =>
+    prisma.uploadedChapter.create({
+      data: {
+        mdChapterId: MD_CHAPTER,
+        extension: "chaptertest",
+        chapterId: "src-1",
+        chapterUrl: "https://example.test/1",
+        chapterNumber: "1",
+        chapterTitle: "Beginnings",
+        chapterVolume: "1",
+        chapterLanguage: "en",
+        mangaId: "m-1",
+        mangaName: "Test Series",
+        mdMangaId: MD_MANGA,
+        mdGroupId: MD_GROUP,
+        ...overrides,
+      },
+    });
+
+  let seq = 0;
+  const queued = (overrides: Record<string, unknown> = {}) =>
+    prisma.uploadTask.create({
+      data: {
+        kind: "UPLOAD",
+        dedupeKey: `src-${(seq += 1)}|${seq}|en`,
+        chapter: {
+          chapterId: `src-${seq}`,
+          chapterNumber: String(seq),
+          chapterLanguage: "en",
+          mangaName: "Test Series",
+          mdMangaId: MD_MANGA,
+          extensionName: "chaptertest",
+        },
+        ...overrides,
+      },
+    });
+
+  // -------------------------------------------------- 1. found, per run
+
+  it("reports what a run found, in the extension's own order, per segment", async () => {
+    const { run } = await seedRun({
+      segments: 2,
+      reported: 2,
+      chaptersPerSegment: [
+        [chapterRecord({ chapterNumber: "1" }), chapterRecord({ chapterNumber: "2", chapterId: "src-2" })],
+        [chapterRecord({ chapterNumber: "3", chapterId: "src-3", mangaName: "Other Series" })],
+      ],
+    });
+
+    const list = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${run.id}/chapters`,
+      headers: root,
+    });
+    expect(list.statusCode).toBe(200);
+    expect(list.json().total).toBe(3);
+    // Segment order first, then the position the extension reported them in —
+    // this is the extension's own ordering, not a sort we imposed.
+    expect(list.json().chapters.map((c: { position: number; segmentIndex: number }) => [c.segmentIndex, c.position])).toEqual([
+      [0, 1],
+      [0, 2],
+      [1, 1],
+    ]);
+    expect(list.json().chapters[0].chapter.chapterNumber).toBe("1");
+
+    const summary = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${run.id}/chapters/summary`,
+      headers: root,
+    });
+    expect(summary.json().totals.updated).toBe(3);
+    expect(summary.json().complete).toBe(true);
+    expect(summary.json().segmentsReported).toBe(2);
+    // Grouped by title, so "41 chapters across 9 series" is one read.
+    expect(summary.json().byManga).toHaveLength(1);
+    expect(summary.json().byManga[0].count).toBe(3);
+  });
+
+  it("distinguishes a segment that found nothing from one that has not reported", async () => {
+    const { run } = await seedRun({
+      segments: 3,
+      reported: 2,
+      chaptersPerSegment: [[chapterRecord()], []],
+    });
+
+    const summary = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${run.id}/chapters/summary`,
+      headers: root,
+    });
+    const segments = summary.json().segments;
+    expect(segments).toHaveLength(3);
+    // Zero is a report of nothing; null is no report at all. Collapsing the two
+    // would let a run that half-failed read as a run that found one chapter.
+    expect(segments[1].updated).toBe(0);
+    expect(segments[2].updated).toBeNull();
+    expect(summary.json().complete).toBe(false);
+    expect(summary.json().segmentsReported).toBe(2);
+  });
+
+  it("separates the new-or-changed set from the catalogue snapshot", async () => {
+    const { run } = await seedRun({
+      segments: 1,
+      reported: 1,
+      chaptersPerSegment: [[chapterRecord({ chapterNumber: "9" })]],
+      allChapters: [[chapterRecord({ chapterNumber: "1" }), chapterRecord({ chapterNumber: "9" })]],
+    });
+
+    const updated = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${run.id}/chapters?set=updated`,
+      headers: root,
+    });
+    expect(updated.json().total).toBe(1);
+
+    const all = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${run.id}/chapters?set=all`,
+      headers: root,
+    });
+    expect(all.json().total).toBe(2);
+
+    // An extension that sends no snapshot reports null, not zero: removal
+    // detection is skipped in that case and the difference has to be visible.
+    const { run: noSnapshot } = await seedRun({
+      segments: 1,
+      reported: 1,
+      chaptersPerSegment: [[chapterRecord()]],
+    });
+    const summary = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${noSnapshot.id}/chapters/summary`,
+      headers: root,
+    });
+    expect(summary.json().totals.all).toBeNull();
+  });
+
+  it("filters a run's chapters by search, series and segment", async () => {
+    const { run } = await seedRun({
+      segments: 2,
+      reported: 2,
+      chaptersPerSegment: [
+        [chapterRecord({ chapterTitle: "The Duel", chapterNumber: "1" })],
+        [chapterRecord({ mangaName: "Other Series", mdMangaId: "5555aaaa-0000-4000-8000-000000000000", chapterNumber: "2" })],
+      ],
+    });
+
+    const search = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${run.id}/chapters?q=duel`,
+      headers: root,
+    });
+    expect(search.json().total).toBe(1);
+
+    const bySegment = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${run.id}/chapters?segmentIndex=1`,
+      headers: root,
+    });
+    expect(bySegment.json().total).toBe(1);
+    expect(bySegment.json().chapters[0].chapter.mangaName).toBe("Other Series");
+
+    const byManga = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/runs/${run.id}/chapters?mdMangaId=${MD_MANGA}`,
+      headers: root,
+    });
+    expect(byManga.json().total).toBe(1);
+  });
+
+  it("puts the chapters-found count on the runs list without a query per run", async () => {
+    await seedRun({ segments: 1, reported: 1, chaptersPerSegment: [[chapterRecord(), chapterRecord()]] });
+    await seedRun({ segments: 1, reported: 0, chaptersPerSegment: [] });
+
+    const runs = await app.inject({ method: "GET", url: "/api/v1/admin/runs", headers: root });
+    const counts = runs.json().runs.map((r: { chaptersFound: number | null }) => r.chaptersFound);
+    expect(counts).toContain(2);
+    // The unreported run reads "—", not "0".
+    expect(counts).toContain(null);
+  });
+
+  // -------------------------------------------- 2. queued, in claim order
+
+  it("reads the queue as chapters, numbered by their place in the whole claim order", async () => {
+    const later = await queued({ notBefore: new Date(Date.now() + 600_000) });
+    const soon = await queued({ notBefore: new Date(Date.now() - 600_000) });
+    const middle = await queued({ notBefore: new Date(Date.now() - 60_000) });
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/admin/queues/chapters", headers: root });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().order).toBe("notBefore,createdAt,id");
+    const rows = res.json().chapters;
+    expect(rows.map((r: { id: string }) => r.id)).toEqual([soon.id, middle.id, later.id]);
+    expect(rows.map((r: { position: number }) => r.position)).toEqual([1, 2, 3]);
+    // Projected from the payload, so the row names a chapter rather than a
+    // dedupe key.
+    expect(rows[0].mangaName).toBe("Test Series");
+    expect(rows[0].chapterNumber).toBe(soon.dedupeKey.split("|")[1]);
+
+    // Position is the place in the whole ordering, not on the page: page two of
+    // a one-row page starts at 2.
+    const paged = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/queues/chapters?limit=1",
+      headers: root,
+    });
+    expect(paged.json().chapters[0].position).toBe(1);
+    const next = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/queues/chapters?limit=1&cursor=${encodeURIComponent(paged.json().nextCursor)}`,
+      headers: root,
+    });
+    expect(next.json().chapters[0].position).toBe(2);
+    expect(next.json().chapters[0].id).toBe(middle.id);
+  });
+
+  it("tracks a reorder, because it reads the same ordering the uploader claims by", async () => {
+    await queued({ notBefore: new Date(Date.now() - 600_000) });
+    const last = await queued({ notBefore: new Date(Date.now() + 600_000) });
+
+    const before = await app.inject({ method: "GET", url: "/api/v1/admin/queues/chapters", headers: root });
+    expect(before.json().chapters.find((c: { id: string }) => c.id === last.id).position).toBe(2);
+
+    const moved = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/queues/reorder",
+      headers: root,
+      payload: { ids: [last.id], mode: "front" },
+    });
+    expect(moved.statusCode).toBe(200);
+
+    const after = await app.inject({ method: "GET", url: "/api/v1/admin/queues/chapters", headers: root });
+    expect(after.json().chapters[0].id).toBe(last.id);
+    expect(after.json().chapters[0].position).toBe(1);
+  });
+
+  it("defaults to PENDING and searches the payload rather than the dedupe key", async () => {
+    await queued({ chapter: { mangaName: "Sakamoto Days", chapterNumber: "12", chapterLanguage: "en" } });
+    await queued({ chapter: { mangaName: "Other Series", chapterNumber: "3", chapterLanguage: "en" } });
+    await queued({ state: "DONE" });
+
+    const pending = await app.inject({ method: "GET", url: "/api/v1/admin/queues/chapters", headers: root });
+    expect(pending.json().total).toBe(2);
+
+    const byName = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/queues/chapters?q=sakamoto",
+      headers: root,
+    });
+    expect(byName.json().total).toBe(1);
+    expect(byName.json().chapters[0].mangaName).toBe("Sakamoto Days");
+
+    const done = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/queues/chapters?state=DONE",
+      headers: root,
+    });
+    expect(done.json().total).toBe(1);
+  });
+
+  it("shows an EDIT task's diff, which is what that row is actually about", async () => {
+    await queued({
+      kind: "EDIT",
+      dedupeKey: MD_CHAPTER,
+      chapter: {
+        mdChapterId: MD_CHAPTER,
+        mangaName: "Test Series",
+        chapterNumber: "12",
+        payload: { title: "Corrected" },
+        oldInfo: { title: "Wrong" },
+      },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/queues/chapters?kind=EDIT",
+      headers: root,
+    });
+    expect(res.json().chapters[0].editPayload).toEqual({ title: "Corrected" });
+    expect(res.json().chapters[0].mdChapterId).toBe(MD_CHAPTER);
+  });
+
+  // ------------------------------------------- 3. already on MangaDex
+
+  it("browses the archives and filters them", async () => {
+    await uploaded();
+    await uploaded({ mdChapterId: "1c2d3e4f-0000-4000-8000-000000000002", chapterNumber: "2", extension: "other", chapterLanguage: "es" });
+
+    const all = await app.inject({ method: "GET", url: "/api/v1/admin/chapters", headers: root });
+    expect(all.json().total).toBe(2);
+    expect(all.json().table).toBe("uploaded");
+
+    const byExtension = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters?extension=chaptertest",
+      headers: root,
+    });
+    expect(byExtension.json().total).toBe(1);
+
+    const byLanguage = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters?language=es",
+      headers: root,
+    });
+    expect(byLanguage.json().total).toBe(1);
+
+    const bySearch = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters?q=beginnings",
+      headers: root,
+    });
+    expect(bySearch.json().total).toBe(2);
+
+    const extensions = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters/extensions",
+      headers: root,
+    });
+    expect(extensions.json().extensions).toEqual(
+      expect.arrayContaining([{ extension: "chaptertest", count: 1 }, { extension: "other", count: 1 }]),
+    );
+  });
+
+  it("shows one chapter across all four archives, with its history and queued work", async () => {
+    await uploaded();
+    await prisma.editedChapter.create({
+      data: {
+        mdChapterId: MD_CHAPTER,
+        extension: "chaptertest",
+        chapterNumber: "1",
+        edits: [{ editedAt: "2026-07-01T00:00:00.000Z", old: { title: "Typo" }, new: { title: "Beginnings" } }],
+      },
+    });
+    const task = await queued({ kind: "EDIT", dedupeKey: MD_CHAPTER, chapter: { mdChapterId: MD_CHAPTER, payload: { volume: "2" } } });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}`,
+      headers: root,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().present).toEqual(expect.arrayContaining(["uploaded", "edited"]));
+    expect(res.json().edits).toHaveLength(1);
+    expect(res.json().queued.map((t: { id: string }) => t.id)).toContain(task.id);
+    expect(res.json().editable).toBe(true);
+    // The MangaDex-shaped starting point for an edit, so the form does not have
+    // to re-derive it from column names.
+    expect(res.json().mdFields).toEqual({
+      volume: "1",
+      chapter: "1",
+      title: "Beginnings",
+      translatedLanguage: "en",
+      groups: [MD_GROUP],
+    });
+
+    const missing = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters/1c2d3e4f-0000-4000-8000-0000000000ff",
+      headers: root,
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  // ---------------------------------------------------- the one write
+
+  it("queues a correction as an EDIT task carrying the diff, the old values and the new chapter", async () => {
+    await uploaded();
+    const session = await sessionAs("OWNER", "owner@example.com");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { chapter: "1.5", title: "Beginnings, Revised" },
+    });
+    expect(res.statusCode).toBe(201);
+
+    const task = await prisma.uploadTask.findFirstOrThrow({ where: { kind: "EDIT" } });
+    expect(task.dedupeKey).toBe(MD_CHAPTER);
+    const chapter = task.chapter as Record<string, unknown>;
+    // The diff MangaDex will be sent…
+    expect(chapter.payload).toEqual({ chapter: "1.5", title: "Beginnings, Revised" });
+    // …the values it had, for the chapter's permanent edit history…
+    expect(chapter.oldInfo).toEqual({
+      volume: "1",
+      chapter: "1",
+      title: "Beginnings",
+      translatedLanguage: "en",
+      groups: [MD_GROUP],
+    });
+    // …and the chapter carrying the NEW values, because on success the uploader
+    // mirrors this payload into uploaded_chapters. Carrying the old ones would
+    // land the edit and leave our mirror describing what it used to say.
+    expect(chapter.chapterNumber).toBe("1.5");
+    expect(chapter.chapterTitle).toBe("Beginnings, Revised");
+    expect(chapter.mdChapterId).toBe(MD_CHAPTER);
+
+    // Nothing was written to the canonical mirror: that happens when the edit
+    // actually lands, not when it is queued.
+    const mirror = await prisma.uploadedChapter.findUniqueOrThrow({ where: { mdChapterId: MD_CHAPTER } });
+    expect(mirror.chapterNumber).toBe("1");
+
+    const audit = await prisma.auditEvent.findFirstOrThrow({ where: { action: "chapter.edit_queued" } });
+    expect(audit.subject).toBe(MD_CHAPTER);
+  });
+
+  it("drops fields that already hold the requested value, and refuses a no-op edit", async () => {
+    await uploaded();
+    const session = await sessionAs("OWNER", "owner@example.com");
+
+    const partial = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      // `volume` is already "1"; only the title actually changes.
+      payload: { volume: "1", title: "New" },
+    });
+    expect(partial.statusCode).toBe(201);
+    expect(partial.json().payload).toEqual({ title: "New" });
+
+    await prisma.uploadTask.deleteMany({});
+    const noop = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { volume: "1", chapter: "1" },
+    });
+    expect(noop.statusCode).toBe(400);
+    expect(await prisma.uploadTask.count()).toBe(0);
+  });
+
+  it("refuses a second queued correction rather than working around the dedupe constraint", async () => {
+    await uploaded();
+    const session = await sessionAs("OWNER", "owner@example.com");
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { title: "One" },
+    });
+    expect(first.statusCode).toBe(201);
+
+    const second = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { title: "Two" },
+    });
+    expect(second.statusCode).toBe(409);
+    expect(second.json().existing.id).toBe(first.json().task.id);
+    expect(await prisma.uploadTask.count({ where: { kind: "EDIT" } })).toBe(1);
+  });
+
+  it("refuses to edit a chapter that has been deleted from MangaDex", async () => {
+    await prisma.deletedChapter.create({
+      data: { mdChapterId: MD_CHAPTER, extension: "chaptertest", chapterNumber: "1", mdGroupId: MD_GROUP },
+    });
+    const session = await sessionAs("OWNER", "owner@example.com");
+
+    const detail = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}`,
+      headers: root,
+    });
+    expect(detail.json().editable).toBe(false);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { title: "Too late" },
+    });
+    // Refused now rather than after a lease, five attempts and a dead letter.
+    expect(res.statusCode).toBe(409);
+    expect(await prisma.uploadTask.count()).toBe(0);
+  });
+
+  it("refuses a group list that drops our own upload group", async () => {
+    await uploaded();
+    const session = await sessionAs("OWNER", "owner@example.com");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { groups: ["aaaaaaaa-0000-4000-8000-000000000000"] },
+    });
+    // MangaDex replaces attribution wholesale; this would detach the chapter
+    // from the catalogue this platform can see.
+    expect(res.statusCode).toBe(422);
+    expect(res.json().uploadGroupId).toBe(MD_GROUP);
+    expect(await prisma.uploadTask.count()).toBe(0);
+
+    // Adding a group alongside ours is fine.
+    const ok = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { groups: [MD_GROUP, "aaaaaaaa-0000-4000-8000-000000000000"] },
+    });
+    expect(ok.statusCode).toBe(201);
+  });
+
+  it("rejects a language MangaDex would not accept, and normalises the case of one it would", async () => {
+    await uploaded();
+    const session = await sessionAs("OWNER", "owner@example.com");
+
+    const bad = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { translatedLanguage: "klingon" },
+    });
+    expect(bad.statusCode).toBe(400);
+
+    const good = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: session,
+      payload: { translatedLanguage: "PT-BR" },
+    });
+    expect(good.statusCode).toBe(201);
+    expect(good.json().payload.translatedLanguage).toBe("pt-br");
+  });
+
+  // ------------------------------------------------------------ authority
+
+  it("keeps queueing a MangaDex write behind the ADMIN role, not merely runs:write", async () => {
+    await uploaded();
+
+    // A CONTRIBUTOR holds neither the role nor runs:write.
+    const contributor = await sessionAs("CONTRIBUTOR", "contrib@example.com");
+    const byContributor = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: contributor,
+      payload: { title: "No" },
+    });
+    expect(byContributor.statusCode).toBe(403);
+
+    // An api-token with runs:write is the Discord bot's shape: it may trigger a
+    // scrape, and that is not the same authority as rewriting a published
+    // chapter.
+    const bot = await mint(["runs:write"]);
+    const byToken = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${MD_CHAPTER}/edit`,
+      headers: bot,
+      payload: { title: "No" },
+    });
+    expect(byToken.statusCode).toBe(403);
+    expect(await prisma.uploadTask.count()).toBe(0);
+
+    // Reading is a different question: runs:read is enough for all three views.
+    const reader = await mint(["runs:read"]);
+    for (const url of ["/api/v1/admin/chapters", "/api/v1/admin/queues/chapters"]) {
+      const res = await app.inject({ method: "GET", url, headers: reader });
+      expect(res.statusCode).toBe(200);
+    }
+  });
+});

--- a/test/unit/dashboardChapters.test.ts
+++ b/test/unit/dashboardChapters.test.ts
@@ -1,0 +1,393 @@
+// @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The three chapter views, actually rendered.
+ *
+ * `dashboard/app.js` is 7 000 lines of vanilla JavaScript that nothing
+ * type-checks and — until this file — nothing executed. The server-side tests
+ * assert it is *served*; `dashboardModules.test.ts` covers the two views that
+ * live in their own ES modules. The shell itself, where a mistyped helper name
+ * is a blank card and a green suite, had no coverage at all.
+ *
+ * So this drives the real file under jsdom against a stubbed API: sign in as an
+ * owner, navigate to each new destination, and assert the chapters actually
+ * appear. It is a smoke test by design — it proves the views mount, ask the
+ * endpoints this branch added, and put the returned chapters on the page. It
+ * deliberately does not assert layout.
+ *
+ * app.js is a classic script for exactly this reason (see its header comment):
+ * jsdom cannot execute module scripts, so it is evaluated here the way a browser
+ * would evaluate it.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any --
+   The DOM lib is deliberately kept out of this program (see the same note in
+   dashboardModules.test.ts), so the jsdom globals are loosely typed in this
+   file only. */
+const doc: any = (globalThis as any).document;
+const win: any = globalThis;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// Resolved from the working directory, not from `import.meta.url`: under the
+// jsdom environment that URL is an http one, and readFileSync wants a path.
+const DASHBOARD = resolve(process.cwd(), "src/core/api/dashboard");
+const APP_JS = join(DASHBOARD, "app.js");
+const INDEX_HTML = join(DASHBOARD, "index.html");
+
+const MD_CHAPTER = "1c2d3e4f-0000-4000-8000-000000000001";
+const MD_MANGA = "9a1b1c1d-0000-4000-8000-000000000000";
+
+/** Canned API responses, keyed by the path prefix the view requests. */
+function apiRoutes(): { match: RegExp; body: unknown }[] {
+  return [
+    { match: /\/session$/, body: { actor: "ardax", role: "OWNER", userId: "u1", email: "a@b.c" } },
+    {
+      match: /\/whoami$/,
+      body: { kind: "session", name: "ardax", role: "OWNER", scopes: ["*"], csrfHeader: "x-requested-with", csrfValue: "publoader-dash" },
+    },
+    { match: /\/stats$/, body: { paused: false, workers: {}, jobs: {}, uploadTasks: [] } },
+    {
+      match: /\/runs\?limit=1/,
+      body: { runs: [{ id: "r1", extension: "mangaplus", state: "PROCESSED", createdAt: "2026-08-01T00:00:00Z" }] },
+    },
+    {
+      match: /\/runs\?limit=50/,
+      body: {
+        runs: [
+          {
+            id: "r1",
+            extension: "mangaplus",
+            kind: "UPDATE",
+            state: "PROCESSED",
+            segmentsTotal: 1,
+            triggeredBy: "scheduler",
+            createdAt: "2026-08-01T00:00:00Z",
+            error: null,
+            chaptersFound: 41,
+            chaptersSeen: 902,
+          },
+        ],
+      },
+    },
+    {
+      match: /\/runs\/r1\/chapters\/summary/,
+      body: {
+        run: { id: "r1", extension: "mangaplus" },
+        set: "updated",
+        segments: [{ jobId: "j1", segmentIndex: 0, segmentKey: "seg0", jobState: "SUCCEEDED", updated: 2, all: null, untrackedManga: 0, submittedAt: "2026-08-01T00:00:00Z" }],
+        segmentsTotal: 1,
+        segmentsReported: 1,
+        complete: true,
+        totals: { updated: 2, all: null, untrackedManga: 0 },
+        byManga: [{ mdMangaId: MD_MANGA, mangaId: "m1", mangaName: "Sakamoto Days", count: 2 }],
+        mangaTitles: 1,
+        mangaCapped: false,
+      },
+    },
+    {
+      match: /\/runs\/r1\/chapters\?/,
+      body: {
+        run: { id: "r1", extension: "mangaplus", state: "PROCESSED" },
+        set: "updated",
+        total: 2,
+        limit: 100,
+        offset: 0,
+        order: "segmentIndex,position",
+        chapters: [
+          {
+            jobId: "j1",
+            segmentIndex: 0,
+            segmentKey: "seg0",
+            position: 1,
+            chapter: { mangaName: "Sakamoto Days", mdMangaId: MD_MANGA, chapterNumber: "142", chapterTitle: "The Duel", chapterLanguage: "en", chapterUrl: "https://example.test/1", mdChapterId: null },
+          },
+          {
+            jobId: "j1",
+            segmentIndex: 0,
+            segmentKey: "seg0",
+            position: 2,
+            chapter: { mangaName: "Sakamoto Days", mdMangaId: MD_MANGA, chapterNumber: "143", chapterTitle: null, chapterLanguage: "en", mdChapterId: MD_CHAPTER },
+          },
+        ],
+      },
+    },
+    {
+      match: /\/runs\/r1$/,
+      body: {
+        run: {
+          id: "r1",
+          extension: "mangaplus",
+          extensionVersion: "1.0.0",
+          bundleSha256: "a".repeat(64),
+          kind: "UPDATE",
+          state: "PROCESSED",
+          createdAt: "2026-08-01T00:00:00Z",
+          jobs: [],
+        },
+      },
+    },
+    {
+      match: /\/queues\/chapters/,
+      body: {
+        total: 2,
+        limit: 100,
+        nextCursor: null,
+        order: "notBefore,createdAt,id",
+        states: ["PENDING"],
+        summary: [],
+        chapters: [
+          {
+            id: "t1",
+            kind: "UPLOAD",
+            state: "PENDING",
+            dedupeKey: "src-1|142|en",
+            attempt: 0,
+            maxAttempts: 5,
+            notBefore: "2026-08-01T00:00:00Z",
+            position: 1,
+            mangaName: "Sakamoto Days",
+            mdMangaId: MD_MANGA,
+            chapterNumber: "142",
+            chapterVolume: "17",
+            chapterTitle: "The Duel",
+            chapterLanguage: "en",
+            mdChapterId: null,
+            editPayload: null,
+            pageCount: 18,
+          },
+          {
+            id: "t2",
+            kind: "EDIT",
+            state: "PENDING",
+            dedupeKey: MD_CHAPTER,
+            attempt: 0,
+            maxAttempts: 5,
+            notBefore: "2026-08-01T00:01:00Z",
+            position: 2,
+            mangaName: "Sakamoto Days",
+            mdMangaId: MD_MANGA,
+            chapterNumber: "141",
+            chapterTitle: "Old title",
+            chapterLanguage: "en",
+            mdChapterId: MD_CHAPTER,
+            editPayload: { title: "Corrected title" },
+            pageCount: 0,
+          },
+        ],
+      },
+    },
+    { match: /\/chapters\/extensions/, body: { table: "uploaded", extensions: [{ extension: "mangaplus", count: 902 }] } },
+    {
+      match: new RegExp(`/chapters/${MD_CHAPTER}$`),
+      body: {
+        chapter: {
+          mdChapterId: MD_CHAPTER,
+          extensionName: "mangaplus",
+          chapterNumber: "141",
+          chapterVolume: "17",
+          chapterTitle: "Old title",
+          chapterLanguage: "en",
+          mangaName: "Sakamoto Days",
+          mdMangaId: MD_MANGA,
+          mdGroupId: "4f1de6a2-f0c5-4ac5-bce5-02c7dbb67deb",
+          imageArtifacts: [],
+        },
+        present: ["uploaded", "edited"],
+        edits: [{ editedAt: "2026-07-01T00:00:00Z", old: { title: "Typo" }, new: { title: "Old title" } }],
+        uploadedAt: "2026-06-01T00:00:00Z",
+        updatedAt: "2026-07-01T00:00:00Z",
+        lastEditedAt: "2026-07-01T00:00:00Z",
+        unavailableAt: null,
+        deletedAt: null,
+        queued: [],
+        mdFields: { volume: "17", chapter: "141", title: "Old title", translatedLanguage: "en", groups: ["4f1de6a2-f0c5-4ac5-bce5-02c7dbb67deb"] },
+        editable: true,
+      },
+    },
+    {
+      match: /\/chapters\?/,
+      body: {
+        table: "uploaded",
+        total: 1,
+        limit: 50,
+        offset: 0,
+        tables: ["uploaded", "edited", "unavailable", "deleted"],
+        chapters: [
+          {
+            mdChapterId: MD_CHAPTER,
+            extensionName: "mangaplus",
+            chapterNumber: "141",
+            chapterVolume: "17",
+            chapterTitle: "Old title",
+            chapterLanguage: "en",
+            mangaName: "Sakamoto Days",
+            mdMangaId: MD_MANGA,
+            at: "2026-07-01T00:00:00Z",
+          },
+        ],
+      },
+    },
+  ];
+}
+
+/** Every path the stub was asked for, so a test can assert what a view fetched. */
+let requested: string[] = [];
+
+function installFetch(): void {
+  const routes = apiRoutes();
+  win.fetch = vi.fn(async (url: string) => {
+    const path = String(url);
+    requested.push(path);
+    const route = routes.find((r) => r.match.test(path));
+    const body = route ? route.body : {};
+    return {
+      // `ok` is what api() branches on; a stub without it makes every call throw
+      // "200 OK" and the page falls back to the sign-in layer.
+      ok: Boolean(route),
+      status: route ? 200 : 404,
+      statusText: route ? "OK" : "Not Found",
+      text: async () => JSON.stringify(body),
+    };
+  });
+}
+
+/** Let the view's promises settle — resources fetch, then redraw. */
+async function settle(times = 6): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const text = (): string => doc.getElementById("view").textContent ?? "";
+
+async function goto(hash: string): Promise<void> {
+  win.location.hash = hash;
+  // jsdom fires hashchange asynchronously; app.js listens for it.
+  await settle();
+}
+
+describe("dashboard chapter views", () => {
+  beforeEach(async () => {
+    requested = [];
+    const html = readFileSync(INDEX_HTML, "utf8");
+    // Body only: the <head> would pull app.js and style.css over the network,
+    // and the script is evaluated by hand below. The markup is this repo's own
+    // checked-in file, not input — this is the shipped page, which is the point.
+    const body = html.split("<body>")[1]?.split("</body>")[0];
+    if (!body) throw new Error("index.html has no <body>: the dashboard shell cannot be mounted");
+    doc.body.innerHTML = body;
+    win.location.hash = "";
+    installFetch();
+
+    // Evaluated rather than imported. app.js is deliberately a classic script
+    // (jsdom cannot execute module scripts) ending in `void boot()`, so this is
+    // how a browser runs it and `boot()` is exactly the entry point under test.
+    // The source is this repo's own file read from disk; nothing is interpolated
+    // into it.
+    new Function(readFileSync(APP_JS, "utf8")).call(win);
+    await settle(10);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  it("signs in and shows the new Chapters destination in the sidebar", () => {
+    expect(doc.getElementById("app").hidden).toBe(false);
+    expect(doc.getElementById("nav").textContent).toContain("Chapters");
+  });
+
+  it("shows how many chapters each run found, in the runs list", async () => {
+    await goto("#/runs/recent");
+    expect(text()).toContain("Chapters found");
+    expect(text()).toContain("41");
+    expect(text()).toContain("of 902 seen");
+  });
+
+  it("lists the chapters a run found, with the per-series breakdown", async () => {
+    await goto("#/runs/r1");
+    expect(requested.some((path) => path.includes("/runs/r1/chapters?"))).toBe(true);
+    expect(requested.some((path) => path.includes("/runs/r1/chapters/summary"))).toBe(true);
+    expect(text()).toContain("Chapters found");
+    // The chapters themselves, not just the counts.
+    expect(text()).toContain("The Duel");
+    expect(text()).toContain("143");
+    // And the coverage line that says the list can be trusted as whole.
+    expect(text()).toContain("segments reported");
+  });
+
+  it("lists the queue as chapters, numbered in claim order", async () => {
+    await goto("#/queues/chapters");
+    expect(requested.some((path) => path.includes("/queues/chapters"))).toBe(true);
+    const view = text();
+    expect(view).toContain("Sakamoto Days");
+    expect(view).toContain("142");
+    // An EDIT row shows what it will change rather than the title it carries.
+    expect(view).toContain("title → Corrected title");
+    expect(view).toContain("claim order");
+  });
+
+  it("defaults the Queues page to the chapter view", async () => {
+    await goto("#/queues");
+    await settle();
+    // The tab is resolved into the canonical hash, so a bookmark of `#/queues`
+    // lands on the chapter list rather than the row list.
+    expect(win.location.hash).toBe("#/queues/chapters");
+  });
+
+  it("browses the chapter archive and opens one chapter in full", async () => {
+    await goto("#/chapters");
+    expect(text()).toContain("Sakamoto Days");
+    expect(text()).toContain("Old title");
+
+    await goto(`#/chapters/${MD_CHAPTER}`);
+    const view = text();
+    expect(view).toContain("Edit metadata");
+    expect(view).toContain("Edit history");
+    // The archives this chapter appears in, and the history entry.
+    expect(view).toContain("UPLOADED");
+    expect(view).toContain("title → ");
+  });
+
+  it("opens the correction form prefilled with what MangaDex currently holds", async () => {
+    await goto(`#/chapters/${MD_CHAPTER}`);
+    const button = [...doc.querySelectorAll("button")].find((b: { textContent: string }) =>
+      b.textContent === "Edit metadata",
+    );
+    expect(button).toBeTruthy();
+    button.click();
+    await settle();
+
+    const dialog = doc.getElementById("modal-body");
+    expect(dialog.textContent).toContain("does not change MangaDex directly");
+    expect(doc.getElementById("md-edit-chapter").value).toBe("141");
+    expect(doc.getElementById("md-edit-title").value).toBe("Old title");
+    expect(doc.getElementById("md-edit-translatedLanguage").value).toBe("en");
+  });
+
+  it("sends only the fields that changed, as a MangaDex-shaped body", async () => {
+    await goto(`#/chapters/${MD_CHAPTER}`);
+    [...doc.querySelectorAll("button")]
+      .find((b: { textContent: string }) => b.textContent === "Edit metadata")
+      .click();
+    await settle();
+
+    doc.getElementById("md-edit-title").value = "Corrected title";
+    [...doc.querySelectorAll("#modal-body button")]
+      .find((b: { textContent: string }) => b.textContent === "Queue the correction")
+      .click();
+    await settle();
+
+    const call = win.fetch.mock.calls.find(
+      ([url]: [string]) => String(url).includes(`/chapters/${MD_CHAPTER}/edit`),
+    );
+    expect(call).toBeTruthy();
+    expect(call[1].method).toBe("POST");
+    // `volume` and `chapter` were left alone, so they are not in the body —
+    // a form that submitted all four would write "unchanged" edits into the
+    // chapter's permanent history.
+    expect(JSON.parse(call[1].body)).toEqual({ title: "Corrected title" });
+  });
+});


### PR DESCRIPTION
The dashboard modelled the pipeline — runs produce jobs produce queue rows — and dropped the thread the moment a chapter was published. Three questions had no answer short of `psql`.

## What this adds

**What a run found** — `GET /runs/:id/chapters` + `/chapters/summary`, and a chapters-found column on the runs list. Read back out of the stored result envelopes rather than copied into a table on ingest (up to 20k rows a segment, one human reader, and a second write path to keep honest); Postgres unnests on demand so the envelope stays the source of truth. A segment with no committed envelope reports `null`, not `0` — a run that half failed must not read as a run that found one chapter.

**What is about to go up, in order** — `GET /queues/chapters`, the same rows as `/queues/tasks` projected through the chapter payload, so the queue names a series and a chapter number instead of `1015117|142|en`. `position` comes from a window function over the claim ordering, so it is the place in the whole filtered queue rather than on the page, and it tracks a reorder. **This is now the default tab on Queues**; the row view is one click away and is still where incident work happens.

**What is on MangaDex, correctable** — a new Chapters destination over the four chapter archives, and `POST /chapters/:id/edit`. The edit does not talk to MangaDex: it enqueues the same `EDIT` task the processor writes on drift, so the write happens in `core-uploader` and is amendable on the Queues page until claimed. The task carries the new values on its chapter as well as the diff, because the uploader mirrors that chapter into `uploaded_chapters` on success.

Five refusals on the edit path, each protecting something hard to undo: an api token (session + ADMIN only), a no-op edit, a second queued edit, a deleted chapter, and a `groups` list omitting our own upload group.

## Tests

18 integration tests against real Postgres — the `jsonb` unnest and the window function *are* the system under test. Plus 8 tests that execute `dashboard/app.js` under jsdom, the first coverage that file has ever had. 850 passing, typecheck and lint clean.

## One thing for you to decide

`requireAdminRole` in `routes/queues.ts` (hand-enqueue) does not actually exclude api tokens: `adminAuthHook` assigns every scoped `pa_…` token `adminRole = "ADMIN"`, so the role test passes. A test comment in `queues.test.ts:1013` records this deliberately, so I left it alone. The equivalent guard on the new edit endpoint **does** refuse tokens (`routes/chapters.ts`), matching `requireApplyRole` in `ops.ts`. Worth deciding whether the two should agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)