### PR TITLE
Chapter management: edit, take down, or delete chapters already on MangaDex — singly or in bulk

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -453,6 +453,35 @@ that has not happened yet.
 | `POST` | `/chapters/:mdChapterId/unavailable` | `chapters:write` + ADMIN | `{force?, footerNote?}`. Queues an `UNAVAILABLE`: render the card, attach it as the chapter's only page, repoint `externalUrl`, archive the row. **`409` when the chapter is already marked unavailable unless `force: true`** — without the flag the uploader treats it as done and changes nothing, which would make a wrong card unfixable |
 | `DELETE` | `/chapters/:mdChapterId` | `chapters:write` + ADMIN | `{confirm: true, reason?}`. Queues a `DELETE`. **`400` without `confirm`**, and the refusal names the unavailable route as the reversible alternative. The whole row goes into the audit detail, because afterwards `deleted_chapters` and that entry are the only records the chapter existed |
 
+The same three actions over a set of chapters:
+
+| Method | Path | Scope | Notes |
+| --- | --- | --- | --- |
+| `POST` | `/chapters/bulk/edit` | `chapters:write` + ADMIN | `{ids?, filter?, changes: {volume?, translatedLanguage?, groups?}, dryRun?, confirm?}`. **The fields are a subset of the single-chapter edit on purpose**: a title, a chapter number and an external URL are one chapter's identity, so they are not expressible here. `oldInfo` is taken from our own rows rather than 200 live MangaDex reads; the uploader still merges against the live resource when it runs |
+| `POST` | `/chapters/bulk/unavailable` | `chapters:write` + ADMIN | `{ids?, filter?, force?, footerNote?, dryRun?, confirm?}`. Cards are rendered per chapter from that chapter's own details |
+| `POST` | `/chapters/bulk/delete` | `chapters:write` + ADMIN | `{ids?, filter?, reason?, dryRun?, confirm?}`. The whole row goes into each chapter's audit entry |
+
+Three rules hold across all three:
+
+- **Exactly one of `ids` or `filter`.** `filter` takes the list's own fields plus
+  `archive` (default `uploaded`); `ids` is capped at 200 by the schema.
+- **`dryRun` defaults to `true`.** The first call anyone makes — including a
+  client that forgot the field — writes nothing, queues nothing, audits nothing,
+  and returns a per-chapter prediction: `would_queue`, or the same refusal the
+  live call would give (`not_found`, `deleted`, `needs_force`, `already_queued`,
+  `leased`). A live run needs `dryRun: false` **and** `confirm: true`. It is a
+  preview of the operation, not an estimate of it.
+- **200 chapters per call**, lower than the 1000 of `/queues/*` because this cap
+  bounds a change to public pages rather than to queue rows. A truncated set
+  answers `capped: true` and the operator calls again.
+
+A live bulk call answers **`200`** (not `202`) with `{queued, refused, results}` —
+a batch where eight chapters queued and two were refused is a success and a
+partial failure at once, and only the per-chapter results say which is which.
+Each queued chapter gets **its own audit event** (subject = the chapter id,
+detail carrying a shared `bulk` id) plus one `<action>.bulk` summary row, so
+"why was this chapter deleted?" stays answerable by subject.
+
 Two refusals are worth knowing about:
 
 - **`409` `already_queued` / `leased`.** One queue slot per (kind, chapter): a

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -255,11 +255,12 @@ route writes an audit event naming the acting principal.
 
 ### Scopes
 
-The nineteen valid scopes (`api/scopes.ts:20-45`):
+The twenty-one valid scopes (`api/scopes.ts:20-52`):
 
 | Area | Scopes |
 | --- | --- |
 | runs | `runs:read` `runs:write` |
+| published chapters | `chapters:read` `chapters:write` |
 | workers | `workers:read` `workers:write` `enroll:write` |
 | extensions | `extensions:read` `extensions:write` |
 | series map | `tracked:read` `tracked:append` `tracked:write` |
@@ -272,6 +273,13 @@ The nineteen valid scopes (`api/scopes.ts:20-45`):
 **Implication** (`scopes.ts:91-101`): `write` implies `append` implies `read`,
 within one area only. Nothing else implies anything, so `users:admin` grants only
 itself and a token scoped for account management cannot quietly publish bundles.
+
+`chapters:*` is separate from `runs:*` on purpose. `runs:*` is about scraping and
+the queue that drains from it; `chapters:write` queues an edit, a takedown or a
+delete against a live public catalogue entry. A credential that may trigger a run
+does not thereby get to unpublish chapters — and `chapters:write` is not enough
+on its own either: every mutating chapter route also requires the ADMIN role and
+refuses api tokens outright (see *Published chapters* below).
 
 `tracked:*` is deliberately split three ways, and the middle one is the point.
 `tracked:append` can create mappings that do not exist yet — the worst case is a
@@ -426,6 +434,41 @@ is logged even if the publish then fails for another reason).
 | `POST` | `/upload-tasks/requeue-stale` | `runs:write` | Manual lease sweep → `{ok, requeued}` |
 
 `routes/ops.ts:103-217`, tested at `test/integration/ops.test.ts`.
+
+### Published chapters
+
+What the platform has put on MangaDex, and the three things an operator can do to
+a chapter afterwards. **Nothing here writes to MangaDex.** Every action queues an
+`UploadTask` and answers **`202`** with the task — `core-uploader` is the only
+process holding write credentials, and a `200` here would be claiming a change
+that has not happened yet.
+
+| Method | Path | Scope | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/chapters` | `chapters:read` | `?archive=uploaded\|unavailable\|deleted\|edited` (default `uploaded`), `?extension=`, `?language=`, `?mdMangaId=`, `?mdChapterId=`, `?chapterId=`, `?chapterNumber=`, `?search=`, `?since=`, `?until=`, `?limit=1..200` (50), `?cursor=` → `{archive, chapters, total, nextCursor, order, totals, archives}`. Newest first, **keyset** paged: the table grows while it is read, so an offset page would repeat rows. `search` covers the series name, the chapter title and all four ids. `totals` is global, so a narrow filter cannot hide an archive that is filling up |
+| `GET` | `/chapters/extensions` | `chapters:read` | `?archive=` → `{extensions: [{extension, count}]}` — what the filter picker offers |
+| `GET` | `/chapters/:mdChapterId` | `chapters:read` | The row from whichever archives hold it, `archives` (when each recorded it), `edits`, `tasks` (queue rows keyed on this chapter), `links`, and **`mangadex`**: what MangaDex says right now, when this instance has credentials. A MangaDex outage degrades to `mangadex: null` + `mangadexError` and never makes the row unreadable. `actionsBlockedReason` is why a mutating call would be refused, so a UI can disable a control *with the reason* |
+| `GET` | `/chapters/:mdChapterId/card.png` | `chapters:read` | `?footerNote=`, `?unavailableAt=` → **`image/png`**. The unavailable card as it would be posted, rendered by the same function the uploader calls (`md/unavailableCard.ts`). Writes and queues nothing |
+| `PATCH` | `/chapters/:mdChapterId` | `chapters:write` + ADMIN | `{volume?, chapter?, title?, translatedLanguage?, groups?, externalUrl?}` — MangaDex's own field names, `null` clears, omitted leaves alone. Queues an `EDIT` carrying `payload` and `oldInfo`. The merge onto MangaDex's current resource happens at execution time, because `PUT /chapter` replaces rather than patches and needs the `version` current when the write lands. `400` unknown field / bad language / bad URL |
+| `POST` | `/chapters/:mdChapterId/unavailable` | `chapters:write` + ADMIN | `{force?, footerNote?}`. Queues an `UNAVAILABLE`: render the card, attach it as the chapter's only page, repoint `externalUrl`, archive the row. **`409` when the chapter is already marked unavailable unless `force: true`** — without the flag the uploader treats it as done and changes nothing, which would make a wrong card unfixable |
+| `DELETE` | `/chapters/:mdChapterId` | `chapters:write` + ADMIN | `{confirm: true, reason?}`. Queues a `DELETE`. **`400` without `confirm`**, and the refusal names the unavailable route as the reversible alternative. The whole row goes into the audit detail, because afterwards `deleted_chapters` and that entry are the only records the chapter existed |
+
+Two refusals are worth knowing about:
+
+- **`409` `already_queued` / `leased`.** One queue slot per (kind, chapter): a
+  `PENDING` task is not silently rewritten, and a `LEASED` one belongs to a live
+  uploader. A task that has *finished* is superseded in place and the response
+  says `superseded: true` — without that a chapter could be edited exactly once,
+  ever, since nothing deletes `DONE` rows.
+- **`403` for api tokens.** Changing a public catalogue entry under the shared
+  MangaDex account is attributable to a signed-in operator or nothing, so these
+  routes are closed to `pa_…` credentials however broadly they are scoped —
+  every api token carries `adminRole = "ADMIN"`, which means "not
+  owner-equivalent", not "vetted human". The break-glass `ADMIN_TOKEN` is a
+  `root` principal and still works.
+
+`routes/chapters.ts`, `store/chapters.ts`, tested at
+`test/integration/chapters.test.ts`.
 
 ### MangaDex session
 

--- a/docs/architecture-guide.md
+++ b/docs/architecture-guide.md
@@ -121,7 +121,7 @@ and one for the worker (`docker/worker/Dockerfile`).
 
 | Service | Entry point | Loop | Interval | Needs MD creds? | Replicas |
 | --- | --- | --- | --- | --- | --- |
-| `core-api` | `src/services/api.ts` | none — Fastify listener | — | optional (only so operator title approvals can run synchronously) | 1+ |
+| `core-api` | `src/services/api.ts` | none — Fastify listener | — | optional, and **reads only**: operator title approvals run synchronously, and the chapter views show the live MangaDex state and preview the unavailable card. Chapter changes are queued for the uploader | 1+ |
 | `core-scheduler` | `src/services/scheduler.ts` | `scheduler.tick()` | `SCHEDULER_INTERVAL_SECONDS`, 30 s | no | **exactly 1** by convention; racing is harmless |
 | `core-processor` | `src/services/processor.ts` | `processor.tick()` | 15 s (`INTERVAL_SECONDS`, a module constant) | yes — reads MangaDex | 1; several are safe |
 | `core-uploader` | `src/services/uploader.ts` | drain queues + `titles.tick()` | event-driven, 5 s idle sleep | **yes — write credentials** | **exactly 1** (MangaDex sessions are per-account) |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -143,7 +143,7 @@ leak an id into an access log.
 | **Activity** | `runs:read` | One time-ordered feed merged across runs, jobs, upload tasks, quarantine and the audit log, filtered by severity, time window, extension and free text. Every row links to the thing it is about and offers a permalink. |
 | **Errors** | `runs:read` | *Failures*: everything that failed, newest first, across all three sources. *Quarantine*: result envelopes the core refused to believe — the security-relevant queue, not just an error queue. A non-zero quarantine count also shows as a red badge on Errors in the sidebar. |
 | **Extensions** | `extensions:read` | The published-bundle list, the chapter removal mode, and the publish drop zone. Opening one gives *Overview* (its bundle, its curation counts, and its runs, jobs, upload tasks and quarantine on one screen — the join is the point: green runs beside red upload tasks is the diagnosis), *Series map*, *Schedule*, *Config*, and *Versions* (every version ever published, with yank). |
-| **Chapters** | `chapters:read` | Every chapter this platform has published, in four archives — *On MangaDex*, *Unavailable*, *Deleted*, *Edited* — filtered by extension, language, chapter number and a search that matches the series name, the chapter title and any of the four ids. Opening one shows our row beside what MangaDex says right now, anything already queued against it, and its edit history, with the three actions: edit the metadata, replace it with an unavailable card (previewed first), or delete it. See below. |
+| **Chapters** | `chapters:read` | Every chapter this platform has published, in four archives — *On MangaDex*, *Unavailable*, *Deleted*, *Edited* — filtered by extension, language, chapter number and a search that matches the series name, the chapter title and any of the four ids. Opening one shows our row beside what MangaDex says right now, anything already queued against it, and its edit history, with the three actions: edit the metadata, replace it with an unavailable card (previewed first), or delete it. The same three run in bulk over ticked rows or over the whole filter. See below. |
 | **Tracked** | `tracked:read` | The series map across every extension: how many mappings each has and the most recent one, linking into the map that can be edited. There is no cross-extension endpoint, so this is an index rather than a merged table. |
 | **Untracked** | `untracked:read` | Series an extension reported that have no mapping yet, filtered by state. Opening one gives its details **editable** — see below. Approve creates the MangaDex title; skip never does. |
 | **Workers** | `workers:read` | *Fleet*: status, trust tier, heartbeat, agent version, which extensions each worker takes, with drain / activate / revoke. *Enrolment*: mint a one-time token and copy the compose snippet that uses it. |
@@ -407,7 +407,31 @@ the result appears under Queues within seconds.
   (recorded in the audit trail), states that marking the chapter unavailable is
   the reversible alternative, and needs an explicit confirmation.
 
-All three need the **ADMIN** role on top of `chapters:write`, and all three are
+### The same three, in bulk
+
+Tick rows on the list and a bar appears above it with the same three actions.
+The **whole filter** toggle switches them from the ticked rows to every chapter
+the current filter matches — which is how "this series was licensed, take the lot
+down" and "that run got the volume wrong on fifty chapters" are one click each.
+
+Each button opens a dialog that **previews before it offers to apply**. The
+preview is the server's own dry run: it names every chapter in the set, says what
+would happen to each, and lists the ones it would refuse (already carded and no
+`force`, already queued, claimed by an uploader, already deleted). The apply
+button stays disabled until that preview has been fetched, and says how many
+chapters it will queue. One call, one preview, and 200 chapters at a time — a
+wider filter says so and is run again for the rest.
+
+A bulk edit offers only **volume**, **language** and **groups**: the fields a set
+of chapters can share. A title or a chapter number belongs to one chapter, so
+those stay on the single-chapter form rather than being applicable two hundred
+times by accident.
+
+Afterwards the toast reports how many queued and how many were refused, and the
+refusals are listed with their reasons — a batch is routinely a success and a
+partial failure at once.
+
+All of these need the **ADMIN** role on top of `chapters:write`, and all are
 closed to `pa_…` api tokens however broadly they are scoped: changing a public
 catalogue entry under the shared MangaDex account is attributable to a signed-in
 operator or nothing. The buttons are disabled with the server's own reason rather

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -143,6 +143,7 @@ leak an id into an access log.
 | **Activity** | `runs:read` | One time-ordered feed merged across runs, jobs, upload tasks, quarantine and the audit log, filtered by severity, time window, extension and free text. Every row links to the thing it is about and offers a permalink. |
 | **Errors** | `runs:read` | *Failures*: everything that failed, newest first, across all three sources. *Quarantine*: result envelopes the core refused to believe — the security-relevant queue, not just an error queue. A non-zero quarantine count also shows as a red badge on Errors in the sidebar. |
 | **Extensions** | `extensions:read` | The published-bundle list, the chapter removal mode, and the publish drop zone. Opening one gives *Overview* (its bundle, its curation counts, and its runs, jobs, upload tasks and quarantine on one screen — the join is the point: green runs beside red upload tasks is the diagnosis), *Series map*, *Schedule*, *Config*, and *Versions* (every version ever published, with yank). |
+| **Chapters** | `chapters:read` | Every chapter this platform has published, in four archives — *On MangaDex*, *Unavailable*, *Deleted*, *Edited* — filtered by extension, language, chapter number and a search that matches the series name, the chapter title and any of the four ids. Opening one shows our row beside what MangaDex says right now, anything already queued against it, and its edit history, with the three actions: edit the metadata, replace it with an unavailable card (previewed first), or delete it. See below. |
 | **Tracked** | `tracked:read` | The series map across every extension: how many mappings each has and the most recent one, linking into the map that can be edited. There is no cross-extension endpoint, so this is an index rather than a merged table. |
 | **Untracked** | `untracked:read` | Series an extension reported that have no mapping yet, filtered by state. Opening one gives its details **editable** — see below. Approve creates the MangaDex title; skip never does. |
 | **Workers** | `workers:read` | *Fleet*: status, trust tier, heartbeat, agent version, which extensions each worker takes, with drain / activate / revoke. *Enrolment*: mint a one-time token and copy the compose snippet that uses it. |
@@ -363,6 +364,54 @@ language** and **Source URL** editable:
 The order this is designed around is: **fix the details, then approve.** A row
 whose title already exists shows a banner saying local edits do not reach
 MangaDex until they are applied.
+
+---
+
+## Fixing a chapter that is already on MangaDex
+
+`#/chapters` is the mirror of what the platform has published. It answers the
+question that used to mean `psql` on the core container — *which MangaDex chapter
+is this, is it still up, and what did we think it was?* — and then lets you change
+it.
+
+Opening one chapter (`#/chapters/<md chapter id>`) puts three things side by side:
+
+- **our row**, written when the chapter was published;
+- **what MangaDex says right now**, read live when the API instance holds
+  credentials. This is the one that decides anything: our row is a mirror that
+  may be days old while you are about to change a public entry. When MangaDex
+  cannot be read the panel says why, and every action still works — the uploader
+  reads MangaDex itself when it runs them;
+- **what is already queued** against the chapter, so you do not queue a second
+  change on top of somebody else's.
+
+The three actions all **queue an upload task** and say so. `core-uploader` is the
+only process holding MangaDex credentials; nothing is applied by the click, and
+the result appears under Queues within seconds.
+
+- **Edit metadata** takes MangaDex's own field names — volume, chapter, title,
+  language, groups, external URL — prefilled from the live values and sending
+  only what you actually changed. Blanking a field clears it; blanking the
+  language leaves it alone, because a chapter always has one.
+- **Mark unavailable** replaces the chapter's page with the info card explaining
+  the publisher removed it, and repoints the publisher link away from the dead
+  URL. **The card is previewed in the dialog first**, rendered by the same code
+  the uploader posts, so what you approve is what readers get. A footer note
+  replaces the standard wording for a takedown whose reason is not "the
+  publisher removed it".
+- **Regenerate the unavailable card** is the same button on a chapter that
+  already carries one, and it is why the underlying task has a `force` flag:
+  without it the uploader treats an archived chapter as done and would change
+  nothing, leaving a card that says the wrong thing on a public page forever.
+- **Delete from MangaDex** is the one irreversible action. It asks for a reason
+  (recorded in the audit trail), states that marking the chapter unavailable is
+  the reversible alternative, and needs an explicit confirmation.
+
+All three need the **ADMIN** role on top of `chapters:write`, and all three are
+closed to `pa_…` api tokens however broadly they are scoped: changing a public
+catalogue entry under the shared MangaDex account is attributable to a signed-in
+operator or nothing. The buttons are disabled with the server's own reason rather
+than hidden, so a contributor can see that the operation exists and who to ask.
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -297,8 +297,8 @@ The MangaDex work queue.
 
 | Column | Meaning |
 | --- | --- |
-| `kind` + `dedupe_key` **unique together** | The idempotency guard. Insertion is `ON CONFLICT DO NOTHING` (`store/uploadTasks.ts:32`), so re-processing a run is a no-op for already-queued chapters. Dedupe keys differ by kind: `UPLOAD` uses `chapterId|chapterNumber|chapterLanguage` (`uploadTasks.ts:15-21`), `EDIT`/`DELETE`/`UNAVAILABLE` use the MangaDex chapter id (`core/processor/processor.ts:219`, `490`). |
-| `chapter` | JSONB. **Stays JSONB, and the asymmetry with the four chapter tables is deliberate** (documented at `schema.prisma:228-235`): this is a transient payload consumed once by one worker and never queried by field, and it is *not* the canonical chapter shape — `EDIT` rows carry `payload`/`oldInfo` and `UNAVAILABLE` rows carry `unavailableAt` alongside the chapter, which typed columns would have to model as a union. |
+| `kind` + `dedupe_key` **unique together** | The idempotency guard. Insertion is `ON CONFLICT DO NOTHING` (`store/uploadTasks.ts:32`), so re-processing a run is a no-op for already-queued chapters. Dedupe keys differ by kind: `UPLOAD` uses `chapterId\|chapterNumber\|chapterLanguage` (`uploadTasks.ts:15-21`), `EDIT`/`DELETE`/`UNAVAILABLE` use the MangaDex chapter id (`core/processor/processor.ts:219`, `490`). **One slot per (kind, chapter), forever**: nothing deletes `DONE` rows, so an operator action on an already-actioned chapter resets the settled row in place instead of inserting (`uploadTasks.requeueForChapter`), which is refused for a `PENDING` or `LEASED` row and never accepted for `UPLOAD` — that would re-arm a double upload. |
+| `chapter` | JSONB. **Stays JSONB, and the asymmetry with the four chapter tables is deliberate** (documented at `schema.prisma:228-235`): this is a transient payload consumed once by one worker and never queried by field, and it is *not* the canonical chapter shape — `EDIT` rows carry `payload`/`oldInfo` and `UNAVAILABLE` rows carry `unavailableAt` (plus `force` and `footerNote` when an operator asked for a fresh card) alongside the chapter, which typed columns would have to model as a union. |
 | `state`, `attempt`, `max_attempts` (5), `not_before` | Retry budget, backoff. |
 | `lease_id`, `lease_expires_at` | Same SKIP LOCKED lease pattern as jobs, so multiple uploader processes would be safe (`uploadTasks.ts:38-60`). |
 | `last_error` | Failure reason, or the operator's cancellation note. |
@@ -359,6 +359,13 @@ Per-table differences:
 | `edited_chapters` | `edits` JSONB (default `[]`), `last_edited_at` | none beyond the unique key | `edits` **stays JSONB**: an append-only `{editedAt, old, new}` history of genuinely variable length and shape that nothing queries into (`schema.prisma:317-319`). |
 | `unavailable_chapters` | `unavailable_at` | none beyond the unique key | `extra` also holds `mdAttributes`, the chapter as MangaDex had it at takedown — an external API resource, not our shape. |
 | `deleted_chapters` | `deleted_at` | `(extension)` | Deletion is the one irreversible action the platform takes, so the record of what was removed outlives it (`schema.prisma:353-356`). Written *before* the live row is dropped (`taskWorkers.ts:341-350`). |
+
+All four are readable through `GET /api/v1/admin/chapters?archive=…`
+(`store/chapters.ts`), which is what makes them operator-facing rather than
+forensic: one parameterised query serves all four precisely because they share a
+shape, and the only difference the reader sees is which instant dates the row
+(`created_at`, `unavailable_at`, `deleted_at`, `last_edited_at`). Writes still go
+through the upload queue — the API process never touches MangaDex.
 
 ### `uploaded_ids` (canonical)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1114,6 +1114,54 @@ curl -s -X DELETE -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: appl
   "$API/api/v1/admin/chapters/$MD_CHAPTER_ID"
 ```
 
+### Do it to a whole set
+
+The same three actions take a set of chapters — either a list of ids, or a
+filter (`?archive=`, `extension`, `language`, `mdMangaId`, `chapterNumber`,
+`search`, `since`, `until`). The realistic cases are "this series was licensed,
+take the lot down" and "that run uploaded fifty chapters under the wrong volume".
+
+**Every bulk call is a dry run unless you say otherwise.** With no flags it
+writes nothing, queues nothing, audits nothing, and returns a per-chapter
+prediction — including the chapters it would refuse and why. Read that list;
+it is the last chance anyone gets.
+
+```bash
+# what would happen (this is inert)
+curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"filter":{"mdMangaId":"'"$MD_MANGA_ID"'"}}' \
+  "$API/api/v1/admin/chapters/bulk/unavailable" | jq '{matched, wouldQueue, blocked, capped, results}'
+
+# then, and only then
+curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"filter":{"mdMangaId":"'"$MD_MANGA_ID"'"},"dryRun":false,"confirm":true,
+       "footerNote":"Licensed; removed at the publisher'"'"'s request."}' \
+  "$API/api/v1/admin/chapters/bulk/unavailable" | jq '{queued, refused, results}'
+```
+
+A bulk **edit** only takes the fields a set of chapters can legitimately share —
+`volume`, `translatedLanguage`, `groups`. A title, a chapter number or a source
+URL belongs to one chapter, so those stay on the single-chapter route rather than
+being available to apply two hundred times by accident.
+
+```bash
+curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"filter":{"mdMangaId":"'"$MD_MANGA_ID"'"},"changes":{"volume":"3"},"dryRun":false,"confirm":true}' \
+  "$API/api/v1/admin/chapters/bulk/edit"
+```
+
+**200 chapters per call.** A wider filter answers `capped: true`; run it again
+for the rest. The response is a `200` with `queued`, `refused` and a result per
+chapter — a batch is routinely a success and a partial failure at once, and the
+per-chapter rows are the part to act on. Each queued chapter also gets its own
+audit event, correlated by a shared `bulk` id, so the history of one chapter
+still explains itself.
+
+In the dashboard this is the tick-boxes on the Chapters list plus the bar above
+it; the **whole filter** toggle switches the buttons from the ticked rows to
+everything the current filter matches. Each button opens a dialog that previews
+first and only then offers to queue.
+
 ### When it refuses
 
 | Answer | Meaning |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1021,6 +1021,112 @@ superseded and is not going away:
 
 ---
 
+## Fix a chapter that is already published
+
+The queue endpoints above act on *work that has not run yet*. This section is the
+other case: the chapter is on MangaDex, and it is wrong.
+
+Everything here goes through `/api/v1/admin/chapters/*` (Chapters in the
+dashboard), and every action **queues an upload task** rather than calling
+MangaDex — `core-uploader` remains the only process with write credentials, so
+the response is `202` with a task id and the change lands within seconds. Watch
+it under Queues, filtered to that chapter id.
+
+Two guards apply to all three actions: the **ADMIN** role on top of
+`chapters:write`, and no api tokens at all. Use the dashboard, or the break-glass
+`ADMIN_TOKEN`.
+
+### Find the chapter
+
+```bash
+# by anything: series name, chapter title, or any of the four ids
+curl -s -H "authorization: Bearer $ADMIN_TOKEN" \
+  "$API/api/v1/admin/chapters?search=$(printf %s 'Series Name' | jq -sRr @uri)" | jq '.chapters[]'
+
+# everything one extension has up
+curl -s -H "authorization: Bearer $ADMIN_TOKEN" \
+  "$API/api/v1/admin/chapters?extension=mangaplus&limit=200" | jq '.total'
+```
+
+`?archive=unavailable|deleted|edited` reads the three history tables with the
+same filters. Paging is by the `nextCursor` the response hands back, never an
+offset — the table grows while it is being read.
+
+Then open one chapter, which is the read worth doing before any change: it shows
+our row, **what MangaDex says right now**, and anything already queued against it.
+
+```bash
+curl -s -H "authorization: Bearer $ADMIN_TOKEN" \
+  "$API/api/v1/admin/chapters/$MD_CHAPTER_ID" | jq '{chapter, mangadex, mangadexError, tasks, archives}'
+```
+
+### Correct its metadata
+
+The body uses MangaDex's field names; `null` clears a field and an omitted field
+is left alone. The uploader lays this over MangaDex's current resource when it
+runs, because `PUT /chapter` replaces rather than patches and needs the version
+current at that moment.
+
+```bash
+curl -s -X PATCH -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"chapter":"12.1","title":"The right title"}' \
+  "$API/api/v1/admin/chapters/$MD_CHAPTER_ID"
+```
+
+### Replace it with an unavailable card
+
+The chapter keeps its place on MangaDex; its page becomes the card and the
+publisher link is repointed away from the dead URL. Preview the exact image
+first — the endpoint renders it with the same code the uploader posts:
+
+```bash
+curl -s -H "authorization: Bearer $ADMIN_TOKEN" \
+  "$API/api/v1/admin/chapters/$MD_CHAPTER_ID/card.png" > /tmp/card.png
+
+curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"footerNote":"Removed at the publisher'"'"'s request."}' \
+  "$API/api/v1/admin/chapters/$MD_CHAPTER_ID/unavailable"
+```
+
+**Regenerating a card that is already posted needs `force: true`.** Without it
+the uploader sees a chapter with nothing left to take down and correctly does
+nothing, which is right for the automated pass and useless when the card on a
+public page says the wrong thing. Asking without the flag is a `409` that says
+so, rather than a silent no-op.
+
+```bash
+curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"force":true,"footerNote":"Corrected wording."}' \
+  "$API/api/v1/admin/chapters/$MD_CHAPTER_ID/unavailable"
+```
+
+### Delete it
+
+The one irreversible action. `confirm: true` is required, the reason goes into
+the audit trail, and the whole row is copied into that audit entry — after the
+uploader runs, it and `deleted_chapters` are the only records the chapter
+existed. Prefer the unavailable card unless the chapter should never have been
+published at all (a duplicate, a wrong series).
+
+```bash
+curl -s -X DELETE -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"confirm":true,"reason":"duplicate of ch. 12"}' \
+  "$API/api/v1/admin/chapters/$MD_CHAPTER_ID"
+```
+
+### When it refuses
+
+| Answer | Meaning |
+|---|---|
+| `409 already_queued` | A task of that kind for this chapter is queued and has not run. Look at it under Queues — edit or remove it there rather than stacking a second one. |
+| `409 leased` | An uploader is executing that action right now. Wait for it and read the result before deciding again. |
+| `409 already_unavailable` | The card is already posted; pass `force: true` to replace it. |
+| `409` naming a deletion | The chapter is recorded as deleted, so there is nothing left to change. If MangaDex still has it, the archive row is stale — queue the task by hand from `/admin/queues/tasks`. |
+| `403` closed to api tokens | Use the dashboard as a signed-in admin, or the break-glass admin token. |
+| `superseded: true` in a `202` | Normal. A completed task for this chapter was reset in place, because nothing deletes `DONE` rows and the slot is one per (kind, chapter). |
+
+---
+
 ## Clear a bad MangaDex session
 
 The MangaDex token pair lives in the `settings` table (`mdauth_access` /

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -51,11 +51,11 @@ not how much you personally trust the person running it.
 
 | | |
 |---|---|
-| **Assets** | Every control operation: trigger runs, publish bundles, pause, drain/revoke workers, mint enroll tokens, change removal mode, edit the tracked-manga mapping and extension override options (the config authority), and approve untracked series into new MangaDex titles. |
+| **Assets** | Every control operation: trigger runs, publish bundles, pause, drain/revoke workers, mint enroll tokens, change removal mode, edit the tracked-manga mapping and extension override options (the config authority), approve untracked series into new MangaDex titles, and queue edits, takedowns or deletions of chapters already published. |
 | **Trust level** | Operator-only. Effectively equivalent to shell access to the control plane. |
 | **Authn/authz** | Single bearer token. `X-Actor` header is **attribution, not authentication** — it is attacker-controlled and only meaningful because possession of the token is already proven. |
 | **Network exposure** | Through the tunnel, same as everything else. |
-| **Hardening** | Every mutating route writes an `AuditEvent` with actor, action, subject and detail. Extension names are regex-validated (`^[a-z0-9_]+$`) at the route before reaching any store. Removal mode is enum-validated. Rate limited. |
+| **Hardening** | Every mutating route writes an `AuditEvent` with actor, action, subject and detail. Extension names are regex-validated (`^[a-z0-9_]+$`) at the route before reaching any store. Removal mode is enum-validated. Rate limited. **Nothing here writes to MangaDex.** When the API is configured with MangaDex credentials it uses them for reads only — showing an operator the live title or chapter they are about to change, and rendering the unavailable-card preview — while every change is queued as an `UploadTask` for core-uploader. That is what keeps "exactly one writer" true no matter how many API replicas run, and it means an API-side bug can enqueue a wrong task (visible, cancellable while `PENDING`) but cannot itself publish, edit or delete anything. |
 | **Residual risks** | No scopes and no per-client tokens: the Discord bot holds the same credential you do, so a compromised bot can publish a bundle, repoint a tracked-manga mapping, or approve a title into existence. No overlap window on rotation — changing the token breaks every client at once. `bundle publish` accepts any zip that passes manifest validation, so admin-token compromise is code execution on every worker. Repointing a `tracked_manga` mapping is the quietest destructive action available: it makes future chapters upload to the *wrong MangaDex title*, with nothing in the upload path to notice. |
 
 ### 1.3a Operator dashboard — `/`, `/dash`, and the session/account endpoints
@@ -381,6 +381,15 @@ above hold:
   attack the account table offline and authenticate to MangaDex as the operator.
   It therefore sits at the account-administration bar and not at `settings:write`
   — which the Discord bot holds so it can pause the platform.
+- A second, lower bar uses the same shape for the two operations that change a
+  **public** MangaDex entry: applying an untracked row's corrections to a title
+  (`/untracked/:id/apply-to-mangadex`) and editing, hiding or deleting a
+  published chapter (`/chapters/:id*`). Both need the scope **and** the ADMIN
+  role, and both refuse `pa_…` tokens outright — an api token is assigned
+  `adminRole = "ADMIN"` by `adminAuthHook`, which means "not owner-equivalent",
+  not "vetted human", so judging these on the role alone would let any token
+  holding the area scope mutate the public catalogue under the shared MangaDex
+  account. These changes are attributable to a signed-in operator or nothing.
 - **The scope alone is never the gate; `requireOwner` is.** An OWNER may mint a
   `pa_…` token with `["*"]`, and wildcard satisfies every scope check — so a
   route guarded only by `requireScope("users:admin")` is reachable by a client

--- a/src/core/api/context.ts
+++ b/src/core/api/context.ts
@@ -7,9 +7,11 @@ import { BundleStore } from "../store/bundles.js";
 import { ArtifactStore } from "../store/artifacts.js";
 import { SettingsStore, AuditLog } from "../store/settings.js";
 import { UploadTaskStore } from "../store/uploadTasks.js";
+import { ChapterStore } from "../store/chapters.js";
 import { IngestService } from "../ingest/ingest.js";
 import { SchedulerService } from "../scheduler/service.js";
 import type { TitleService } from "../md/titleService.js";
+import type { MdExtendedApi } from "../md/client.js";
 import type { RepoArchiveFetcher } from "../webhooks/repoArchive.js";
 import { ApiTokenStore } from "../store/apiTokens.js";
 import { TrackedMangaStore } from "../store/trackedManga.js";
@@ -28,6 +30,8 @@ export interface AppContext {
   artifacts: ArtifactStore;
   settings: SettingsStore;
   uploadTasks: UploadTaskStore;
+  /** The four chapter history tables, read-only. */
+  chapters: ChapterStore;
   audit: AuditLog;
   /** Scoped per-client `pa_…` credentials. */
   apiTokens: ApiTokenStore;
@@ -38,6 +42,15 @@ export interface AppContext {
   scheduler: SchedulerService;
   /** Present when this instance holds MangaDex credentials (api + uploader). */
   titleService?: TitleService;
+  /**
+   * A MangaDex client, when this instance has credentials. READ-ONLY by
+   * convention on the API side: the chapter views use it to show what MangaDex
+   * currently says and to render a card preview, and every change is queued as
+   * an UploadTask instead. core-uploader remains the only process that writes
+   * to MangaDex, which is what keeps "exactly one writer" true — an API replica
+   * behind a load balancer must not be able to open an upload session.
+   */
+  md?: MdExtendedApi;
   /**
    * Test seam for the GitHub webhook's archive download. Injected here rather
    * than as a route option so `buildServer` can register the webhook routes
@@ -67,6 +80,7 @@ export function buildContext(prisma: PrismaClient, config: Config, log: Logger):
     artifacts: new ArtifactStore(prisma),
     settings: new SettingsStore(prisma),
     uploadTasks: new UploadTaskStore(prisma),
+    chapters: new ChapterStore(prisma),
     audit: new AuditLog(prisma),
     apiTokens: new ApiTokenStore(prisma),
     trackedManga: new TrackedMangaStore(prisma),

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -3144,6 +3144,16 @@ VIEWS.chapters = (route) => {
     return q;
   };
 
+  /** The filter as the bulk endpoints take it — same names, no paging keys. */
+  const activeFilter = () => {
+    const filter = { archive };
+    if (f().chapterExtension) filter.extension = f().chapterExtension;
+    if (f().chapterLanguage) filter.language = f().chapterLanguage;
+    if (f().chapterNumber) filter.chapterNumber = f().chapterNumber;
+    if (f().chapterSearch) filter.search = f().chapterSearch;
+    return filter;
+  };
+
   const chapters = new Resource(`chapters:${archive}`, () => api(`/chapters?${queryString()}`));
   const extensions = new Resource(`chapter-extensions:${archive}`, () =>
     api(`/chapters/extensions?archive=${archive}`),
@@ -3152,12 +3162,27 @@ VIEWS.chapters = (route) => {
   const reload = () => void chapters.load({ force: true });
   const resetPaging = () => {
     setFilter({ chapterCursors: { ...f().chapterCursors, [archive]: [] } });
+    selected.clear();
     reload();
   };
   const page = (walked) => {
     setFilter({ chapterCursors: { ...f().chapterCursors, [archive]: walked } });
+    selected.clear();
     reload();
   };
+
+  // Selection is by MangaDex chapter id and survives a refresh, but only for
+  // rows still on screen: acting on an id that has scrolled out of the filter is
+  // how a bulk action reports refusals the operator did not cause.
+  const selected = new Set();
+  const reconcile = (rows) => {
+    const present = new Set(rows.map((r) => r.mdChapterId));
+    for (const id of [...selected]) if (!present.has(id)) selected.delete(id);
+  };
+  // Whether the buttons act on the ticked rows or on everything the filter
+  // matches. One toggle rather than two sets of buttons, because the difference
+  // is the *scope* of an action and not a different action.
+  const scope = { wholeFilter: false };
 
   return el(
     "div",
@@ -3167,18 +3192,98 @@ VIEWS.chapters = (route) => {
       null,
       live(
         [chapters],
-        (data) =>
-          el(
+        (data) => {
+          const rows = data.chapters ?? [];
+          reconcile(rows);
+          return el(
             "div",
             {},
-            chapterTable(data.chapters ?? [], archive),
+            chapterBulkBar(selected, scope, rows, data, activeFilter, archive, reload),
+            chapterTable(rows, archive, selected, reload),
             chapterPager(data, cursors(), page),
-          ),
-        { reserve: 320, skeleton: () => skeletonTable(8, 6) },
+          );
+        },
+        { reserve: 320, skeleton: () => skeletonTable(8, 7) },
       ),
     ),
   );
 };
+
+/**
+ * Bulk actions over the ticked chapters, or over everything the filter matches.
+ *
+ * Every one of these opens the same preview-then-apply dialog rather than
+ * firing: the server's dry run is not optional decoration, it is how an operator
+ * sees the actual list of public pages they are about to change.
+ */
+function chapterBulkBar(selected, scope, rows, data, activeFilter, archive, reload) {
+  const count = selected.size;
+  const total = data.total ?? 0;
+  const targeting = scope.wholeFilter ? total : count;
+
+  const bulk = (label, action, danger) =>
+    gatedButton("chapters:write", {
+      class: danger ? "danger" : null,
+      text: label,
+      disabled: targeting === 0,
+      title:
+        targeting === 0
+          ? "Tick some chapters, or switch to the whole filter"
+          : `Preview this over ${targeting} chapter(s) first`,
+      onclick: () =>
+        chapterBulkDialog({
+          action,
+          archive,
+          target: scope.wholeFilter ? { filter: activeFilter() } : { ids: [...selected] },
+          targeting,
+          done: () => {
+            selected.clear();
+            reload();
+          },
+        }),
+    });
+
+  return el(
+    "div",
+    { class: "row bulk-bar" },
+    el("span", {
+      class: targeting ? null : "dim",
+      text: scope.wholeFilter
+        ? `Acting on all ${total} matching this filter`
+        : count
+          ? `${count} selected`
+          : "Tick chapters to act on them",
+    }),
+    bulk("Edit…", "edit", false),
+    bulk("Mark unavailable…", "unavailable", false),
+    bulk("Delete…", "delete", true),
+    el("span", { class: "grow" }),
+    el(
+      "label",
+      { class: "inline", for: "chapter-whole-filter" },
+      el("input", {
+        id: "chapter-whole-filter",
+        type: "checkbox",
+        checked: scope.wholeFilter,
+        onchange: (event) => {
+          scope.wholeFilter = event.target.checked;
+          reload();
+        },
+      }),
+      " whole filter",
+    ),
+    el("button", {
+      type: "button",
+      text: rows.length && count === rows.length ? "Select none" : "Select all on this page",
+      disabled: rows.length === 0 || scope.wholeFilter,
+      onclick: () => {
+        if (count === rows.length) selected.clear();
+        else for (const entry of rows) selected.add(entry.mdChapterId);
+        reload();
+      },
+    }),
+  );
+}
 
 function chapterFilterCard(extensions, onChange) {
   const text = (id, label, key, placeholder) =>
@@ -3262,10 +3367,20 @@ function chapterFilterCard(extensions, onChange) {
   );
 }
 
-function chapterTable(rows, archive) {
+function chapterTable(rows, archive, selected, reload) {
   return table(
-    ["Series", "Chapter", "Language", "Extension", CHAPTER_ARCHIVE_LABELS[archive] ?? "When", ""],
+    ["", "Series", "Chapter", "Language", "Extension", CHAPTER_ARCHIVE_LABELS[archive] ?? "When", ""],
     rows.map((entry) => [
+      el("input", {
+        type: "checkbox",
+        checked: selected.has(entry.mdChapterId),
+        "aria-label": `Select ${entry.mangaName ?? entry.mdChapterId} ${chapterLabel(entry)}`,
+        onchange: (event) => {
+          if (event.target.checked) selected.add(entry.mdChapterId);
+          else selected.delete(entry.mdChapterId);
+          reload();
+        },
+      }),
       routeLink(routeTo("chapters", entry.mdChapterId, null), truncate(entry.mangaName || "—", 48)),
       chapterLabel(entry),
       entry.chapterLanguage || "—",
@@ -3735,6 +3850,221 @@ function chapterDeleteDialog(data, detail) {
   );
 
   openModal("Delete this chapter from MangaDex", body);
+}
+
+/**
+ * One dialog for all three bulk actions: fill in what changes, **preview**, then
+ * apply.
+ *
+ * The preview is the server's own dry run, and the apply button stays disabled
+ * until it has been seen. That is not UI ceremony duplicating a server check —
+ * the server would refuse a live call without `{dryRun: false, confirm: true}`
+ * anyway — it is making the safe order the only order the page offers, so the
+ * list of public pages about to change is always read before it changes.
+ */
+function chapterBulkDialog({ action, archive, target, targeting, done }) {
+  const inputs = {};
+  const field = (key, label, hint, attrs = {}) => {
+    const id = `chapter-bulk-${key}`;
+    inputs[key] = el("input", { id, type: "text", ...attrs });
+    return [
+      el("label", { for: id, text: label }),
+      inputs[key],
+      hint ? el("p", { class: "dim small", text: hint }) : null,
+    ];
+  };
+
+  const force = el("input", { id: "chapter-bulk-force", type: "checkbox" });
+  const body = el("div", {});
+  const preview = el("div", {});
+
+  const specifics =
+    action === "edit"
+      ? el(
+          "div",
+          {},
+          el("p", {
+            class: "dim small",
+            text:
+              "Only the fields a set of chapters can share. A title, a chapter number or a source URL " +
+              "belongs to one chapter, so those stay on the single-chapter form.",
+          }),
+          field("volume", "Volume", "Blank leaves it alone; “-” is not a clear — use the single-chapter form to clear."),
+          field("translatedLanguage", "Language", "A MangaDex language code, e.g. en, ja, pt-br."),
+          field("groups", "Groups", "Comma-separated MangaDex group ids."),
+        )
+      : action === "unavailable"
+        ? el(
+            "div",
+            {},
+            el("p", {
+              text:
+                "Each chapter keeps its place on MangaDex; its page becomes the card and its publisher " +
+                "link is repointed. Cards are rendered per chapter from that chapter's own details.",
+            }),
+            el("label", { class: "inline", for: "chapter-bulk-force" }, force, " re-card chapters that already have one"),
+            ...field("footerNote", "Footer note", "Replaces the standard wording on every card in this batch.", {
+              maxlength: "600",
+            }),
+          )
+        : el(
+            "div",
+            {},
+            el("p", {
+              text:
+                "Deleting removes these chapters from MangaDex outright. Readers lose them and nothing " +
+                "here brings them back.",
+            }),
+            ...field("reason", "Reason (recorded against every chapter in the audit trail)", "", {
+              maxlength: "500",
+            }),
+          );
+
+  /** The action-specific half of the request body. */
+  const changes = () => {
+    if (action === "edit") {
+      const out = {};
+      const volume = inputs.volume.value.trim();
+      const language = inputs.translatedLanguage.value.trim();
+      const groups = inputs.groups.value
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean);
+      if (volume) out.volume = volume;
+      if (language) out.translatedLanguage = language;
+      if (groups.length) out.groups = groups;
+      return { changes: out };
+    }
+    if (action === "unavailable") {
+      const note = inputs.footerNote.value.trim();
+      return { force: force.checked, ...(note ? { footerNote: note } : {}) };
+    }
+    const reason = inputs.reason.value.trim();
+    return reason ? { reason } : {};
+  };
+
+  const call = (extra) =>
+    api(`/chapters/bulk/${action}`, { method: "POST", body: { ...target, ...changes(), ...extra } });
+
+  const applyButton = gatedButton("chapters:write", {
+    class: action === "delete" ? "danger" : "primary",
+    text: "Preview first",
+    disabled: true,
+    onclick: async (event) => {
+      const result = await act(`chapter.bulk_${action}`, () => call({ dryRun: false, confirm: true }), {
+        button: event.currentTarget,
+      });
+      if (result) {
+        reportChapterBulk(result);
+        closeModal();
+        done();
+      }
+    },
+  });
+
+  const previewButton = gatedButton("chapters:read", {
+    text: "Preview",
+    onclick: async (event) => {
+      const result = await act("chapter.bulk_preview", () => call({ dryRun: true }), {
+        button: event.currentTarget,
+      });
+      if (!result) return;
+      applyButton.disabled = !can("chapters:write") || result.wouldQueue === 0;
+      applyButton.textContent =
+        result.wouldQueue === 0
+          ? "Nothing to queue"
+          : `Queue ${result.wouldQueue} chapter(s)`;
+      setChildren(preview, chapterBulkPreview(result, archive));
+    },
+  });
+
+  setChildren(
+    body,
+    el("p", {
+      class: "dim small",
+      text: target.filter
+        ? `Every chapter matching the current filter (${targeting} right now).`
+        : `${targeting} selected chapter(s).`,
+    }),
+    specifics,
+    el("div", { class: "row end" }, previewButton, applyButton, el("button", { type: "button", text: "Cancel", onclick: closeModal })),
+    preview,
+  );
+
+  openModal(
+    action === "edit"
+      ? "Edit these chapters on MangaDex"
+      : action === "unavailable"
+        ? "Mark these chapters unavailable"
+        : "Delete these chapters from MangaDex",
+    body,
+  );
+}
+
+/** The dry run, rendered: what would happen to each chapter, and what would not. */
+function chapterBulkPreview(result, archive) {
+  const blocked = (result.results ?? []).filter((item) => !item.ok);
+  return el(
+    "div",
+    {},
+    el("h3", { text: "Preview" }),
+    defs([
+      ["Matching the filter", String(result.matched ?? result.resolved ?? 0)],
+      ["Would be queued", String(result.wouldQueue ?? 0)],
+      ["Blocked", String(blocked.length)],
+    ]),
+    result.capped
+      ? el("p", {
+          class: "error",
+          text: `More chapters match than the ${result.cap}-chapter cap. This queues the first ${result.cap}; run it again for the rest.`,
+        })
+      : null,
+    table(
+      ["Series", "Chapter", "Language", "Would happen"],
+      (result.results ?? []).slice(0, 100).map((item) => [
+        truncate(item.mangaName || item.mdChapterId, 40),
+        item.chapterNumber ? `Ch. ${item.chapterNumber}` : "—",
+        item.chapterLanguage || "—",
+        item.ok ? chip("queued") : el("span", { class: "dim small", text: item.reason ?? item.outcome }),
+      ]),
+      { empty: `Nothing in the ${archive} archive matched.` },
+    ),
+    (result.results ?? []).length > 100
+      ? el("p", { class: "dim small", text: `…and ${result.results.length - 100} more.` })
+      : null,
+  );
+}
+
+/**
+ * Per-chapter results, reported rather than summarised — a batch where eight
+ * chapters queued and two were refused is a success and a partial failure at
+ * once, and collapsing that to "ok" loses the only part worth acting on.
+ */
+function reportChapterBulk(result) {
+  const refused = (result.results ?? []).filter((item) => !item.ok);
+  if (refused.length === 0) {
+    toast(`${result.queued} chapter(s) queued`);
+    return;
+  }
+  toast(`${result.queued} queued, ${refused.length} refused`, false);
+  openModal(
+    "Some chapters were refused",
+    el(
+      "div",
+      {},
+      el("p", { class: "dim small", text: "The rest of the batch was queued. These were not, and why:" }),
+      el(
+        "ul",
+        { class: "errors" },
+        refused
+          .slice(0, 50)
+          .map((item) =>
+            el("li", { text: `${item.mangaName ?? item.mdChapterId}: ${item.reason ?? item.outcome}` }),
+          ),
+      ),
+      el("div", { class: "row end" }, el("button", { type: "button", text: "Close", onclick: closeModal })),
+    ),
+  );
 }
 
 /** Say what was queued — including that a completed task was reset in place. */

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -67,6 +67,16 @@ const store = {
     queueAttemptMax: "",
     /** Keyset cursors already walked, so "Back" does not need a second scheme. */
     queueCursors: [],
+    chapterExtension: "",
+    chapterLanguage: "",
+    chapterNumber: "",
+    chapterSearch: "",
+    /**
+     * Cursors per archive, not one list: a cursor minted while reading
+     * `uploaded` names a row `deleted` has never seen, so one shared list would
+     * page the wrong table the moment a tab changed.
+     */
+    chapterCursors: {},
     untrackedState: "NEW",
     activitySeverity: "all",
     activityHours: 72,
@@ -372,6 +382,7 @@ const ICONS = {
   activity: "M3 12h4l3 8 4-16 3 8h4",
   errors: "M12 4l9 16H3l9-16Zm0 5v6m0 3v.5",
   extensions: "M4 4h7v7H4V4Zm9 0h7v7h-7V4ZM4 13h7v7H4v-7Zm12.5 0v7m-3.5-3.5h7",
+  chapters: "M6 3h8l4 4v14H6V3Zm8 0v4h4M9 12h6m-6 3.5h6",
   tracked: "M6 4h12v16l-6-4-6 4V4Z",
   untracked: "M12 3l9 5v8l-9 5-9-5V8l9-5Zm0 6v4m0 3v.5",
   workers: "M4 17h16M6 17V9l6-4 6 4v8M10 17v-4h4v4",
@@ -940,6 +951,21 @@ const NAV = [
       ["versions", "Versions"],
     ],
     blurb: "Published bundles, and everything about one extension.",
+  },
+  {
+    id: "chapters",
+    label: "Chapters",
+    group: "Catalogue",
+    icon: "chapters",
+    scope: "chapters:read",
+    param: true,
+    tabs: [
+      ["uploaded", "On MangaDex"],
+      ["unavailable", "Unavailable"],
+      ["deleted", "Deleted"],
+      ["edited", "Edited"],
+    ],
+    blurb: "Every chapter this platform has published, and what has happened to it since.",
   },
   {
     id: "tracked",
@@ -3079,6 +3105,644 @@ function toLocalInput(value) {
     `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
     `T${pad(d.getHours())}:${pad(d.getMinutes())}`
   );
+}
+
+// ------------------------------------------------------------------- chapters
+
+/**
+ * What this platform has on MangaDex, and the three things that can be done to
+ * a chapter after it is published.
+ *
+ * Nothing here talks to MangaDex. Every action queues an UploadTask and the
+ * page says so — core-uploader is the only process with write credentials, and
+ * a dashboard that claimed "deleted" the moment the request returned would be
+ * describing something that has not happened yet. The buttons therefore report
+ * "queued", link to the queue row, and the detail view shows what MangaDex
+ * currently says next to what our own tables think.
+ */
+const CHAPTER_ARCHIVE_LABELS = {
+  uploaded: "Uploaded",
+  unavailable: "Unavailable since",
+  deleted: "Deleted",
+  edited: "Last edited",
+};
+
+VIEWS.chapters = (route) => {
+  if (route.param) return chapterDetail(route.param);
+  const archive = route.tab ?? "uploaded";
+  const f = () => store.filters;
+  const cursors = () => f().chapterCursors[archive] ?? [];
+
+  const queryString = () => {
+    const q = new URLSearchParams({ archive, limit: "50" });
+    if (f().chapterExtension) q.set("extension", f().chapterExtension);
+    if (f().chapterLanguage) q.set("language", f().chapterLanguage);
+    if (f().chapterNumber) q.set("chapterNumber", f().chapterNumber);
+    if (f().chapterSearch) q.set("search", f().chapterSearch);
+    const walked = cursors();
+    if (walked.length) q.set("cursor", walked[walked.length - 1]);
+    return q;
+  };
+
+  const chapters = new Resource(`chapters:${archive}`, () => api(`/chapters?${queryString()}`));
+  const extensions = new Resource(`chapter-extensions:${archive}`, () =>
+    api(`/chapters/extensions?archive=${archive}`),
+  );
+
+  const reload = () => void chapters.load({ force: true });
+  const resetPaging = () => {
+    setFilter({ chapterCursors: { ...f().chapterCursors, [archive]: [] } });
+    reload();
+  };
+  const page = (walked) => {
+    setFilter({ chapterCursors: { ...f().chapterCursors, [archive]: walked } });
+    reload();
+  };
+
+  return el(
+    "div",
+    {},
+    chapterFilterCard(extensions, resetPaging),
+    card(
+      null,
+      live(
+        [chapters],
+        (data) =>
+          el(
+            "div",
+            {},
+            chapterTable(data.chapters ?? [], archive),
+            chapterPager(data, cursors(), page),
+          ),
+        { reserve: 320, skeleton: () => skeletonTable(8, 6) },
+      ),
+    ),
+  );
+};
+
+function chapterFilterCard(extensions, onChange) {
+  const text = (id, label, key, placeholder) =>
+    el(
+      "span",
+      { class: "row tight" },
+      el("label", { class: "inline", for: id, text: label }),
+      el("input", {
+        id,
+        type: "text",
+        value: store.filters[key],
+        placeholder,
+        onchange: (event) => {
+          setFilter({ [key]: event.target.value });
+          onChange();
+        },
+      }),
+    );
+
+  return card(
+    "Filter",
+    row(
+      // The extension list is a resource of its own so the picker offers what
+      // this archive actually holds, with counts — an extension that has never
+      // published is not a useful filter option.
+      live(
+        [extensions],
+        (data) =>
+          el(
+            "span",
+            { class: "row tight" },
+            el("label", { class: "inline", for: "chapter-extension", text: "Extension" }),
+            el(
+              "select",
+              {
+                id: "chapter-extension",
+                onchange: (event) => {
+                  setFilter({ chapterExtension: event.target.value });
+                  onChange();
+                },
+              },
+              el("option", {
+                value: "",
+                text: "all",
+                selected: store.filters.chapterExtension === "",
+              }),
+              (data.extensions ?? []).map((entry) =>
+                el("option", {
+                  value: entry.extension,
+                  text: `${entry.extension || "(unattributed)"} · ${entry.count}`,
+                  selected: entry.extension === store.filters.chapterExtension,
+                }),
+              ),
+            ),
+          ),
+        { reserve: 32, skeleton: () => el("span", { class: "dim small", text: "extensions…" }) },
+      ),
+      text("chapter-search", "Search", "chapterSearch", "title, name, or any id"),
+      text("chapter-number", "Chapter", "chapterNumber", "exact, e.g. 12.5"),
+      text("chapter-language", "Language", "chapterLanguage", "e.g. en"),
+      el("button", {
+        type: "button",
+        text: "Clear",
+        onclick: () => {
+          setFilter({
+            chapterExtension: "",
+            chapterLanguage: "",
+            chapterNumber: "",
+            chapterSearch: "",
+          });
+          onChange();
+        },
+      }),
+    ),
+    el("p", {
+      class: "dim small",
+      text:
+        "Search matches the series name, the chapter title and any of the four ids, so a chapter id " +
+        "pasted from a MangaDex URL or a Discord embed finds its row.",
+    }),
+  );
+}
+
+function chapterTable(rows, archive) {
+  return table(
+    ["Series", "Chapter", "Language", "Extension", CHAPTER_ARCHIVE_LABELS[archive] ?? "When", ""],
+    rows.map((entry) => [
+      routeLink(routeTo("chapters", entry.mdChapterId, null), truncate(entry.mangaName || "—", 48)),
+      chapterLabel(entry),
+      entry.chapterLanguage || "—",
+      entry.extension || "—",
+      fmtTime(entry.at),
+      [
+        el("a", {
+          class: "button-link inline",
+          href: `https://mangadex.org/chapter/${encodeURIComponent(entry.mdChapterId)}`,
+          target: "_blank",
+          rel: "noreferrer noopener",
+          text: "MangaDex",
+        }),
+        entry.editCount > 0 ? el("span", { class: "dim small", text: `${entry.editCount} edit(s)` }) : null,
+      ],
+    ]),
+    {
+      empty:
+        archive === "uploaded"
+          ? "No chapter has been published yet, or none matches this filter."
+          : "Nothing in this archive matches.",
+    },
+  );
+}
+
+/** "Vol. 2 Ch. 12.5 — Title", degrading to whichever parts exist. */
+function chapterLabel(entry) {
+  const number = entry.chapterNumber ? `Ch. ${entry.chapterNumber}` : "Oneshot";
+  const volume = entry.chapterVolume ? `Vol. ${entry.chapterVolume} ` : "";
+  return truncate(`${volume}${number}${entry.chapterTitle ? ` — ${entry.chapterTitle}` : ""}`, 72);
+}
+
+function chapterPager(data, walked, go) {
+  return el(
+    "div",
+    { class: "row pager" },
+    el("span", {
+      class: "dim small",
+      text: `${data.chapters?.length ?? 0} shown of ${data.total ?? 0} matching · ${data.order ?? ""}`,
+    }),
+    el("span", { class: "grow" }),
+    el("button", {
+      type: "button",
+      text: "← Back",
+      disabled: walked.length === 0,
+      onclick: () => go(walked.slice(0, -1)),
+    }),
+    el("button", {
+      type: "button",
+      text: "Next →",
+      disabled: !data.nextCursor,
+      onclick: () => go([...walked, data.nextCursor]),
+    }),
+  );
+}
+
+/**
+ * One chapter: our record of it, what MangaDex says about it right now, what is
+ * already queued against it, and its edit history.
+ *
+ * The live column is the one that decides anything. Our row is a mirror written
+ * when the chapter was published and may be days stale, while the operator is
+ * about to change a public catalogue entry — so where the two disagree, the
+ * page shows both rather than picking one.
+ */
+function chapterDetail(mdChapterId) {
+  const detail = new Resource(`chapter:${mdChapterId}`, () =>
+    api(`/chapters/${encodeURIComponent(mdChapterId)}`),
+  );
+
+  return live(
+    [detail],
+    (data) => {
+      const chapter = data.chapter ?? {};
+      const archives = data.archives ?? {};
+      return el(
+        "div",
+        {},
+        card(
+          null,
+          row(
+            archives.deleted ? chip("DELETED") : null,
+            archives.unavailable ? chip("UNAVAILABLE") : null,
+            archives.uploaded ? chip("UPLOADED") : null,
+            archives.edited ? chip("EDITED") : null,
+            el("span", {
+              class: "dim",
+              text: `${chapter.extension || "unattributed"} · ${chapterLabel(chapter)}`,
+            }),
+          ),
+          defs([
+            ["Series", chapter.mangaName || "—"],
+            ["MangaDex chapter", el("code", { text: mdChapterId })],
+            ["MangaDex title", chapter.mdMangaId ? mdTitleLink(chapter.mdMangaId, chapter.mdMangaId) : "—"],
+            ["Group", chapter.mdGroupId ? el("code", { text: chapter.mdGroupId }) : "—"],
+            ["Language", chapter.chapterLanguage || "—"],
+            ["Source chapter id", chapter.chapterId ? el("code", { text: chapter.chapterId }) : "—"],
+            ["Source URL", chapter.chapterUrl || "—"],
+            ["Published by the source", fmtTime(chapter.chapterTimestamp)],
+            ["Source expiry", fmtTime(chapter.chapterExpire)],
+            ["Uploaded", fmtTime(archives.uploaded)],
+            ["Marked unavailable", fmtTime(archives.unavailable)],
+            ["Deleted", fmtTime(archives.deleted)],
+          ]),
+          row(
+            el("a", {
+              class: "button-link inline",
+              href: data.links?.chapter ?? `https://mangadex.org/chapter/${encodeURIComponent(mdChapterId)}`,
+              target: "_blank",
+              rel: "noreferrer noopener",
+              text: "Open on MangaDex",
+            }),
+            chapter.chapterUrl
+              ? el("a", {
+                  class: "button-link inline",
+                  href: chapter.chapterUrl,
+                  target: "_blank",
+                  rel: "noreferrer noopener",
+                  text: "Open the source",
+                })
+              : null,
+            copyLinkButton(routeTo("chapters", mdChapterId, null)),
+          ),
+        ),
+        chapterActionsCard(data, detail),
+        chapterMangadexCard(data),
+        chapterTasksCard(data),
+        chapterEditsCard(data),
+      );
+    },
+    { reserve: 420, skeleton: () => el("div", {}, skeletonTable(10, 2), skeletonTable(4, 4)) },
+  );
+}
+
+/**
+ * The three verbs, with the reason they are unavailable rather than a button
+ * that 403s. `actionsBlockedReason` comes from the server, so the page and the
+ * endpoint cannot disagree about who may do this.
+ */
+function chapterActionsCard(data, detail) {
+  const blocked = data.actionsBlockedReason;
+  const already = Boolean(data.archives?.unavailable);
+
+  return card(
+    "Change this chapter on MangaDex",
+    el("p", {
+      class: "dim small",
+      text:
+        "Each of these queues one upload task. core-uploader — the only process holding MangaDex " +
+        "credentials — picks it up within a few seconds and the result appears under Queues.",
+    }),
+    blocked ? el("p", { class: "error", text: blocked }) : null,
+    row(
+      gatedButton("chapters:write", {
+        text: "Edit metadata…",
+        disabled: Boolean(blocked),
+        onclick: () => chapterEditDialog(data, detail),
+      }),
+      gatedButton("chapters:write", {
+        text: already ? "Regenerate the unavailable card…" : "Mark unavailable…",
+        disabled: Boolean(blocked),
+        title: already
+          ? "Renders a fresh card and posts it over the one already on this chapter"
+          : "Replaces the chapter's page with a card explaining the publisher removed it",
+        onclick: () => chapterUnavailableDialog(data, detail, already),
+      }),
+      gatedButton("chapters:write", {
+        class: "danger",
+        text: "Delete from MangaDex…",
+        disabled: Boolean(blocked),
+        onclick: () => chapterDeleteDialog(data, detail),
+      }),
+    ),
+  );
+}
+
+function chapterMangadexCard(data) {
+  const md = data.mangadex;
+  if (!md) {
+    return card(
+      "On MangaDex now",
+      el("p", { class: "error", text: data.mangadexError ?? "MangaDex could not be read." }),
+      el("p", {
+        class: "dim small",
+        text:
+          "Actions still work: they are queued for the uploader, which reads MangaDex itself when it " +
+          "runs them.",
+      }),
+    );
+  }
+  return card(
+    "On MangaDex now",
+    defs([
+      ["Volume", md.volume || "—"],
+      ["Chapter", md.chapter || "—"],
+      ["Title", md.title || "—"],
+      ["Language", md.translatedLanguage || "—"],
+      ["External URL", md.externalUrl || "— (none: this chapter has pages)"],
+      ["Groups", (md.groups ?? []).join(", ") || "—"],
+      ["Version", String(md.version ?? "—")],
+      ["Created", fmtTime(md.createdAt)],
+    ]),
+  );
+}
+
+function chapterTasksCard(data) {
+  const tasks = data.tasks ?? [];
+  return card(
+    "Queued against this chapter",
+    table(
+      ["Kind", "State", "Attempts", "Due", "Last error"],
+      tasks.map((task) => [
+        task.kind,
+        chip(task.state),
+        `${task.attempt}/${task.maxAttempts}`,
+        fmtTime(task.notBefore),
+        truncate(task.lastError, 160),
+      ]),
+      { empty: "Nothing is queued for this chapter." },
+    ),
+    tasks.length
+      ? routeLink(routeTo("queues", null, "tasks"), "Open the queue", { class: "button-link inline" })
+      : null,
+  );
+}
+
+function chapterEditsCard(data) {
+  const edits = data.edits ?? [];
+  if (!edits.length) return null;
+  return card(
+    "Edit history",
+    table(
+      ["When", "Changed to", "From"],
+      edits
+        .slice()
+        .reverse()
+        .map((edit) => [
+          fmtTime(edit.editedAt),
+          truncate(JSON.stringify(edit.new ?? {}), 160),
+          truncate(JSON.stringify(edit.old ?? {}), 160),
+        ]),
+      { empty: "No edits recorded." },
+    ),
+  );
+}
+
+/**
+ * Queue an edit of the chapter's MangaDex metadata.
+ *
+ * Prefilled from what MangaDex currently holds, falling back to our row when it
+ * could not be read — and only the fields the operator actually changed are
+ * sent, so an unrelated value cannot be pinned to a stale prefill.
+ */
+function chapterEditDialog(data, detail) {
+  const md = data.mangadex ?? {};
+  const stored = data.chapter ?? {};
+  const initial = {
+    volume: md.volume ?? stored.chapterVolume ?? "",
+    chapter: md.chapter ?? stored.chapterNumber ?? "",
+    title: md.title ?? stored.chapterTitle ?? "",
+    translatedLanguage: md.translatedLanguage ?? stored.chapterLanguage ?? "",
+    externalUrl: md.externalUrl ?? stored.chapterUrl ?? "",
+    groups: (md.groups ?? (stored.mdGroupId ? [stored.mdGroupId] : [])).join(", "),
+  };
+
+  const inputs = {};
+  const field = (key, label, hint) => {
+    const id = `chapter-edit-${key}`;
+    inputs[key] = el("input", { id, type: "text", value: initial[key] });
+    return [
+      el("label", { for: id, text: label }),
+      inputs[key],
+      hint ? el("p", { class: "dim small", text: hint }) : null,
+    ];
+  };
+
+  const body = el(
+    "div",
+    {},
+    el("p", {
+      class: "dim small",
+      text:
+        "Only the fields you change are sent. The uploader lays them over whatever MangaDex holds at " +
+        "the moment it runs, because PUT /chapter replaces the whole resource and needs the current " +
+        "version.",
+    }),
+    field("chapter", "Chapter number", "Blank clears it — a oneshot has no number."),
+    field("volume", "Volume", ""),
+    field("title", "Title", ""),
+    field("translatedLanguage", "Language", "A MangaDex language code, e.g. en, ja, pt-br."),
+    field("externalUrl", "External URL", "The publisher link readers are sent to."),
+    field("groups", "Groups", "Comma-separated MangaDex group ids."),
+    el(
+      "div",
+      { class: "row end" },
+      el("button", { type: "button", text: "Cancel", onclick: closeModal }),
+      gatedButton("chapters:write", {
+        class: "primary",
+        text: "Queue the edit",
+        onclick: async (event) => {
+          const payload = {};
+          for (const key of ["chapter", "volume", "title", "translatedLanguage", "externalUrl"]) {
+            const value = inputs[key].value.trim();
+            if (value === String(initial[key] ?? "").trim()) continue;
+            // An emptied field is a deliberate clear, which MangaDex expresses
+            // as null. Language is the exception: a chapter always has one, so
+            // blanking it means "leave it alone" rather than "remove it".
+            if (value === "") {
+              if (key === "translatedLanguage") continue;
+              payload[key] = null;
+            } else {
+              payload[key] = value;
+            }
+          }
+          const groups = inputs.groups.value
+            .split(",")
+            .map((id) => id.trim())
+            .filter(Boolean);
+          if (groups.join(", ") !== initial.groups) payload.groups = groups;
+
+          if (Object.keys(payload).length === 0) {
+            toast("nothing changed", false);
+            return;
+          }
+          const result = await act(
+            "chapter.edit",
+            () =>
+              api(`/chapters/${encodeURIComponent(data.mdChapterId)}`, {
+                method: "PATCH",
+                body: payload,
+              }),
+            { button: event.currentTarget, refresh: [detail, summary] },
+          );
+          if (result) {
+            reportChapterQueued(result);
+            closeModal();
+          }
+        },
+      }),
+    ),
+  );
+
+  openModal("Edit chapter metadata", body);
+}
+
+/**
+ * Queue "replace this chapter with an unavailable card", with the card itself
+ * on screen first.
+ *
+ * The preview is rendered by the server from the same function the uploader
+ * uses, so what is approved here is what gets posted. It is an `<img>` rather
+ * than a fetch because the endpoint answers PNG bytes and the session cookie
+ * carries it; the CSP allows `img-src 'self'`.
+ */
+function chapterUnavailableDialog(data, detail, already) {
+  const note = el("textarea", {
+    id: "chapter-note",
+    rows: "3",
+    maxlength: "600",
+    placeholder: "Leave blank for the standard wording.",
+  });
+
+  const preview = el("img", {
+    class: "card-preview",
+    alt: "Preview of the card that will be posted as this chapter's only page",
+    src: previewSrc(data.mdChapterId, ""),
+  });
+
+  const refresh = () => {
+    preview.src = previewSrc(data.mdChapterId, note.value.trim());
+  };
+
+  const body = el(
+    "div",
+    {},
+    el("p", {
+      text: already
+        ? "This chapter already carries an unavailable card. Queueing this renders a fresh one and " +
+          "posts it over the old page."
+        : "The chapter keeps its place on MangaDex. Its page becomes the card below, and the " +
+          "publisher link is repointed away from the dead chapter URL.",
+    }),
+    el("label", { for: "chapter-note", text: "Footer note" }),
+    note,
+    row(el("button", { type: "button", text: "Refresh the preview", onclick: refresh })),
+    preview,
+    el(
+      "div",
+      { class: "row end" },
+      el("button", { type: "button", text: "Cancel", onclick: closeModal }),
+      gatedButton("chapters:write", {
+        class: "primary",
+        text: already ? "Queue a fresh card" : "Queue it",
+        onclick: async (event) => {
+          const result = await act(
+            "chapter.unavailable",
+            () =>
+              api(`/chapters/${encodeURIComponent(data.mdChapterId)}/unavailable`, {
+                method: "POST",
+                // `force` is what makes this repeatable: without it the uploader
+                // treats an already-archived chapter as done and changes nothing.
+                body: { force: already, ...(note.value.trim() ? { footerNote: note.value.trim() } : {}) },
+              }),
+            { button: event.currentTarget, refresh: [detail, summary] },
+          );
+          if (result) {
+            reportChapterQueued(result);
+            closeModal();
+          }
+        },
+      }),
+    ),
+  );
+
+  openModal(already ? "Regenerate the unavailable card" : "Mark this chapter unavailable", body);
+}
+
+function previewSrc(mdChapterId, note) {
+  const q = new URLSearchParams();
+  if (note) q.set("footerNote", note);
+  // Cache-busting is belt-and-braces — the endpoint sends no-store — but an
+  // `<img>` whose src did not change is not re-fetched at all.
+  q.set("t", String(Date.now()));
+  return `${API}/chapters/${encodeURIComponent(mdChapterId)}/card.png?${q}`;
+}
+
+function chapterDeleteDialog(data, detail) {
+  const reason = el("input", { id: "chapter-reason", type: "text", maxlength: "500" });
+  const body = el(
+    "div",
+    {},
+    el("p", {
+      text:
+        "Deleting removes the chapter from MangaDex outright. Readers lose it, and nothing here can " +
+        "bring it back — the archive row records what was removed, not the pages.",
+    }),
+    el("ul", { class: "errors" }, [
+      el("li", { text: "Marking it unavailable keeps the entry and explains the takedown instead." }),
+      el("li", { text: "The change is queued; the uploader performs it within seconds." }),
+    ]),
+    el("label", { for: "chapter-reason", text: "Reason (recorded in the audit trail)" }),
+    reason,
+    el(
+      "div",
+      { class: "row end" },
+      el("button", { type: "button", text: "Cancel", onclick: closeModal }),
+      gatedButton("chapters:write", {
+        class: "danger",
+        text: "Queue the delete",
+        onclick: async (event) => {
+          const result = await act(
+            "chapter.delete",
+            () =>
+              api(`/chapters/${encodeURIComponent(data.mdChapterId)}`, {
+                method: "DELETE",
+                body: { confirm: true, ...(reason.value.trim() ? { reason: reason.value.trim() } : {}) },
+              }),
+            { button: event.currentTarget, refresh: [detail, summary] },
+          );
+          if (result) {
+            reportChapterQueued(result);
+            closeModal();
+          }
+        },
+      }),
+    ),
+  );
+
+  openModal("Delete this chapter from MangaDex", body);
+}
+
+/** Say what was queued — including that a completed task was reset in place. */
+function reportChapterQueued(result) {
+  const parts = [`${result.action} queued`];
+  if (result.superseded) parts.push("a previously completed task for this chapter was reused");
+  for (const warning of result.warnings ?? []) parts.push(warning);
+  toast(parts.join(" · "));
 }
 
 // ------------------------------------------------------------------- activity

--- a/src/core/api/dashboard/index.html
+++ b/src/core/api/dashboard/index.html
@@ -20,9 +20,9 @@
         <h2>JavaScript required</h2>
         <p>
           The control plane renders its views in the browser. The navigation offers Overview;
-          Runs, Queues, Activity and Errors under Work; Extensions, Tracked and Untracked under
-          Catalogue; Workers under Fleet; and Users, Tokens, Audit, System, Maintenance and Docs
-          under Admin.
+          Runs, Queues, Activity and Errors under Work; Extensions, Chapters, Tracked and
+          Untracked under Catalogue; Workers under Fleet; and Users, Tokens, Audit, System,
+          Maintenance and Docs under Admin.
           Enable scripting for this origin, or use the <code>publoader-admin</code> CLI instead.
         </p>
       </div>

--- a/src/core/api/dashboard/style.css
+++ b/src/core/api/dashboard/style.css
@@ -1382,3 +1382,28 @@ dialog::backdrop {
   gap: 8px;
   padding-top: 10px;
 }
+
+/* ---- chapter card preview ------------------------------------------------ */
+
+/* The unavailable card is a square 2000x2000 PNG. Constrained by width AND by
+   viewport height so the dialog's buttons stay reachable on a laptop — a
+   preview you have to scroll past to approve is one nobody looks at. */
+.card-preview {
+  display: block;
+  width: 100%;
+  max-width: 420px;
+  max-height: 50vh;
+  object-fit: contain;
+  margin: 10px auto 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+}
+
+/* The footer-note box is prose, not the JSON payloads every other textarea in
+   this page holds, so it opts out of the mono/180px default. */
+#chapter-note {
+  font-family: inherit;
+  font-size: 13px;
+  min-height: 72px;
+}

--- a/src/core/api/routes/chapters.ts
+++ b/src/core/api/routes/chapters.ts
@@ -1,0 +1,784 @@
+// Not self-registering: server.ts is owned elsewhere, so the integrator wires
+// this module in with `registerChapterRoutes(app, ctx)` next to the other route
+// modules.
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { adminAuthHook, requireScope } from "../auth.js";
+import { sessionAuthenticator } from "../session.js";
+import { normaliseMangadexLanguage } from "../../../contracts/languages.js";
+import { Manifest, hostAllowed } from "../../../contracts/manifest.js";
+import { chapterToTaskPayload } from "../../md/chapterRows.js";
+import { generateChapterCard } from "../../md/card.js";
+import { unavailableCardOptions } from "../../md/unavailableCard.js";
+import type { MdChapterDetail } from "../../md/client.js";
+import {
+  ARCHIVES,
+  CHAPTER_ARCHIVES,
+  chapterOf,
+  decodeChapterCursor,
+  type ChapterArchive,
+  type ChapterFilter,
+  type ChapterRow,
+} from "../../store/chapters.js";
+import { taskDedupeKey } from "../../store/uploadTasks.js";
+import { manualTaskProblems } from "./queues.js";
+
+/**
+ * The chapters this platform has published on MangaDex, and the three things an
+ * operator can do to one after the fact: edit its metadata, replace it with an
+ * "unavailable" card, or delete it outright.
+ *
+ * WHY THIS IS NOT A MANGADEX CLIENT. Every action here queues an UploadTask and
+ * returns. core-uploader is the only process that writes to MangaDex, and that
+ * is a property worth more than the immediacy of a synchronous PUT: it is what
+ * makes "one open upload session per account" enforceable, what gives every
+ * change a retry budget and a dead-letter, and what stops two API replicas from
+ * racing each other into a duplicate. The endpoints below therefore answer 202
+ * with a task id — "queued", never "done" — and the operator watches the queue.
+ *
+ * The read side is direct: the four chapter tables answer immediately, and when
+ * this instance holds MangaDex credentials the detail view also shows what
+ * MangaDex currently says. That live read is the one that matters, because the
+ * local row is a mirror that may be days old while the operator is deciding
+ * what a public catalogue entry should look like. A MangaDex outage degrades
+ * that to `mangadexError` and never makes the row unreadable.
+ *
+ * Guards, in the order they bite:
+ *   1. `chapters:read` to look, `chapters:write` to queue anything.
+ *   2. ADMIN-or-above by role on every mutating route — the same
+ *      role-plus-scope construction routes/queues.ts uses for hand-enqueueing,
+ *      and for the same reason: this reaches a public catalogue, and a
+ *      CONTRIBUTOR must not.
+ *   3. A settled queue row for the chapter is superseded; a PENDING or LEASED
+ *      one is a 409 naming it. Nothing here can touch work an uploader holds.
+ *   4. Deleting needs `confirm: true`, because it is the one action MangaDex
+ *      cannot give back.
+ */
+
+/** Cap on one page of chapters. */
+const MAX_PAGE = 200;
+const DEFAULT_PAGE = 50;
+
+const MD_CHAPTER_URL = "https://mangadex.org/chapter/";
+const MD_MANGA_URL = "https://mangadex.org/title/";
+
+/**
+ * A MangaDex chapter id as it appears in our tables.
+ *
+ * Not `z.string().uuid()`: chapters migrated from the legacy Mongo collections
+ * carry whatever id that database held, and refusing to *display* one because
+ * it is not a well-formed uuid would hide exactly the rows most likely to need
+ * attention. The charset is still closed, so nothing routable or injectable
+ * gets through.
+ */
+const MdChapterId = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9_-]+$/, "not a MangaDex chapter id");
+
+/** Validate, answering 400 instead of 500. Same helper as the sibling modules. */
+function parseOrThrow<S extends z.ZodTypeAny>(schema: S, value: unknown): z.infer<S> {
+  const result = schema.safeParse(value);
+  if (result.success) return result.data;
+  const issue = result.error.issues[0];
+  const where = issue && issue.path.length > 0 ? issue.path.join(".") : "request";
+  throw Object.assign(new Error(`invalid ${where}: ${issue?.message ?? "validation failed"}`), {
+    statusCode: 400,
+  });
+}
+
+/**
+ * A boolean that may arrive as a query-string word. NOT `z.coerce.boolean()`,
+ * which maps the string "false" to TRUE — the wrong direction to be wrong in on
+ * a flag that guards a delete.
+ */
+const Flag = z.preprocess(
+  (value) => (typeof value === "string" ? value === "true" || value === "1" : value),
+  z.boolean(),
+);
+
+/**
+ * The fields a chapter edit may change, as MangaDex names them.
+ *
+ * This is deliberately the same vocabulary as `PUT /chapter/{id}` rather than
+ * our column names: what an operator types here is what MangaDex receives, and
+ * a translation layer in between is a place for the two to drift. `null` clears
+ * a field; omitting it leaves it alone.
+ *
+ * Lengths mirror the MangaDex API's own limits. They are validated here rather
+ * than discovered from a 400 half an hour later, when the task is claimed.
+ */
+const EditPayload = z
+  .object({
+    volume: z.string().max(8).nullish(),
+    chapter: z.string().max(8).nullish(),
+    title: z.string().max(255).nullish(),
+    translatedLanguage: z.string().min(2).max(16).optional(),
+    groups: z.array(z.string().uuid()).min(1).max(5).optional(),
+    externalUrl: z.string().max(2048).nullish(),
+  })
+  .strict();
+
+export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): void {
+  app.register(async (scope) => {
+    scope.addHook(
+      "preHandler",
+      adminAuthHook({
+        adminToken: ctx.config.adminToken,
+        session: sessionAuthenticator(ctx),
+        apiTokens: ctx.apiTokens,
+      }),
+    );
+    scope.addHook("preHandler", async (req, reply) => {
+      if (!ctx.adminLimiter.allow(req.ip)) {
+        await reply.code(429).send({ error: "rate limited" });
+      }
+    });
+
+    /** Same attribution rules as routes/admin.ts, ops.ts and queues.ts. */
+    const actor = (req: FastifyRequest): string => {
+      const claimed = (req.headers["x-actor"] as string | undefined)?.slice(0, 64);
+      const principal = req.principal;
+      if (principal?.kind === "api-token") {
+        return claimed ? `${principal.name} for ${claimed}` : principal.name;
+      }
+      if (principal?.kind === "session") return principal.name;
+      return `admin:${claimed ?? "root"}`;
+    };
+
+    /**
+     * Every mutating route is ADMIN-or-above AND closed to api tokens, on top
+     * of `chapters:write` — the same construction, and the same reasoning, as
+     * `requireApplyRole` in routes/ops.ts.
+     *
+     * The scope says "this credential works on the chapter catalogue"; the role
+     * says "this principal may change a public one". Tokens are refused
+     * outright rather than judged on their role, because `adminAuthHook` gives
+     * every api token `adminRole = "ADMIN"` — a default meaning "not
+     * owner-equivalent", not "vetted human". Judged on the role alone, any
+     * token carrying `chapters:write` could unpublish chapters under the shared
+     * MangaDex account, which is precisely the blast radius scoped tokens exist
+     * to contain. The dashboard is the only caller, so closing this to tokens
+     * costs no capability, and the break-glass ADMIN_TOKEN is a `root`
+     * principal and still gets through.
+     *
+     * An allow-list on the role, not "refuse CONTRIBUTOR": a deny-list on a
+     * role enum grants every role added after it.
+     */
+    async function requireAdminRole(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+      if (req.principal?.kind === "api-token") {
+        await reply.code(403).send({ error: TOKEN_REFUSAL, requiredRole: "ADMIN" });
+        return;
+      }
+      if (req.adminRole !== "OWNER" && req.adminRole !== "ADMIN") {
+        await reply.code(403).send({ error: ROLE_REFUSAL, requiredRole: "ADMIN" });
+      }
+    }
+
+    const chapterParam = z.object({ mdChapterId: MdChapterId });
+
+    /**
+     * Find the chapter wherever it is recorded.
+     *
+     * Order matters: `uploaded` is the live mirror and wins, then the two
+     * archives that still describe something on MangaDex (a chapter carrying an
+     * unavailable card is still a published chapter, and an edited one
+     * certainly is), and `deleted` last — a hit there alone means the chapter is
+     * gone, which every action needs to refuse.
+     */
+    async function locate(
+      mdChapterId: string,
+    ): Promise<{ archive: ChapterArchive; row: ChapterRow } | null> {
+      for (const archive of ["uploaded", "unavailable", "edited", "deleted"] as const) {
+        const row = await ctx.chapters.get(archive, mdChapterId);
+        if (row) return { archive, row };
+      }
+      return null;
+    }
+
+    /** What MangaDex says right now, or why we could not ask. */
+    async function liveChapter(
+      mdChapterId: string,
+    ): Promise<{ detail: MdChapterDetail | null; error: string | null }> {
+      if (!ctx.md) {
+        return {
+          detail: null,
+          error: "this API instance holds no MangaDex credentials, so the live chapter was not read",
+        };
+      }
+      try {
+        const detail = await ctx.md.chapterById(mdChapterId, ["scanlation_group", "manga"]);
+        return {
+          detail,
+          error: detail ? null : `MangaDex has no chapter ${mdChapterId}; it may already be gone`,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        ctx.log.warn({ err, mdChapterId }, "live MangaDex chapter read failed");
+        return { detail: null, error: message };
+      }
+    }
+
+    /**
+     * Queue one chapter action.
+     *
+     * The payload is built by `chapterToTaskPayload` — the same function the
+     * processor writes its queue rows with — from the stored row, so the queued
+     * work describes the chapter the operator was actually looking at, and the
+     * per-kind sidecars ride along exactly as taskWorkers expects them.
+     * `manualTaskProblems` is the validator routes/queues.ts uses for a
+     * hand-built task: reusing it means a task that would throw on claim is
+     * refused now, and that the two paths cannot drift.
+     */
+    async function queueAction(
+      req: FastifyRequest,
+      reply: FastifyReply,
+      opts: {
+        kind: "EDIT" | "DELETE" | "UNAVAILABLE";
+        row: ChapterRow;
+        sidecars: Record<string, unknown>;
+        audit: string;
+        auditDetail: Record<string, unknown>;
+        warnings?: string[];
+      },
+    ): Promise<FastifyReply> {
+      const chapter = chapterOf(opts.row);
+      const payload: Record<string, unknown> = {
+        ...chapterToTaskPayload(
+          chapter as unknown as Record<string, unknown>,
+          chapter.imageArtifacts,
+        ),
+        ...opts.sidecars,
+      };
+
+      const problems = manualTaskProblems(opts.kind, payload);
+      if (problems.length > 0) {
+        // Reachable for a row whose md_chapter_id is somehow absent, and for an
+        // EDIT whose payload the schema allowed but which reduces to nothing.
+        return reply.code(422).send({ error: "this chapter cannot be queued", problems });
+      }
+
+      const dedupeKey = taskDedupeKey(opts.kind, chapter);
+      if (dedupeKey === null) {
+        return reply.code(422).send({ error: "cannot derive a queue key for this chapter" });
+      }
+
+      const queued = await ctx.uploadTasks.requeueForChapter(opts.kind, dedupeKey, payload);
+      if (!queued) {
+        // The slot is held by work that is already queued or in flight. Read the
+        // row only now, and only to name it — never to decide whether to write.
+        const existing = (await ctx.uploadTasks.forDedupeKey(dedupeKey)).find(
+          (task) => task.kind === opts.kind,
+        );
+        return reply.code(409).send({
+          error:
+            existing?.state === "LEASED"
+              ? `an uploader is executing a ${opts.kind} for this chapter right now ` +
+                `(lease ${existing.leaseId ?? "unknown"}); wait for it to finish and look at the ` +
+                "result before queueing another"
+              : `a ${opts.kind} for this chapter is already queued and has not run yet; ` +
+                "cancel or edit it from the Queues view rather than queueing a second one",
+          outcome: existing?.state === "LEASED" ? "leased" : "already_queued",
+          task: existing ?? null,
+        });
+      }
+
+      await ctx.audit.record(actor(req), opts.audit, opts.row.mdChapterId, {
+        ...opts.auditDetail,
+        extension: opts.row.extension,
+        mdMangaId: opts.row.mdMangaId,
+        chapterNumber: opts.row.chapterNumber,
+        chapterLanguage: opts.row.chapterLanguage,
+        taskId: queued.task.id,
+        supersededCompletedTask: queued.superseded,
+      });
+
+      // 202: the change is queued, not applied. The uploader may still fail it,
+      // and a client that reports "done" here would be lying.
+      return reply.code(202).send({
+        ok: true,
+        queued: true,
+        action: opts.kind,
+        task: queued.task,
+        /** True when a completed or failed task for this chapter was reset in place. */
+        superseded: queued.superseded,
+        mdChapterId: opts.row.mdChapterId,
+        // Named for what it points at: `chapterUrl` on a chapter means the
+        // publisher's link everywhere else in this codebase.
+        mangadexUrl: `${MD_CHAPTER_URL}${opts.row.mdChapterId}`,
+        warnings: opts.warnings ?? [],
+        note: "core-uploader drains this queue; watch it under Queues, filtered by this chapter id.",
+      });
+    }
+
+    // ------------------------------------------------------------------ read
+
+    /**
+     * One page of an archive, newest first.
+     *
+     * `archive` selects which of the four tables is being read — what is on
+     * MangaDex now (`uploaded`), what was replaced by a card (`unavailable`),
+     * what was removed (`deleted`), and what has been edited since it was
+     * published (`edited`). They share a shape, so they share an endpoint.
+     */
+    scope.get("/api/v1/admin/chapters", { preHandler: requireScope("chapters:read") }, async (req) => {
+      const query = parseOrThrow(
+        z.object({
+          archive: z.enum(CHAPTER_ARCHIVES).default("uploaded"),
+          extension: z.string().max(64).optional(),
+          language: z.string().max(16).optional(),
+          mdMangaId: z.string().max(64).optional(),
+          mdChapterId: z.string().max(64).optional(),
+          chapterId: z.string().max(128).optional(),
+          chapterNumber: z.string().max(32).optional(),
+          search: z.string().min(1).max(256).optional(),
+          since: z.coerce.date().optional(),
+          until: z.coerce.date().optional(),
+          limit: z.coerce.number().int().min(1).max(MAX_PAGE).default(DEFAULT_PAGE),
+          cursor: z.string().max(512).optional(),
+        }),
+        req.query ?? {},
+      );
+
+      const cursor = query.cursor ? decodeChapterCursor(query.cursor) : null;
+      if (query.cursor && !cursor) {
+        throw Object.assign(new Error("invalid cursor: not a cursor this endpoint issued"), {
+          statusCode: 400,
+        });
+      }
+
+      const filter: ChapterFilter = {
+        extension: query.extension,
+        chapterLanguage: query.language,
+        mdMangaId: query.mdMangaId,
+        mdChapterId: query.mdChapterId,
+        chapterId: query.chapterId,
+        chapterNumber: query.chapterNumber,
+        search: query.search,
+        since: query.since,
+        until: query.until,
+      };
+
+      const [page, totals] = await Promise.all([
+        ctx.chapters.list(query.archive, filter, { limit: query.limit, cursor }),
+        ctx.chapters.totals(),
+      ]);
+
+      return {
+        archive: query.archive,
+        chapters: page.chapters,
+        total: page.total,
+        limit: query.limit,
+        nextCursor: page.nextCursor,
+        // Named so a client never has to infer it, and so a cursor is obviously
+        // not an offset.
+        order: "at,id (descending)",
+        // Global rather than filtered, so a narrow filter cannot hide that an
+        // extension has three hundred chapters marked unavailable.
+        totals,
+        archives: CHAPTER_ARCHIVES,
+      };
+    });
+
+    /** Per-extension counts for one archive — the filter picker's contents. */
+    scope.get(
+      "/api/v1/admin/chapters/extensions",
+      { preHandler: requireScope("chapters:read") },
+      async (req) => {
+        const { archive } = parseOrThrow(
+          z.object({ archive: z.enum(CHAPTER_ARCHIVES).default("uploaded") }),
+          req.query ?? {},
+        );
+        return { archive, extensions: await ctx.chapters.byExtension(archive) };
+      },
+    );
+
+    /**
+     * One chapter, everywhere it is recorded, plus what MangaDex says now and
+     * anything already queued against it.
+     *
+     * The three together are what an operator needs before touching a public
+     * entry: the row says what we think we published, MangaDex says what is
+     * actually there, and the queue says whether somebody has already asked for
+     * a change that has not landed yet.
+     */
+    scope.get(
+      "/api/v1/admin/chapters/:mdChapterId",
+      { preHandler: requireScope("chapters:read") },
+      async (req, reply) => {
+        const { mdChapterId } = parseOrThrow(chapterParam, req.params);
+        const [history, tasks, live] = await Promise.all([
+          ctx.chapters.history(mdChapterId),
+          ctx.uploadTasks.forDedupeKey(mdChapterId),
+          liveChapter(mdChapterId),
+        ]);
+
+        const found = history.uploaded ?? history.unavailable ?? history.edited ?? history.deleted;
+        if (!found) return reply.code(404).send({ error: "no chapter with that MangaDex id" });
+
+        const attrs = live.detail?.attributes ?? null;
+        return {
+          mdChapterId,
+          chapter: found,
+          // Which tables hold it, so an inconsistency (deleted AND uploaded) is
+          // visible rather than resolved silently by the lookup order above.
+          archives: {
+            uploaded: history.uploaded?.at ?? null,
+            unavailable: history.unavailable?.at ?? null,
+            deleted: history.deleted?.at ?? null,
+            edited: history.edited?.at ?? null,
+          },
+          edits: history.edited?.edits ?? [],
+          mangadex: attrs
+            ? {
+                id: mdChapterId,
+                volume: attrs.volume,
+                chapter: attrs.chapter,
+                title: attrs.title,
+                translatedLanguage: attrs.translatedLanguage,
+                externalUrl: attrs.externalUrl,
+                version: attrs.version,
+                createdAt: attrs.createdAt,
+                groups: (live.detail?.relationships ?? [])
+                  .filter((rel) => rel.type === "scanlation_group")
+                  .map((rel) => rel.id),
+              }
+            : null,
+          mangadexError: live.error,
+          /** Queue rows keyed on this chapter id, whatever their kind or state. */
+          tasks,
+          links: {
+            chapter: `${MD_CHAPTER_URL}${mdChapterId}`,
+            manga: found.mdMangaId ? `${MD_MANGA_URL}${found.mdMangaId}` : null,
+            source: found.chapterUrl ?? null,
+          },
+          /** What a mutating call would be refused for, so the UI can say why first. */
+          actionsBlockedReason: actionsBlockedReason(req, history.deleted !== null && !history.uploaded),
+        };
+      },
+    );
+
+    /**
+     * The unavailable card as it would be posted, rendered now.
+     *
+     * Built by `unavailableCardOptions` — the same function the uploader calls —
+     * from the live chapter when MangaDex is readable and from the stored row
+     * otherwise. That shared derivation is the whole point: an operator
+     * approving one image and publishing another would be worse than having no
+     * preview at all.
+     *
+     * Nothing is written and nothing is queued; this renders a PNG and returns
+     * it. `footerNote` and `unavailableAt` are echoed through so the preview can
+     * show exactly the overrides the action would carry.
+     */
+    scope.get(
+      "/api/v1/admin/chapters/:mdChapterId/card.png",
+      { preHandler: requireScope("chapters:read") },
+      async (req, reply) => {
+        const { mdChapterId } = parseOrThrow(chapterParam, req.params);
+        const query = parseOrThrow(
+          z.object({
+            footerNote: z.string().max(600).optional(),
+            unavailableAt: z.coerce.date().optional(),
+          }),
+          req.query ?? {},
+        );
+
+        const located = await locate(mdChapterId);
+        if (!located) return reply.code(404).send({ error: "no chapter with that MangaDex id" });
+
+        const { detail } = await liveChapter(mdChapterId);
+        const png = await generateChapterCard(
+          unavailableCardOptions({
+            chapter: chapterOf(located.row),
+            detail,
+            unavailableAt: (query.unavailableAt ?? new Date()).toISOString(),
+            footerNote: query.footerNote ?? null,
+          }),
+        );
+        return reply
+          .header("content-type", "image/png")
+          // The image is derived from an admin-only record; the server's global
+          // onSend already sets no-store, and this is a second statement of the
+          // same intent for any intermediary that reads only one of them.
+          .header("cache-control", "no-store, private")
+          .send(png);
+      },
+    );
+
+    // --------------------------------------------------------------- mutate
+
+    /**
+     * Queue an edit of the chapter's MangaDex metadata.
+     *
+     * The body carries only what should change; the uploader lays it over
+     * whatever MangaDex currently holds and sends the whole resource, because
+     * `PUT /chapter/{id}` replaces rather than patches. That merge happens at
+     * execution time on purpose — MangaDex's `version` must be the one current
+     * when the write lands, and reading it here would guarantee it was stale by
+     * the time the task ran.
+     *
+     * `oldInfo` records what the fields looked like when the operator decided,
+     * which is what makes the `edited_chapters` history readable afterwards.
+     */
+    scope.patch(
+      "/api/v1/admin/chapters/:mdChapterId",
+      { preHandler: [requireScope("chapters:write"), requireAdminRole] },
+      async (req, reply) => {
+        const { mdChapterId } = parseOrThrow(chapterParam, req.params);
+        const body = parseOrThrow(EditPayload, req.body ?? {});
+        if (Object.keys(body).length === 0) {
+          return reply.code(400).send({
+            error:
+              "nothing to change: send at least one of volume, chapter, title, " +
+              "translatedLanguage, groups or externalUrl",
+          });
+        }
+
+        const located = await locate(mdChapterId);
+        if (!located) return reply.code(404).send({ error: "no chapter with that MangaDex id" });
+        const gone = goneReason(located);
+        if (gone) return reply.code(409).send({ error: gone });
+
+        const warnings: string[] = [];
+        const payload: Record<string, unknown> = { ...body };
+
+        if (body.translatedLanguage !== undefined) {
+          const language = normaliseMangadexLanguage(body.translatedLanguage);
+          if (!language) {
+            return reply.code(400).send({
+              error:
+                `translatedLanguage ${JSON.stringify(body.translatedLanguage)} is not a language ` +
+                `MangaDex accepts (expected e.g. "en", "ja", "pt-br")`,
+            });
+          }
+          payload.translatedLanguage = language;
+        }
+
+        if (body.externalUrl !== undefined && body.externalUrl !== null && body.externalUrl !== "") {
+          const url = body.externalUrl.trim();
+          let parsed: URL;
+          try {
+            parsed = new URL(url);
+          } catch {
+            return reply.code(400).send({ error: "externalUrl is not a valid absolute URL" });
+          }
+          if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+            return reply
+              .code(400)
+              .send({ error: `externalUrl scheme ${parsed.protocol} is not allowed (http or https only)` });
+          }
+          // The same allowlist the sandbox enforces on the extension, applied to
+          // the operator correcting its output — this URL is published on a
+          // MangaDex entry. A host outside it is a warning rather than a refusal
+          // because a publisher legitimately moves domains, and the person
+          // typing it is the only one who can judge that; the refusal case
+          // (routes/ops.ts, links.raw on a title) is a field we own outright.
+          const manifest = await manifestFor(located.row.extension);
+          if (manifest && !hostAllowed(url, manifest.allowed_hosts)) {
+            warnings.push(
+              `${parsed.host} is not in ${located.row.extension}'s allowed_hosts ` +
+                `(${manifest.allowed_hosts.join(", ")})`,
+            );
+          }
+          payload.externalUrl = url;
+        }
+
+        // What the fields look like now, preferring MangaDex over our mirror —
+        // the history is only worth keeping if "old" is what was really there.
+        const { detail } = await liveChapter(mdChapterId);
+        const attrs = detail?.attributes;
+        const oldInfo: Record<string, unknown> = {};
+        for (const field of Object.keys(payload)) {
+          if (field === "groups") {
+            oldInfo.groups = detail
+              ? detail.relationships.filter((rel) => rel.type === "scanlation_group").map((rel) => rel.id)
+              : located.row.mdGroupId
+                ? [located.row.mdGroupId]
+                : null;
+          } else if (field === "chapter") {
+            oldInfo.chapter = attrs?.chapter ?? located.row.chapterNumber ?? null;
+          } else if (field === "volume") {
+            oldInfo.volume = attrs?.volume ?? located.row.chapterVolume ?? null;
+          } else if (field === "title") {
+            oldInfo.title = attrs?.title ?? located.row.chapterTitle ?? null;
+          } else if (field === "translatedLanguage") {
+            oldInfo.translatedLanguage = attrs?.translatedLanguage ?? located.row.chapterLanguage ?? null;
+          } else if (field === "externalUrl") {
+            oldInfo.externalUrl = attrs?.externalUrl ?? located.row.chapterUrl ?? null;
+          }
+        }
+
+        return queueAction(req, reply, {
+          kind: "EDIT",
+          row: located.row,
+          sidecars: { payload, oldInfo },
+          audit: "chapter.edit",
+          auditDetail: { payload, oldInfo, archive: located.archive },
+          warnings,
+        });
+      },
+    );
+
+    /**
+     * Queue "replace this chapter with an unavailable card".
+     *
+     * What the uploader will do: render the card, attach it as the chapter's
+     * only page through an edit session, repoint `externalUrl` away from the
+     * dead publisher link, and archive the row into `unavailable_chapters`.
+     *
+     * `force` is what makes this repeatable. Without it a chapter that has
+     * already been marked unavailable is a no-op — correct for the automated
+     * pass, useless for an operator replacing a card that says the wrong thing
+     * — so asking again for an already-archived chapter is refused with the
+     * flag it needs, rather than silently doing nothing.
+     */
+    scope.post(
+      "/api/v1/admin/chapters/:mdChapterId/unavailable",
+      { preHandler: [requireScope("chapters:write"), requireAdminRole] },
+      async (req, reply) => {
+        const { mdChapterId } = parseOrThrow(chapterParam, req.params);
+        const body = parseOrThrow(
+          z.object({
+            force: z.boolean().default(false),
+            footerNote: z.string().max(600).optional(),
+          }),
+          req.body ?? {},
+        );
+
+        const located = await locate(mdChapterId);
+        if (!located) return reply.code(404).send({ error: "no chapter with that MangaDex id" });
+        const gone = goneReason(located);
+        if (gone) return reply.code(409).send({ error: gone });
+
+        const already = await ctx.chapters.get("unavailable", mdChapterId);
+        if (already && !body.force) {
+          return reply.code(409).send({
+            error:
+              `this chapter was already marked unavailable on ${already.at.toISOString()}; ` +
+              "pass force: true to render and post a fresh card over the old one",
+            outcome: "already_unavailable",
+            unavailableAt: already.at,
+          });
+        }
+
+        return queueAction(req, reply, {
+          kind: "UNAVAILABLE",
+          row: located.row,
+          sidecars: {
+            unavailableAt: new Date().toISOString(),
+            ...(body.force ? { force: true } : {}),
+            ...(body.footerNote ? { footerNote: body.footerNote } : {}),
+          },
+          audit: "chapter.unavailable",
+          auditDetail: {
+            force: body.force,
+            footerNote: body.footerNote ?? null,
+            archive: located.archive,
+            regenerated: already !== null,
+          },
+        });
+      },
+    );
+
+    /**
+     * Queue a hard delete from MangaDex.
+     *
+     * The one irreversible action the platform takes, so: `confirm: true`, the
+     * admin role, a full audit row, and — in the uploader — an archive write to
+     * `deleted_chapters` BEFORE the live row is dropped, so the record of what
+     * was removed outlives it.
+     *
+     * Marking a chapter unavailable is nearly always the better answer, because
+     * it keeps the entry and its reading history on MangaDex; that is what the
+     * `alternative` field says out loud on every refusal for want of `confirm`.
+     */
+    scope.delete(
+      "/api/v1/admin/chapters/:mdChapterId",
+      { preHandler: [requireScope("chapters:write"), requireAdminRole] },
+      async (req, reply) => {
+        const { mdChapterId } = parseOrThrow(chapterParam, req.params);
+        const options = parseOrThrow(
+          z.object({ confirm: Flag.optional(), reason: z.string().max(500).optional() }),
+          { ...(req.query as Record<string, unknown>), ...(req.body as Record<string, unknown>) },
+        );
+        if (options.confirm !== true) {
+          return reply.code(400).send({
+            error:
+              "deleting a chapter from MangaDex cannot be undone; pass confirm: true",
+            alternative:
+              "POST /api/v1/admin/chapters/{id}/unavailable keeps the entry and replaces its page " +
+              "with a card explaining that the publisher removed it",
+          });
+        }
+
+        const located = await locate(mdChapterId);
+        if (!located) return reply.code(404).send({ error: "no chapter with that MangaDex id" });
+        const gone = goneReason(located);
+        if (gone) return reply.code(409).send({ error: gone });
+
+        return queueAction(req, reply, {
+          kind: "DELETE",
+          row: located.row,
+          sidecars: {},
+          audit: "chapter.delete",
+          auditDetail: {
+            reason: options.reason ?? null,
+            archive: located.archive,
+            // The whole row: after the uploader runs, `deleted_chapters` and
+            // this audit entry are the only records that the chapter existed.
+            chapter: located.row,
+          },
+        });
+      },
+    );
+
+    // -------------------------------------------------------------- helpers
+
+    async function manifestFor(extension: string | null): Promise<{ allowed_hosts: string[] } | null> {
+      if (!extension) return null;
+      const bundle = await ctx.bundles.latest(extension);
+      if (!bundle) return null;
+      const parsed = Manifest.safeParse(bundle.manifest);
+      return parsed.success ? parsed.data : null;
+    }
+
+    /**
+     * Why a mutating call would be refused, or null when it would be accepted.
+     * Returned by the GET so the dashboard can disable a control WITH the
+     * reason, rather than letting an operator discover it from a 403.
+     */
+    function actionsBlockedReason(req: FastifyRequest, deletedOnly: boolean): string | null {
+      // Mirrors requireAdminRole exactly, api-token clause included. If the two
+      // ever disagree the dashboard offers a button that 403s, which is the
+      // failure this function exists to avoid.
+      if (req.principal?.kind === "api-token") return TOKEN_REFUSAL;
+      if (req.adminRole !== "OWNER" && req.adminRole !== "ADMIN") return ROLE_REFUSAL;
+      if (deletedOnly) return DELETED_REASON;
+      return null;
+    }
+  });
+}
+
+// ------------------------------------------------------------------ internals
+
+const ROLE_REFUSAL =
+  "changing a published chapter requires the ADMIN role: it edits, hides or removes a public " +
+  "catalogue entry under the platform's MangaDex account. Ask an admin to make the change.";
+
+const TOKEN_REFUSAL =
+  "changing a published chapter is closed to api tokens however broadly they are scoped: it " +
+  "changes a public catalogue entry under the platform's MangaDex account, so it is attributable " +
+  "to a signed-in operator or nothing. Make the change from the dashboard.";
+
+const DELETED_REASON =
+  "this chapter is recorded as deleted from MangaDex, so there is nothing left to change. " +
+  "If MangaDex still has it, the archive row is stale — queue the action from the Queues view by hand.";
+
+/** Refusal text when the only record of a chapter is its deletion. */
+function goneReason(located: { archive: ChapterArchive; row: ChapterRow }): string | null {
+  if (located.archive !== "deleted") return null;
+  return `${DELETED_REASON} (deleted ${located.row.at.toISOString()}; archive: ${ARCHIVES.deleted.label})`;
+}

--- a/src/core/api/routes/chapters.ts
+++ b/src/core/api/routes/chapters.ts
@@ -1,6 +1,7 @@
 // Not self-registering: server.ts is owned elsewhere, so the integrator wires
 // this module in with `registerChapterRoutes(app, ctx)` next to the other route
 // modules.
+import { randomUUID } from "node:crypto";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import type { AppContext } from "../context.js";
@@ -60,6 +61,17 @@ import { manualTaskProblems } from "./queues.js";
 const MAX_PAGE = 200;
 const DEFAULT_PAGE = 50;
 
+/**
+ * Hard ceiling on one bulk action.
+ *
+ * Lower than the 1000 routes/queues.ts allows, and for a reason: that cap bounds
+ * a change to queue rows, this one bounds a change to public pages that readers
+ * are looking at. Two hundred is a large deliberate action — a whole series, a
+ * bad run's worth of uploads — and small enough that the dry run listing every
+ * affected chapter is still something a person will actually read.
+ */
+const CHAPTER_BULK_CAP = 200;
+
 const MD_CHAPTER_URL = "https://mangadex.org/chapter/";
 const MD_MANGA_URL = "https://mangadex.org/title/";
 
@@ -118,6 +130,20 @@ const EditPayload = z
     translatedLanguage: z.string().min(2).max(16).optional(),
     groups: z.array(z.string().uuid()).min(1).max(5).optional(),
     externalUrl: z.string().max(2048).nullish(),
+  })
+  .strict();
+
+/**
+ * What a *bulk* edit may change: the fields a set of chapters can legitimately
+ * share. Title, chapter number and external URL are one chapter's identity, and
+ * writing one of those across two hundred chapters is not an operation anyone
+ * wants — so it is not expressible here rather than merely discouraged.
+ */
+const BulkEditPayload = z
+  .object({
+    volume: z.string().max(8).nullish(),
+    translatedLanguage: z.string().min(2).max(16).optional(),
+    groups: z.array(z.string().uuid()).min(1).max(5).optional(),
   })
   .strict();
 
@@ -731,6 +757,464 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
             // this audit entry are the only records that the chapter existed.
             chapter: located.row,
           },
+        });
+      },
+    );
+
+    // ----------------------------------------------------------------- bulk
+
+    /**
+     * The same three actions over a set of chapters.
+     *
+     * Two ways to name the set, and they are not symmetrical. `ids` is an
+     * enumeration the operator built by looking at rows; `filter` is a
+     * description, and a description can match more than whoever wrote it
+     * imagined. So:
+     *
+     *  - **`dryRun` defaults to TRUE**, always. The first call anyone makes —
+     *    including a client that forgot the field — writes nothing and reports
+     *    exactly what it would have done, per chapter. A live run needs
+     *    `dryRun: false` AND `confirm: true`, two fields that cannot both be set
+     *    by accident. This is the purge doctrine from routes/queues.ts applied
+     *    to a sharper operation: purge deletes queue rows, this changes public
+     *    pages.
+     *  - **The cap is 200 per call** and is applied inside the id resolution, so
+     *    an over-wide filter cannot become an unbounded read on its way to
+     *    becoming an unbounded write. A truncated set says so and the operator
+     *    calls again.
+     *
+     * The dry run is genuinely predictive: it resolves the same rows, checks the
+     * same refusals (deleted, already-unavailable-without-force, a task already
+     * queued or leased) and reports per-chapter outcomes. It is a preview of
+     * this operation, not an estimate of it. The live path still does not
+     * read-then-write — every insert is the same guarded upsert, and a chapter
+     * whose state changed between the preview and the write comes back refused.
+     */
+    interface BulkItem {
+      mdChapterId: string;
+      ok: boolean;
+      outcome:
+        | "queued"
+        | "requeued"
+        | "would_queue"
+        | "already_queued"
+        | "leased"
+        | "not_found"
+        | "deleted"
+        | "needs_force"
+        | "invalid";
+      taskId?: string;
+      reason?: string;
+      /** Enough to recognise the row in a preview without a second request. */
+      mangaName?: string | null;
+      chapterNumber?: string | null;
+      chapterLanguage?: string | null;
+      extension?: string | null;
+    }
+
+    const BulkFilter = z
+      .object({
+        archive: z.enum(CHAPTER_ARCHIVES).default("uploaded"),
+        extension: z.string().max(64).optional(),
+        language: z.string().max(16).optional(),
+        mdMangaId: z.string().max(64).optional(),
+        chapterNumber: z.string().max(32).optional(),
+        search: z.string().min(1).max(256).optional(),
+        since: z.coerce.date().optional(),
+        until: z.coerce.date().optional(),
+      })
+      .strict();
+
+    /** `ids` XOR `filter`, plus the two flags every bulk body carries. */
+    const bulkBody = <T extends z.ZodRawShape>(extra: T) =>
+      z
+        .object({
+          ids: z.array(MdChapterId).min(1).max(CHAPTER_BULK_CAP).optional(),
+          filter: BulkFilter.optional(),
+          dryRun: z.boolean().default(true),
+          confirm: z.boolean().default(false),
+          ...extra,
+        })
+        .strict()
+        .refine((value) => (value.ids ? 1 : 0) + (value.filter ? 1 : 0) === 1, {
+          message: "provide exactly one of `ids` or `filter`",
+        });
+
+    function toBulkFilter(filter: z.infer<typeof BulkFilter>): ChapterFilter {
+      return {
+        extension: filter.extension,
+        chapterLanguage: filter.language,
+        mdMangaId: filter.mdMangaId,
+        chapterNumber: filter.chapterNumber,
+        search: filter.search,
+        since: filter.since,
+        until: filter.until,
+      };
+    }
+
+    /**
+     * Locate many chapters at once, by the same archive precedence as `locate`.
+     *
+     * Four queries whatever the size of the set — the per-chapter `locate` would
+     * be four *each*, and a two-hundred-chapter preview would spend eight
+     * hundred round trips deciding what it was going to do.
+     */
+    async function locateMany(
+      ids: readonly string[],
+    ): Promise<Map<string, { archive: ChapterArchive; row: ChapterRow }>> {
+      const found = new Map<string, { archive: ChapterArchive; row: ChapterRow }>();
+      // Reverse precedence order: later writes win, so `uploaded` (last) beats
+      // `deleted` (first) for a chapter that is somehow in both.
+      for (const archive of ["deleted", "edited", "unavailable", "uploaded"] as const) {
+        for (const row of await ctx.chapters.manyByIds(archive, ids)) {
+          found.set(row.mdChapterId, { archive, row });
+        }
+      }
+      return found;
+    }
+
+    async function runBulk(
+      req: FastifyRequest,
+      reply: FastifyReply,
+      opts: {
+        kind: "EDIT" | "DELETE" | "UNAVAILABLE";
+        body: { ids?: string[]; filter?: z.infer<typeof BulkFilter>; dryRun: boolean; confirm: boolean };
+        /** Per-chapter task sidecars. Constant across the set by construction. */
+        sidecars: Record<string, unknown>;
+        /** UNAVAILABLE only: re-card chapters that already carry one. */
+        force?: boolean;
+        auditAction: string;
+        auditDetail: Record<string, unknown>;
+      },
+    ): Promise<FastifyReply> {
+      const { kind, body } = opts;
+      const archive = body.filter?.archive ?? "uploaded";
+
+      let ids: string[];
+      let capped = false;
+      let matched: number;
+      if (body.ids) {
+        ids = [...new Set(body.ids)];
+        matched = ids.length;
+      } else {
+        const filter = toBulkFilter(body.filter!);
+        const resolved = await ctx.chapters.idsMatching(archive, filter, CHAPTER_BULK_CAP + 1);
+        capped = resolved.length > CHAPTER_BULK_CAP;
+        ids = resolved.slice(0, CHAPTER_BULK_CAP);
+        matched = await ctx.chapters.countMatching(archive, filter);
+      }
+
+      const [located, unavailableRows, queued] = await Promise.all([
+        locateMany(ids),
+        // Only needed by the UNAVAILABLE path, where "is a card already posted?"
+        // decides whether `force` is required — and `locate` may have resolved
+        // the same chapter from `uploaded`, which does not answer that.
+        opts.kind === "UNAVAILABLE" ? ctx.chapters.manyByIds("unavailable", ids) : Promise.resolve([]),
+        ctx.uploadTasks.forDedupeKeys(ids),
+      ]);
+      const alreadyUnavailable = new Set(unavailableRows.map((row) => row.mdChapterId));
+      const taskByChapter = new Map(
+        queued.filter((task) => task.kind === kind).map((task) => [task.dedupeKey, task]),
+      );
+
+      /** The refusal for one chapter, or null when the write should be tried. */
+      const blockedReason = (id: string): { outcome: BulkItem["outcome"]; reason: string } | null => {
+        const hit = located.get(id);
+        if (!hit) return { outcome: "not_found", reason: "no chapter with that MangaDex id" };
+        if (hit.archive === "deleted") return { outcome: "deleted", reason: DELETED_REASON };
+        if (kind === "UNAVAILABLE" && alreadyUnavailable.has(id) && !opts.force) {
+          return {
+            outcome: "needs_force",
+            reason: "already marked unavailable; pass force: true to post a fresh card over the old one",
+          };
+        }
+        const task = taskByChapter.get(id);
+        if (task?.state === "LEASED") {
+          return { outcome: "leased", reason: `an uploader is executing a ${kind} for this chapter now` };
+        }
+        if (task?.state === "PENDING") {
+          return { outcome: "already_queued", reason: `a ${kind} for this chapter is already queued` };
+        }
+        return null;
+      };
+
+      const describe = (id: string): Partial<BulkItem> => {
+        const row = located.get(id)?.row;
+        return row
+          ? {
+              mangaName: row.mangaName ?? null,
+              chapterNumber: row.chapterNumber ?? null,
+              chapterLanguage: row.chapterLanguage ?? null,
+              extension: row.extension ?? null,
+            }
+          : {};
+      };
+
+      // ---- dry run: predict, write nothing, audit nothing ----
+      if (body.dryRun) {
+        const results: BulkItem[] = ids.map((id) => {
+          const blocked = blockedReason(id);
+          return blocked
+            ? { mdChapterId: id, ok: false, ...blocked, ...describe(id) }
+            : { mdChapterId: id, ok: true, outcome: "would_queue", ...describe(id) };
+        });
+        return reply.send({
+          dryRun: true,
+          action: kind,
+          matched,
+          resolved: ids.length,
+          wouldQueue: results.filter((item) => item.ok).length,
+          blocked: results.filter((item) => !item.ok).length,
+          capped,
+          cap: CHAPTER_BULK_CAP,
+          breakdown: body.filter
+            ? await ctx.chapters.byExtension(archive, toBulkFilter(body.filter))
+            : undefined,
+          results,
+          note:
+            "nothing was changed and nothing was queued. Repeat with {dryRun: false, confirm: true} " +
+            "to queue exactly this set" +
+            (capped ? `, ${CHAPTER_BULK_CAP} chapters at a time` : ""),
+        });
+      }
+
+      if (!body.confirm) {
+        return reply.code(400).send({
+          error: "a live bulk action needs confirm: true alongside dryRun: false",
+          wouldQueue: ids.filter((id) => blockedReason(id) === null).length,
+        });
+      }
+
+      // ---- live: one guarded upsert per chapter ----
+      const bulkId = randomUUID();
+      const results: BulkItem[] = [];
+      const auditRows: { actor: string; action: string; subject: string; detail: unknown }[] = [];
+      const who = actor(req);
+      const lostRace: string[] = [];
+
+      for (const id of ids) {
+        const blocked = blockedReason(id);
+        if (blocked) {
+          results.push({ mdChapterId: id, ok: false, ...blocked, ...describe(id) });
+          continue;
+        }
+        const row = located.get(id)!.row;
+        const chapter = chapterOf(row);
+        const payload: Record<string, unknown> = {
+          ...chapterToTaskPayload(chapter as unknown as Record<string, unknown>, chapter.imageArtifacts),
+          ...opts.sidecars,
+        };
+        const problems = manualTaskProblems(kind, payload);
+        const dedupeKey = taskDedupeKey(kind, chapter);
+        if (problems.length > 0 || dedupeKey === null) {
+          results.push({
+            mdChapterId: id,
+            ok: false,
+            outcome: "invalid",
+            reason: problems[0] ?? "cannot derive a queue key for this chapter",
+            ...describe(id),
+          });
+          continue;
+        }
+
+        const created = await ctx.uploadTasks.requeueForChapter(kind, dedupeKey, payload);
+        if (!created) {
+          // The row moved between the prediction and this statement. The write
+          // was still guarded, so nothing was clobbered; name it afterwards.
+          lostRace.push(id);
+          results.push({
+            mdChapterId: id,
+            ok: false,
+            outcome: "already_queued",
+            reason: "a task for this chapter was queued or claimed while this batch was running",
+            ...describe(id),
+          });
+          continue;
+        }
+        results.push({
+          mdChapterId: id,
+          ok: true,
+          outcome: created.superseded ? "requeued" : "queued",
+          taskId: created.task.id,
+          ...describe(id),
+        });
+        // Per chapter, so "who changed this one, and why?" stays answerable by
+        // subject — a batch that wrote only a summary row would not answer it.
+        auditRows.push({
+          actor: who,
+          action: opts.auditAction,
+          subject: id,
+          detail: {
+            ...opts.auditDetail,
+            bulk: bulkId,
+            extension: row.extension,
+            mdMangaId: row.mdMangaId,
+            chapterNumber: row.chapterNumber,
+            chapterLanguage: row.chapterLanguage,
+            taskId: created.task.id,
+            supersededCompletedTask: created.superseded,
+            ...(kind === "DELETE" ? { chapter: row } : {}),
+          },
+        });
+      }
+
+      if (lostRace.length > 0) {
+        // One query, purely to replace a generic message with the real state.
+        const now = await ctx.uploadTasks.forDedupeKeys(lostRace);
+        const byChapter = new Map(
+          now.filter((task) => task.kind === kind).map((task) => [task.dedupeKey, task]),
+        );
+        for (const item of results) {
+          const task = byChapter.get(item.mdChapterId);
+          if (!task || item.ok) continue;
+          if (task.state === "LEASED") {
+            item.outcome = "leased";
+            item.reason = `an uploader claimed a ${kind} for this chapter while this batch was running`;
+          }
+        }
+      }
+
+      const queuedCount = results.filter((item) => item.ok).length;
+      await ctx.audit.recordMany([
+        ...auditRows,
+        {
+          actor: who,
+          action: `${opts.auditAction}.bulk`,
+          subject: bulkId,
+          detail: {
+            ...opts.auditDetail,
+            bulk: bulkId,
+            requested: ids.length,
+            queued: queuedCount,
+            refused: results.length - queuedCount,
+            capped,
+            ...(body.filter ? { filter: body.filter } : { ids }),
+          },
+        },
+      ]);
+
+      // 200, not 202: a batch where eight chapters queued and two were refused
+      // is a success and a partial failure at once, and only the per-chapter
+      // results say which is which.
+      return reply.send({
+        ok: true,
+        dryRun: false,
+        action: kind,
+        bulk: bulkId,
+        matched,
+        requested: ids.length,
+        queued: queuedCount,
+        refused: results.length - queuedCount,
+        capped,
+        ...(capped
+          ? { cap: CHAPTER_BULK_CAP, note: `more chapters matched than the ${CHAPTER_BULK_CAP}-chapter cap; call again` }
+          : {}),
+        results,
+      });
+    }
+
+    /**
+     * Bulk edit.
+     *
+     * The fields are deliberately a SUBSET of the single-chapter edit: volume,
+     * language and groups are properties a set of chapters can legitimately
+     * share, while a title, a chapter number and an external URL are that one
+     * chapter's identity. Writing one title across two hundred chapters is not
+     * an operation anybody wants — it is a mistake with a keyboard shortcut — so
+     * the schema does not express it.
+     *
+     * `oldInfo` here comes from our own rows rather than a live MangaDex read:
+     * two hundred chapter reads would be slower than the batch itself and would
+     * spend the MangaDex ratelimit the uploader needs. Correctness is unaffected
+     * — the uploader still merges against the live resource when it runs, and
+     * `version` is still read there — only the recorded "old" is our mirror's
+     * view, which is the trade the field is worth.
+     */
+    scope.post(
+      "/api/v1/admin/chapters/bulk/edit",
+      { preHandler: [requireScope("chapters:write"), requireAdminRole] },
+      async (req, reply) => {
+        const body = parseOrThrow(bulkBody({ changes: BulkEditPayload }), req.body ?? {});
+        if (Object.keys(body.changes).length === 0) {
+          return reply.code(400).send({
+            error: "nothing to change: send at least one of volume, translatedLanguage or groups",
+            note:
+              "title, chapter number and externalUrl are per-chapter identity and are only editable " +
+              "one chapter at a time",
+          });
+        }
+
+        const changes: Record<string, unknown> = { ...body.changes };
+        if (body.changes.translatedLanguage !== undefined) {
+          const language = normaliseMangadexLanguage(body.changes.translatedLanguage);
+          if (!language) {
+            return reply.code(400).send({
+              error:
+                `translatedLanguage ${JSON.stringify(body.changes.translatedLanguage)} is not a ` +
+                `language MangaDex accepts (expected e.g. "en", "ja", "pt-br")`,
+            });
+          }
+          changes.translatedLanguage = language;
+        }
+
+        return runBulk(req, reply, {
+          kind: "EDIT",
+          body,
+          sidecars: { payload: changes, oldInfo: null },
+          auditAction: "chapter.edit",
+          auditDetail: { payload: changes, bulkKind: "edit" },
+        });
+      },
+    );
+
+    /** Bulk "replace with an unavailable card", including regenerating cards. */
+    scope.post(
+      "/api/v1/admin/chapters/bulk/unavailable",
+      { preHandler: [requireScope("chapters:write"), requireAdminRole] },
+      async (req, reply) => {
+        const body = parseOrThrow(
+          bulkBody({ force: z.boolean().default(false), footerNote: z.string().max(600).optional() }),
+          req.body ?? {},
+        );
+        return runBulk(req, reply, {
+          kind: "UNAVAILABLE",
+          body,
+          force: body.force,
+          sidecars: {
+            unavailableAt: new Date().toISOString(),
+            ...(body.force ? { force: true } : {}),
+            ...(body.footerNote ? { footerNote: body.footerNote } : {}),
+          },
+          auditAction: "chapter.unavailable",
+          auditDetail: { force: body.force, footerNote: body.footerNote ?? null, bulkKind: "unavailable" },
+        });
+      },
+    );
+
+    /**
+     * Bulk delete — the sharpest thing in this file.
+     *
+     * Nothing extra guards it beyond what the other two have, and that is a
+     * deliberate judgement rather than an oversight: the guards that matter are
+     * already the strongest the codebase has (ADMIN role, no api tokens,
+     * dry-run-by-default, an explicit confirm, a 200-chapter cap, the whole row
+     * in the audit trail per chapter). Adding a fourth flag here would train
+     * operators to set flags without reading them.
+     *
+     * The dry run is where the safety actually lives: it names every chapter it
+     * would remove, which is the last chance anyone gets.
+     */
+    scope.post(
+      "/api/v1/admin/chapters/bulk/delete",
+      { preHandler: [requireScope("chapters:write"), requireAdminRole] },
+      async (req, reply) => {
+        const body = parseOrThrow(bulkBody({ reason: z.string().max(500).optional() }), req.body ?? {});
+        return runBulk(req, reply, {
+          kind: "DELETE",
+          body,
+          sidecars: {},
+          auditAction: "chapter.delete",
+          auditDetail: { reason: body.reason ?? null, bulkKind: "delete" },
         });
       },
     );

--- a/src/core/api/scopes.ts
+++ b/src/core/api/scopes.ts
@@ -20,6 +20,13 @@
 export const SCOPES = [
   "runs:read",
   "runs:write",
+  // The chapter history tables: what this platform has published on MangaDex.
+  // Deliberately NOT part of runs:*, which is about scraping and the queue that
+  // drains from it. `chapters:write` queues an edit, a takedown or a delete
+  // against a live public catalogue entry, so a credential that may trigger a
+  // run does not thereby get to unpublish chapters.
+  "chapters:read",
+  "chapters:write",
   "workers:read",
   "workers:write",
   "enroll:write",

--- a/src/core/api/server.ts
+++ b/src/core/api/server.ts
@@ -6,6 +6,7 @@ import { registerAdminRoutes } from "./routes/admin.js";
 import { registerTokenRoutes } from "./routes/tokens.js";
 import { registerOpsRoutes } from "./routes/ops.js";
 import { registerQueueRoutes } from "./routes/queues.js";
+import { registerChapterRoutes } from "./routes/chapters.js";
 import { registerSysopsRoutes } from "./routes/sysops.js";
 import { registerWebhookRoutes } from "./routes/webhooks.js";
 import { registerSessionRoutes } from "./session.js";
@@ -103,6 +104,7 @@ export function buildServer(ctx: AppContext): FastifyInstance {
   registerTokenRoutes(app, ctx);
   registerOpsRoutes(app, ctx);
   registerQueueRoutes(app, ctx);
+  registerChapterRoutes(app, ctx);
   registerSysopsRoutes(app, ctx);
   // Unauthenticated on purpose: the GitHub HMAC signature is the credential,
   // so this must NOT sit inside the admin scope.

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -3,6 +3,7 @@ import type { Config } from "../../config.js";
 import type { Logger } from "../../logging.js";
 import { metrics } from "../../metrics.js";
 import { generateChapterCard } from "./card.js";
+import { unavailableCardOptions } from "./unavailableCard.js";
 import { chapterFromJson, chapterToColumns, uploadedChapterColumns } from "./chapterRows.js";
 import type { MdChapterDetail, MdExtendedApi } from "./client.js";
 import type { DiscordEmbedInput, DiscordNotifier } from "./webhook.js";
@@ -382,6 +383,18 @@ export class UploadTaskWorkers {
    * unavailable.py: fetch the chapter, render the card, open an *edit* upload
    * session for that chapter, attach the card as its only page, then repoint the
    * publisher link away from the dead URL via PUT /chapter.
+   *
+   * Two sidecars on the task payload, both only ever set by an operator action
+   * (routes/chapters.ts); the processor never sets either:
+   *
+   *  - `force` re-renders the card for a chapter that has ALREADY been marked
+   *    unavailable. Without it the "no externalUrl left" branch below archives
+   *    and returns, which is right for the automated pass — the work is done —
+   *    but makes the card unfixable once posted. A card carrying a wrong series
+   *    title, or one rendered before the layout was corrected, is a page on a
+   *    public catalogue, so there has to be a way to replace it.
+   *  - `footerNote` overrides the explanatory paragraph on the card, for the
+   *    takedowns whose reason is not "the publisher removed it".
    */
   private async runUnavailable(
     chapter: Chapter,
@@ -391,6 +404,8 @@ export class UploadTaskWorkers {
     const { md } = this.deps;
     const mdChapterId = chapter.mdChapterId;
     if (!mdChapterId) throw new TaskError("unavailable task has no mdChapterId");
+    const force = raw["force"] === true;
+    const footerNote = readString(raw, "footerNote");
 
     let detail: MdChapterDetail | null;
     try {
@@ -411,7 +426,7 @@ export class UploadTaskWorkers {
     }
 
     const attrs = detail.attributes;
-    if (!attrs.externalUrl) {
+    if (!attrs.externalUrl && !force) {
       log.info({ mdChapterId }, "chapter already has no externalUrl, archiving");
       await this.archiveUnavailable(mdChapterId, chapter, null);
       metrics.uploadsTotal.inc({ outcome: "unavailable_already_done" });
@@ -424,16 +439,14 @@ export class UploadTaskWorkers {
       .map((rel) => rel.id);
 
     try {
-      const card = await generateChapterCard({
-        mangaName: resolveMangaName(detail, chapter),
-        chapterNumber: attrs.chapter ?? chapter.chapterNumber,
-        chapterTitle: attrs.title ?? chapter.chapterTitle,
-        extensionName: chapter.extensionName ?? "Unknown",
-        chapterLanguage: attrs.translatedLanguage || chapter.chapterLanguage,
-        chapterUrl: attrs.externalUrl ?? chapter.chapterUrl,
-        availableFrom: chapter.chapterTimestamp,
-        availableTo: readString(raw, "unavailableAt") ?? chapter.chapterExpire,
-      });
+      const card = await generateChapterCard(
+        unavailableCardOptions({
+          chapter,
+          detail,
+          unavailableAt: readString(raw, "unavailableAt"),
+          footerNote,
+        }),
+      );
 
       const session = await md.beginEditSession(mdChapterId, attrs.version);
       try {
@@ -473,8 +486,8 @@ export class UploadTaskWorkers {
           throw new TaskError(`couldn't repoint externalUrl for chapter ${mdChapterId}`);
         }
         log.info(
-          { mdChapterId, replacementUrl: replacementUrl ?? "cleared" },
-          "chapter marked unavailable",
+          { mdChapterId, replacementUrl: replacementUrl ?? "cleared", force },
+          force ? "unavailable card regenerated" : "chapter marked unavailable",
         );
       } catch (err) {
         await this.safeDeleteSession(session.id, log);
@@ -610,47 +623,6 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 function readString(source: Record<string, unknown>, key: string): string | null {
   const value = source[key];
   return typeof value === "string" && value !== "" ? value : null;
-}
-
-/**
- * Series title for the card. Prefer the manga relationship MangaDex returned
- * (via includes[]=manga) over whatever the queue row carried — the queued name
- * is often absent, which is what used to render cards as "Untitled".
- */
-function resolveMangaName(detail: MdChapterDetail, chapter: Chapter): string {
-  const manga = detail.relationships.find((rel) => rel.type === "manga");
-  const attrs = manga?.attributes;
-  if (attrs) {
-    const title = asRecord(attrs.title) ?? {};
-    const altTitles = Array.isArray(attrs.altTitles) ? attrs.altTitles : [];
-    const alt: Record<string, unknown> = {};
-    for (const entry of altTitles) {
-      const record = asRecord(entry);
-      if (!record) continue;
-      for (const [lang, value] of Object.entries(record)) {
-        if (!(lang in alt)) alt[lang] = value;
-      }
-    }
-    const pick = (lang: string): string | null => {
-      const value = title[lang] ?? alt[lang];
-      return typeof value === "string" && value !== "" ? value : null;
-    };
-    const originalLanguage = typeof attrs.originalLanguage === "string" ? attrs.originalLanguage : null;
-    const resolved =
-      pick("en") ??
-      (originalLanguage ? (pick(`${originalLanguage}-ro`) ?? pick(originalLanguage)) : null) ??
-      firstString(title) ??
-      firstString(alt);
-    if (resolved) return resolved;
-  }
-  return chapter.mangaName ?? "Untitled";
-}
-
-function firstString(source: Record<string, unknown>): string | null {
-  for (const value of Object.values(source)) {
-    if (typeof value === "string" && value !== "") return value;
-  }
-  return null;
 }
 
 function isHttpUrl(url: string | null | undefined): boolean {

--- a/src/core/md/unavailableCard.ts
+++ b/src/core/md/unavailableCard.ts
@@ -1,0 +1,86 @@
+import type { MdChapterDetail } from "./client.js";
+import type { ChapterCardOptions } from "./card.js";
+import type { Chapter } from "./types.js";
+
+/**
+ * What goes on the "this chapter is no longer available" card.
+ *
+ * Extracted from taskWorkers.ts so that the uploader and the dashboard's
+ * preview endpoint derive the card from the same inputs by the same rules. A
+ * preview that differs from what is posted is worse than no preview: an
+ * operator would approve one image and publish another, and the difference
+ * would only ever be noticed by a reader.
+ *
+ * MangaDex is preferred over the stored row wherever both have an answer,
+ * because the row is a mirror that may be days old while the card is about to
+ * become the chapter's only page.
+ */
+export function unavailableCardOptions(input: {
+  chapter: Chapter;
+  /** The live chapter, when MangaDex could be read; null falls back to the row. */
+  detail: MdChapterDetail | null;
+  /** When availability ended; the card's "available from → to" window. */
+  unavailableAt?: string | null;
+  /** Replaces the standard explanatory paragraph. */
+  footerNote?: string | null;
+}): ChapterCardOptions {
+  const { chapter, detail } = input;
+  const attrs = detail?.attributes ?? null;
+  return {
+    mangaName: resolveMangaName(detail, chapter),
+    chapterNumber: attrs?.chapter ?? chapter.chapterNumber,
+    chapterTitle: attrs?.title ?? chapter.chapterTitle,
+    extensionName: chapter.extensionName ?? "Unknown",
+    chapterLanguage: attrs?.translatedLanguage || chapter.chapterLanguage,
+    chapterUrl: attrs?.externalUrl ?? chapter.chapterUrl,
+    availableFrom: chapter.chapterTimestamp,
+    availableTo: input.unavailableAt ?? chapter.chapterExpire,
+    footerNote: input.footerNote ?? null,
+  };
+}
+
+/**
+ * Series title for the card. Prefer the manga relationship MangaDex returned
+ * (via includes[]=manga) over whatever the queue row carried — the queued name
+ * is often absent, which is what used to render cards as "Untitled".
+ */
+export function resolveMangaName(detail: MdChapterDetail | null, chapter: Chapter): string {
+  const manga = detail?.relationships.find((rel) => rel.type === "manga");
+  const attrs = manga?.attributes;
+  if (attrs) {
+    const title = asRecord(attrs.title) ?? {};
+    const altTitles = Array.isArray(attrs.altTitles) ? attrs.altTitles : [];
+    const alt: Record<string, unknown> = {};
+    for (const entry of altTitles) {
+      const record = asRecord(entry);
+      if (!record) continue;
+      for (const [lang, value] of Object.entries(record)) {
+        if (!(lang in alt)) alt[lang] = value;
+      }
+    }
+    const pick = (lang: string): string | null => {
+      const value = title[lang] ?? alt[lang];
+      return typeof value === "string" && value !== "" ? value : null;
+    };
+    const originalLanguage = typeof attrs.originalLanguage === "string" ? attrs.originalLanguage : null;
+    const resolved =
+      pick("en") ??
+      (originalLanguage ? (pick(`${originalLanguage}-ro`) ?? pick(originalLanguage)) : null) ??
+      firstString(title) ??
+      firstString(alt);
+    if (resolved) return resolved;
+  }
+  return chapter.mangaName ?? "Untitled";
+}
+
+function firstString(source: Record<string, unknown>): string | null {
+  for (const value of Object.values(source)) {
+    if (typeof value === "string" && value !== "") return value;
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}

--- a/src/core/store/chapters.ts
+++ b/src/core/store/chapters.ts
@@ -1,0 +1,297 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { chapterFromColumns, type StoredChapterRow } from "../md/chapterRows.js";
+import type { Chapter } from "../md/types.js";
+
+/**
+ * Read access to the four chapter history tables — what this platform has put
+ * on MangaDex, and what has since happened to it.
+ *
+ * The writers already exist (processor.ts records uploads, taskWorkers.ts
+ * archives deletes/unavailables/edits); until now nothing could *read* them
+ * back, so "which chapter is this, and is it still up?" meant `psql` on the
+ * core container. This is the read half, and it is deliberately read-only:
+ * every mutation an operator can ask for goes through the upload-task queue,
+ * because core-uploader is the only process holding MangaDex write credentials.
+ *
+ * The four tables are structurally identical (see md/chapterRows.ts), so one
+ * parameterised query serves all four. Table and column names come from the
+ * closed ARCHIVES map below and never from a request — `Prisma.raw` appears
+ * only with values from that map, and every operator-supplied value is bound.
+ */
+
+export const CHAPTER_ARCHIVES = ["uploaded", "unavailable", "deleted", "edited"] as const;
+export type ChapterArchive = (typeof CHAPTER_ARCHIVES)[number];
+
+interface ArchiveSpec {
+  /** Physical table. */
+  table: string;
+  /** The column that dates the row — what "at" means for this archive. */
+  instant: string;
+  /** Human name for messages, matching the vocabulary the dashboard uses. */
+  label: string;
+}
+
+/**
+ * The one place an archive name becomes SQL. Every table below has the same
+ * chapter columns; they differ only in which instant dates the row, which is
+ * exactly the thing each archive exists to record.
+ */
+export const ARCHIVES: Record<ChapterArchive, ArchiveSpec> = {
+  uploaded: { table: "uploaded_chapters", instant: "created_at", label: "on MangaDex" },
+  unavailable: { table: "unavailable_chapters", instant: "unavailable_at", label: "marked unavailable" },
+  deleted: { table: "deleted_chapters", instant: "deleted_at", label: "deleted from MangaDex" },
+  edited: { table: "edited_chapters", instant: "last_edited_at", label: "edited" },
+};
+
+export function isChapterArchive(value: string): value is ChapterArchive {
+  return Object.hasOwn(ARCHIVES, value);
+}
+
+/** A row of any of the four tables, plus the instant that dates it. */
+export interface ChapterRow extends StoredChapterRow {
+  id: string;
+  mdChapterId: string;
+  extension: string | null;
+  at: Date;
+  /** Number of recorded edits; only the `edited` archive carries them. */
+  editCount?: number;
+}
+
+export interface ChapterFilter {
+  extension?: string;
+  chapterLanguage?: string;
+  mdMangaId?: string;
+  mdChapterId?: string;
+  chapterId?: string;
+  chapterNumber?: string;
+  /** Case-insensitive substring over the names and the four ids. */
+  search?: string;
+  since?: Date;
+  until?: Date;
+}
+
+/**
+ * Keyset position in `(at DESC, id DESC)`.
+ *
+ * Offset paging would be wrong here for the same reason it is wrong for the
+ * queue: `uploaded_chapters` grows while it is being read (every commit inserts
+ * a row at the top of this ordering), so page 2 of an offset scan repeats rows
+ * page 1 already showed.
+ */
+export interface ChapterCursor {
+  at: Date;
+  id: string;
+}
+
+export function encodeChapterCursor(row: ChapterCursor): string {
+  return Buffer.from(`${row.at.toISOString()}|${row.id}`, "utf8").toString("base64url");
+}
+
+/** Null for anything unparseable; the caller answers 400 rather than guessing. */
+export function decodeChapterCursor(raw: string): ChapterCursor | null {
+  const parts = Buffer.from(raw, "base64url").toString("utf8").split("|");
+  if (parts.length !== 2) return null;
+  const [at, id] = parts as [string, string];
+  const when = new Date(at);
+  if (Number.isNaN(when.getTime())) return null;
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) return null;
+  return { at: when, id };
+}
+
+/** Where a MangaDex chapter id appears across the four tables. */
+export interface ChapterHistory {
+  uploaded: ChapterRow | null;
+  unavailable: ChapterRow | null;
+  deleted: ChapterRow | null;
+  edited: (ChapterRow & { edits: unknown[] }) | null;
+}
+
+export class ChapterStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * One page of an archive, newest first, plus the total matching the filter.
+   *
+   * Newest-first is the operator's ordering, not the machine's: the chapter
+   * somebody is looking for is nearly always one that was just published, and
+   * the reason to open this view at all is usually "the last upload was wrong".
+   */
+  async list(
+    archive: ChapterArchive,
+    filter: ChapterFilter,
+    opts: { limit: number; cursor?: ChapterCursor | null },
+  ): Promise<{ chapters: ChapterRow[]; total: number; nextCursor: string | null }> {
+    const spec = ARCHIVES[archive];
+    const instant = Prisma.raw(`c.${spec.instant}`);
+    const from = Prisma.raw(spec.table);
+    const parts = chapterWhere(filter, spec);
+    if (opts.cursor) {
+      parts.push(Prisma.sql`(${instant}, c.id) < (${opts.cursor.at}, ${opts.cursor.id})`);
+    }
+
+    // One row beyond the page, so "is there another page?" costs no extra query.
+    const [rows, counted] = await Promise.all([
+      this.prisma.$queryRaw<ChapterRow[]>(Prisma.sql`
+        SELECT ${chapterColumns(spec)} FROM ${from} c
+        ${combine(parts)}
+        ORDER BY ${instant} DESC, c.id DESC
+        LIMIT ${opts.limit + 1}
+      `),
+      this.prisma.$queryRaw<{ total: bigint }[]>(Prisma.sql`
+        SELECT count(*) AS total FROM ${from} c ${combine(chapterWhere(filter, spec))}
+      `),
+    ]);
+
+    const page = rows.slice(0, opts.limit);
+    const last = page[page.length - 1];
+    return {
+      chapters: page,
+      total: Number(counted[0]?.total ?? 0),
+      nextCursor: rows.length > opts.limit && last ? encodeChapterCursor(last) : null,
+    };
+  }
+
+  async get(archive: ChapterArchive, mdChapterId: string): Promise<ChapterRow | null> {
+    const spec = ARCHIVES[archive];
+    const rows = await this.prisma.$queryRaw<ChapterRow[]>(Prisma.sql`
+      SELECT ${chapterColumns(spec)} FROM ${Prisma.raw(spec.table)} c
+      WHERE c.md_chapter_id = ${mdChapterId}
+    `);
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Every trace of one MangaDex chapter id.
+   *
+   * All four tables are read, not just the one the operator arrived from: a
+   * chapter that is in `deleted_chapters` and also in `uploaded_chapters` is a
+   * genuine inconsistency worth seeing, and the edit history explains a chapter
+   * whose current values do not match what the source says.
+   */
+  async history(mdChapterId: string): Promise<ChapterHistory> {
+    const [uploaded, unavailable, deleted, edited] = await Promise.all([
+      this.get("uploaded", mdChapterId),
+      this.get("unavailable", mdChapterId),
+      this.get("deleted", mdChapterId),
+      this.get("edited", mdChapterId),
+    ]);
+
+    let edits: unknown[] = [];
+    if (edited) {
+      const row = await this.prisma.editedChapter.findUnique({
+        where: { mdChapterId },
+        select: { edits: true },
+      });
+      edits = Array.isArray(row?.edits) ? row.edits : [];
+    }
+    return {
+      uploaded,
+      unavailable,
+      deleted,
+      edited: edited ? { ...edited, edits } : null,
+    };
+  }
+
+  /**
+   * Per-extension counts for one archive, for the filter picker and for the
+   * "what does this extension have up?" question the Extensions view asks.
+   */
+  async byExtension(archive: ChapterArchive): Promise<{ extension: string; count: number }[]> {
+    const spec = ARCHIVES[archive];
+    const rows = await this.prisma.$queryRaw<{ extension: string | null; count: bigint }[]>(Prisma.sql`
+      SELECT c.extension, count(*) AS count FROM ${Prisma.raw(spec.table)} c
+      GROUP BY c.extension ORDER BY count DESC, c.extension ASC
+    `);
+    // "" is the stand-in uploaded_chapters uses for an unattributed chapter
+    // (the column is NOT NULL there); the other three tables allow NULL. Both
+    // mean the same thing to a reader, so both surface as "".
+    return rows.map((row) => ({ extension: row.extension ?? "", count: Number(row.count) }));
+  }
+
+  /** Row counts for all four archives — the header of the Chapters view. */
+  async totals(): Promise<Record<ChapterArchive, number>> {
+    const entries = await Promise.all(
+      CHAPTER_ARCHIVES.map(async (archive) => {
+        const rows = await this.prisma.$queryRaw<{ total: bigint }[]>(
+          Prisma.sql`SELECT count(*) AS total FROM ${Prisma.raw(ARCHIVES[archive].table)} c`,
+        );
+        return [archive, Number(rows[0]?.total ?? 0)] as const;
+      }),
+    );
+    return Object.fromEntries(entries) as Record<ChapterArchive, number>;
+  }
+}
+
+/**
+ * A stored row as the canonical `Chapter` the upload queue carries.
+ *
+ * This is the bridge between the read side and the write side: an operator
+ * action on a chapter is executed by building a task payload from the row that
+ * records it, so the queued work describes the chapter the operator was
+ * actually looking at.
+ */
+export function chapterOf(row: ChapterRow): Chapter {
+  return chapterFromColumns(row);
+}
+
+// ------------------------------------------------------------------ internals
+
+/**
+ * The shared columns, aliased to the Prisma field names, plus the archive's own
+ * instant as `at` and (for edited_chapters) the size of the edit history.
+ *
+ * `jsonb_array_length` is guarded by `jsonb_typeof` because it errors rather
+ * than returning NULL on a non-array, and one hand-written row would then break
+ * the whole listing.
+ */
+function chapterColumns(spec: ArchiveSpec): Prisma.Sql {
+  const extra =
+    spec.table === "edited_chapters"
+      ? Prisma.sql`, CASE WHEN jsonb_typeof(c.edits) = 'array' THEN jsonb_array_length(c.edits) ELSE 0 END::int AS "editCount"`
+      : Prisma.empty;
+  return Prisma.sql`c.id, c.md_chapter_id AS "mdChapterId", c.extension,
+    c.chapter_id AS "chapterId", c.chapter_url AS "chapterUrl",
+    c.chapter_number AS "chapterNumber", c.chapter_title AS "chapterTitle",
+    c.chapter_volume AS "chapterVolume", c.chapter_language AS "chapterLanguage",
+    c.chapter_timestamp AS "chapterTimestamp", c.chapter_expire AS "chapterExpire",
+    c.chapter_lookup AS "chapterLookup", c.manga_id AS "mangaId",
+    c.manga_name AS "mangaName", c.manga_url AS "mangaUrl",
+    c.md_manga_id AS "mdMangaId", c.md_group_id AS "mdGroupId", c.extra,
+    ${Prisma.raw(`c.${spec.instant}`)} AS "at"${extra}`;
+}
+
+function chapterWhere(filter: ChapterFilter, spec: ArchiveSpec): Prisma.Sql[] {
+  const parts: Prisma.Sql[] = [];
+  // `extension = ''` is how an unattributed chapter is stored in
+  // uploaded_chapters and NULL in the other three, so asking for "" means both.
+  if (filter.extension === "") {
+    parts.push(Prisma.sql`(c.extension IS NULL OR c.extension = '')`);
+  } else if (filter.extension !== undefined) {
+    parts.push(Prisma.sql`c.extension = ${filter.extension}`);
+  }
+  if (filter.chapterLanguage) parts.push(Prisma.sql`c.chapter_language = ${filter.chapterLanguage}`);
+  if (filter.mdMangaId) parts.push(Prisma.sql`c.md_manga_id = ${filter.mdMangaId}`);
+  if (filter.mdChapterId) parts.push(Prisma.sql`c.md_chapter_id = ${filter.mdChapterId}`);
+  if (filter.chapterId) parts.push(Prisma.sql`c.chapter_id = ${filter.chapterId}`);
+  if (filter.chapterNumber) parts.push(Prisma.sql`c.chapter_number = ${filter.chapterNumber}`);
+  if (filter.search) {
+    // Parameterised, so a `%` an operator types is the wildcard they meant and
+    // a quote is data either way. The ids are included because the commonest
+    // way to arrive here is with an id pasted from a MangaDex URL or a Discord
+    // embed, and requiring the operator to know which field it is defeats the
+    // point of a search box.
+    const like = `%${filter.search}%`;
+    parts.push(Prisma.sql`(
+      c.manga_name ILIKE ${like} OR c.chapter_title ILIKE ${like} OR
+      c.chapter_id ILIKE ${like} OR c.md_chapter_id ILIKE ${like} OR
+      c.md_manga_id ILIKE ${like} OR c.chapter_url ILIKE ${like}
+    )`);
+  }
+  if (filter.since) parts.push(Prisma.sql`${Prisma.raw(`c.${spec.instant}`)} >= ${filter.since}`);
+  if (filter.until) parts.push(Prisma.sql`${Prisma.raw(`c.${spec.instant}`)} <= ${filter.until}`);
+  return parts;
+}
+
+function combine(parts: Prisma.Sql[]): Prisma.Sql {
+  return parts.length > 0 ? Prisma.sql`WHERE ${Prisma.join(parts, " AND ")}` : Prisma.empty;
+}

--- a/src/core/store/chapters.ts
+++ b/src/core/store/chapters.ts
@@ -161,6 +161,54 @@ export class ChapterStore {
   }
 
   /**
+   * Rows for many ids from one archive, in ONE query.
+   *
+   * The per-id lookup that `get` supports would be four queries per chapter on
+   * the locate path; a bulk action over two hundred chapters would then be
+   * eight hundred round trips before it wrote anything. This keeps a bulk
+   * resolution at four queries total, whatever the size of the selection.
+   */
+  async manyByIds(archive: ChapterArchive, ids: readonly string[]): Promise<ChapterRow[]> {
+    if (ids.length === 0) return [];
+    const spec = ARCHIVES[archive];
+    return this.prisma.$queryRaw<ChapterRow[]>(Prisma.sql`
+      SELECT ${chapterColumns(spec)} FROM ${Prisma.raw(spec.table)} c
+      WHERE c.md_chapter_id = ANY(${[...ids]}::text[])
+    `);
+  }
+
+  /**
+   * Chapter ids matching a filter, in the list's own order, capped.
+   *
+   * Backs `{filter: …}` bulk calls. The cap is applied here rather than by the
+   * caller so an over-wide filter cannot become an unbounded read on its way to
+   * becoming an unbounded write.
+   */
+  async idsMatching(
+    archive: ChapterArchive,
+    filter: ChapterFilter,
+    cap: number,
+  ): Promise<string[]> {
+    const spec = ARCHIVES[archive];
+    const rows = await this.prisma.$queryRaw<{ mdChapterId: string }[]>(Prisma.sql`
+      SELECT c.md_chapter_id AS "mdChapterId" FROM ${Prisma.raw(spec.table)} c
+      ${combine(chapterWhere(filter, spec))}
+      ORDER BY ${Prisma.raw(`c.${spec.instant}`)} DESC, c.id DESC
+      LIMIT ${cap}
+    `);
+    return rows.map((row) => row.mdChapterId);
+  }
+
+  async countMatching(archive: ChapterArchive, filter: ChapterFilter): Promise<number> {
+    const spec = ARCHIVES[archive];
+    const rows = await this.prisma.$queryRaw<{ total: bigint }[]>(Prisma.sql`
+      SELECT count(*) AS total FROM ${Prisma.raw(spec.table)} c
+      ${combine(chapterWhere(filter, spec))}
+    `);
+    return Number(rows[0]?.total ?? 0);
+  }
+
+  /**
    * Every trace of one MangaDex chapter id.
    *
    * All four tables are read, not just the one the operator arrived from: a
@@ -193,13 +241,19 @@ export class ChapterStore {
   }
 
   /**
-   * Per-extension counts for one archive, for the filter picker and for the
-   * "what does this extension have up?" question the Extensions view asks.
+   * Per-extension counts for one archive, for the filter picker, for the "what
+   * does this extension have up?" question the Extensions view asks, and — with
+   * a filter — for the breakdown a bulk dry run reports, which is how an
+   * operator recognises the set they are about to act on.
    */
-  async byExtension(archive: ChapterArchive): Promise<{ extension: string; count: number }[]> {
+  async byExtension(
+    archive: ChapterArchive,
+    filter: ChapterFilter = {},
+  ): Promise<{ extension: string; count: number }[]> {
     const spec = ARCHIVES[archive];
     const rows = await this.prisma.$queryRaw<{ extension: string | null; count: bigint }[]>(Prisma.sql`
       SELECT c.extension, count(*) AS count FROM ${Prisma.raw(spec.table)} c
+      ${combine(chapterWhere(filter, spec))}
       GROUP BY c.extension ORDER BY count DESC, c.extension ASC
     `);
     // "" is the stand-in uploaded_chapters uses for an unattributed chapter

--- a/src/core/store/settings.ts
+++ b/src/core/store/settings.ts
@@ -143,6 +143,28 @@ export class AuditLog {
     });
   }
 
+  /**
+   * Several events in one statement.
+   *
+   * For a bulk operator action the per-subject rows are what keep "why was this
+   * chapter deleted?" answerable — a lookup by `subject` finds nothing if a
+   * batch only writes one summary row — but two hundred sequential inserts
+   * inside a request is a cost with no upside.
+   */
+  async recordMany(
+    rows: readonly { actor: string; action: string; subject?: string; detail?: unknown }[],
+  ): Promise<void> {
+    if (rows.length === 0) return;
+    await this.prisma.auditEvent.createMany({
+      data: rows.map((row) => ({
+        actor: row.actor.slice(0, 256),
+        action: row.action.slice(0, 128),
+        subject: row.subject?.slice(0, 512) ?? null,
+        detail: row.detail === undefined ? undefined : (row.detail as object),
+      })),
+    });
+  }
+
   async recent(limit = 100): Promise<unknown[]> {
     return this.prisma.auditEvent.findMany({ orderBy: { createdAt: "desc" }, take: limit });
   }

--- a/src/core/store/uploadTasks.ts
+++ b/src/core/store/uploadTasks.ts
@@ -184,6 +184,83 @@ export class UploadTaskStore {
     return res === 1;
   }
 
+  /**
+   * Queue a chapter action an operator asked for, superseding a settled row.
+   *
+   * `enqueue` cannot serve this. Its ON CONFLICT DO NOTHING is what makes the
+   * processor idempotent, but it also means the (kind, dedupe_key) slot for a
+   * chapter is occupied FOREVER once the task completes — nothing deletes DONE
+   * rows — so a second operator action on the same chapter would silently do
+   * nothing. That is correct for the processor (it re-derives the same work
+   * every run) and wrong for a person who has just corrected a title and wants
+   * it pushed again.
+   *
+   * So a settled row is reset in place: same slot, new payload, PENDING, fresh
+   * attempt budget, due now. Which states count as settled is the whole safety
+   * property and it lives in the WHERE clause of the one statement:
+   *
+   *  - LEASED is excluded because an uploader is mid-flight against MangaDex.
+   *  - PENDING is excluded because the work is already queued; overwriting it
+   *    would change what a queued task does under an operator who is watching
+   *    the queue, and "it is already queued" is a better answer than a silent
+   *    rewrite.
+   *
+   * Both come back as null, and the caller reads the row afterwards purely to
+   * name the state in its refusal — never to decide whether to write.
+   *
+   * UPLOAD is not accepted, by type and at runtime: resetting a DONE UPLOAD row
+   * removes half of the double-upload guard (see REMOVABLE_STATES), and every
+   * chapter this is reachable from is already on MangaDex.
+   */
+  async requeueForChapter(
+    kind: Exclude<UploadTaskKind, "UPLOAD">,
+    dedupeKey: string,
+    chapter: unknown,
+    opts: { maxAttempts?: number } = {},
+  ): Promise<{ task: UploadTaskRow; superseded: boolean } | null> {
+    if (kind === ("UPLOAD" as UploadTaskKind)) {
+      throw new Error("requeueForChapter does not accept UPLOAD: it would re-arm a double upload");
+    }
+    const rows = await this.prisma.$queryRaw<(UploadTaskRow & { inserted: boolean })[]>(Prisma.sql`
+      INSERT INTO upload_tasks (id, kind, dedupe_key, chapter, state, attempt, max_attempts,
+                                not_before, created_at, updated_at)
+      VALUES (${randomUUID()}, ${kind}::"UploadTaskKind", ${dedupeKey},
+              ${JSON.stringify(chapter)}::jsonb, 'PENDING', 0,
+              coalesce(${opts.maxAttempts ?? null}::int, 5), now(), now(), now())
+      ON CONFLICT (kind, dedupe_key) DO UPDATE
+        SET chapter = EXCLUDED.chapter, state = 'PENDING', attempt = 0,
+            max_attempts = EXCLUDED.max_attempts, not_before = now(),
+            lease_id = NULL, lease_expires_at = NULL, last_error = NULL, updated_at = now()
+        WHERE upload_tasks.state IN ('DONE', 'FAILED', 'DEAD_LETTER')
+      -- xmax is 0 on a freshly inserted tuple and carries the updating
+      -- transaction id on one that took the DO UPDATE branch. It is the only
+      -- way to tell "queued" from "requeued" without a second statement, and
+      -- the difference matters: superseding a DONE row is worth saying out loud
+      -- in the response and in the audit trail.
+      RETURNING id, kind::text AS kind, dedupe_key AS "dedupeKey", state::text AS state,
+                attempt, max_attempts AS "maxAttempts", not_before AS "notBefore",
+                lease_id AS "leaseId", lease_expires_at AS "leaseExpiresAt",
+                last_error AS "lastError", created_at AS "createdAt",
+                updated_at AS "updatedAt", (xmax = 0) AS inserted
+    `);
+    const row = rows[0];
+    if (!row) return null;
+    const { inserted, ...task } = row;
+    return { task, superseded: !inserted };
+  }
+
+  /**
+   * Every queue row for one dedupe key, across kinds. For a chapter that is
+   * `mdChapterId` — the key EDIT, DELETE and UNAVAILABLE all use — so this
+   * answers "is anything already queued against this chapter?".
+   */
+  async forDedupeKey(dedupeKey: string): Promise<UploadTaskRow[]> {
+    return this.prisma.$queryRaw<UploadTaskRow[]>(Prisma.sql`
+      SELECT ${TASK_COLUMNS} FROM upload_tasks t WHERE t.dedupe_key = ${dedupeKey}
+      ORDER BY t.updated_at DESC
+    `);
+  }
+
   /** Claim one due task of the given kind (SKIP LOCKED lease). */
   async claim(kind: UploadTaskKind, leaseTtlSeconds: number): Promise<UploadTask | null> {
     const leaseId = randomUUID();

--- a/src/core/store/uploadTasks.ts
+++ b/src/core/store/uploadTasks.ts
@@ -255,8 +255,20 @@ export class UploadTaskStore {
    * answers "is anything already queued against this chapter?".
    */
   async forDedupeKey(dedupeKey: string): Promise<UploadTaskRow[]> {
+    return this.forDedupeKeys([dedupeKey]);
+  }
+
+  /**
+   * The same question for many chapters in one query, which is what a bulk
+   * action's dry run asks: it has to predict, for every chapter in the set,
+   * whether the write would be accepted — and doing that one chapter at a time
+   * would make the preview slower than the operation it previews.
+   */
+  async forDedupeKeys(dedupeKeys: readonly string[]): Promise<UploadTaskRow[]> {
+    if (dedupeKeys.length === 0) return [];
     return this.prisma.$queryRaw<UploadTaskRow[]>(Prisma.sql`
-      SELECT ${TASK_COLUMNS} FROM upload_tasks t WHERE t.dedupe_key = ${dedupeKey}
+      SELECT ${TASK_COLUMNS} FROM upload_tasks t
+      WHERE t.dedupe_key = ANY(${[...dedupeKeys]}::text[])
       ORDER BY t.updated_at DESC
     `);
   }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,6 +20,10 @@ if (config.mdUsername && config.mdPassword) {
   const md = new MdClient(config, prisma, log);
   const notifier = DiscordNotifier.fromConfig(config, log);
   ctx.titleService = new TitleService(prisma, md, notifier, log);
+  // Read-only from here: the chapter views show what MangaDex currently holds
+  // and preview the unavailable card. Every write is still queued for
+  // core-uploader, which stays the only process that publishes.
+  ctx.md = md;
 }
 const server = buildServer(ctx);
 

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -514,6 +514,190 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
     expect(await prisma.uploadTask.count()).toBe(0);
   });
 
+  // ---- bulk ----
+
+  describe("bulk actions", () => {
+    const bulk = (action: string, payload: Record<string, unknown>) =>
+      app.inject({
+        method: "POST",
+        url: `/api/v1/admin/chapters/bulk/${action}`,
+        headers: root,
+        payload,
+      });
+
+    it("previews by default and writes nothing at all", async () => {
+      const a = await uploaded();
+      const b = await uploaded();
+
+      const preview = await bulk("delete", { ids: [a.mdChapterId, b.mdChapterId] });
+      expect(preview.statusCode).toBe(200);
+      expect(preview.json().dryRun).toBe(true);
+      expect(preview.json().wouldQueue).toBe(2);
+      // Predictive, not an estimate: every chapter is named with what would
+      // happen to it.
+      expect(preview.json().results.map((r: { outcome: string }) => r.outcome)).toEqual([
+        "would_queue",
+        "would_queue",
+      ]);
+      expect(preview.json().results[0].mangaName).toBe("Test Series");
+      // Not even an audit row — the first call anyone makes is inert.
+      expect(await prisma.uploadTask.count()).toBe(0);
+      expect(await prisma.auditEvent.count()).toBe(0);
+
+      // dryRun: false alone is not enough; the two flags cannot both be set by
+      // accident.
+      const unconfirmed = await bulk("delete", { ids: [a.mdChapterId], dryRun: false });
+      expect(unconfirmed.statusCode).toBe(400);
+      expect(await prisma.uploadTask.count()).toBe(0);
+    });
+
+    it("queues one task per chapter and audits each one by subject", async () => {
+      const a = await uploaded();
+      const b = await uploaded();
+
+      const res = await bulk("delete", {
+        ids: [a.mdChapterId, b.mdChapterId],
+        dryRun: false,
+        confirm: true,
+        reason: "bad run",
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().queued).toBe(2);
+      expect(res.json().refused).toBe(0);
+      expect(res.json().results.every((r: { taskId?: string }) => r.taskId)).toBe(true);
+
+      const tasks = await prisma.uploadTask.findMany({ where: { kind: "DELETE" } });
+      expect(tasks.map((t) => t.dedupeKey).sort()).toEqual([a.mdChapterId, b.mdChapterId].sort());
+
+      // Per-chapter rows, so "why was this chapter deleted?" is answerable by
+      // subject — a batch that wrote only a summary would not answer it — plus
+      // one summary row correlating them.
+      const perChapter = await prisma.auditEvent.findMany({ where: { action: "chapter.delete" } });
+      expect(perChapter.map((e) => e.subject).sort()).toEqual([a.mdChapterId, b.mdChapterId].sort());
+      const summary = await prisma.auditEvent.findFirstOrThrow({
+        where: { action: "chapter.delete.bulk" },
+      });
+      expect((summary.detail as { queued: number }).queued).toBe(2);
+      expect((perChapter[0]!.detail as { bulk: string }).bulk).toBe(summary.subject);
+      expect((perChapter[0]!.detail as { reason: string }).reason).toBe("bad run");
+    });
+
+    it("acts on everything a filter matches, and caps what one call may touch", async () => {
+      for (let i = 0; i < 3; i++) await uploaded({ extension: "bulkext", mangaName: "Bulk Series" });
+      const other = await uploaded({ extension: "otherext" });
+
+      const preview = await bulk("unavailable", { filter: { extension: "bulkext" } });
+      expect(preview.json().matched).toBe(3);
+      expect(preview.json().wouldQueue).toBe(3);
+      expect(preview.json().breakdown).toEqual([{ extension: "bulkext", count: 3 }]);
+
+      const applied = await bulk("unavailable", {
+        filter: { extension: "bulkext" },
+        dryRun: false,
+        confirm: true,
+        footerNote: "Publisher pulled the series.",
+      });
+      expect(applied.json().queued).toBe(3);
+      const tasks = await prisma.uploadTask.findMany({ where: { kind: "UNAVAILABLE" } });
+      expect(tasks).toHaveLength(3);
+      expect((tasks[0]!.chapter as Record<string, unknown>).footerNote).toBe(
+        "Publisher pulled the series.",
+      );
+      // The filter is the whole selection: a chapter outside it is untouched.
+      expect(tasks.some((t) => t.dedupeKey === other.mdChapterId)).toBe(false);
+    });
+
+    it("reports per chapter when only some of a batch can be queued", async () => {
+      const fine = await uploaded();
+      const carded = await uploaded();
+      const removed = await uploaded();
+      // Already carries a card: needs `force`.
+      await prisma.unavailableChapter.create({
+        data: { mdChapterId: carded.mdChapterId, extension: "exampleext" },
+      });
+      // Already queued by hand, and not run yet.
+      await prisma.uploadTask.create({
+        data: { kind: "UNAVAILABLE", dedupeKey: removed.mdChapterId, chapter: {} },
+      });
+
+      const ids = [fine.mdChapterId, carded.mdChapterId, removed.mdChapterId, uuid(999)];
+      const preview = await bulk("unavailable", { ids });
+      const outcomes = Object.fromEntries(
+        preview.json().results.map((r: { mdChapterId: string; outcome: string }) => [r.mdChapterId, r.outcome]),
+      );
+      expect(outcomes[fine.mdChapterId]).toBe("would_queue");
+      expect(outcomes[carded.mdChapterId]).toBe("needs_force");
+      expect(outcomes[removed.mdChapterId]).toBe("already_queued");
+      expect(outcomes[uuid(999)]).toBe("not_found");
+
+      const applied = await bulk("unavailable", { ids, dryRun: false, confirm: true });
+      expect(applied.json().queued).toBe(1);
+      expect(applied.json().refused).toBe(3);
+      // The one that could go, went; the refusals left everything as it was.
+      expect(await prisma.uploadTask.count({ where: { kind: "UNAVAILABLE" } })).toBe(2);
+
+      // `force` unblocks the carded one without touching the other refusals.
+      const forced = await bulk("unavailable", { ids, dryRun: false, confirm: true, force: true });
+      expect(forced.json().queued).toBe(1);
+      const regenerated = await prisma.uploadTask.findFirstOrThrow({
+        where: { kind: "UNAVAILABLE", dedupeKey: carded.mdChapterId },
+      });
+      expect((regenerated.chapter as Record<string, unknown>).force).toBe(true);
+    });
+
+    it("limits a bulk edit to the fields a set of chapters can share", async () => {
+      const chapter = await uploaded();
+
+      // Per-chapter identity is not expressible here, rather than merely
+      // discouraged: one title across two hundred chapters is a mistake with a
+      // keyboard shortcut.
+      for (const changes of [{ title: "One title" }, { chapter: "12" }, { externalUrl: "https://x.example" }]) {
+        const res = await bulk("edit", { ids: [chapter.mdChapterId], changes });
+        expect(res.statusCode).toBe(400);
+      }
+      expect((await bulk("edit", { ids: [chapter.mdChapterId], changes: {} })).statusCode).toBe(400);
+      expect(
+        (await bulk("edit", { ids: [chapter.mdChapterId], changes: { translatedLanguage: "klingon" } }))
+          .statusCode,
+      ).toBe(400);
+
+      const res = await bulk("edit", {
+        ids: [chapter.mdChapterId],
+        changes: { volume: "3", translatedLanguage: "pt-br" },
+        dryRun: false,
+        confirm: true,
+      });
+      expect(res.statusCode).toBe(200);
+      const task = await prisma.uploadTask.findFirstOrThrow({ where: { kind: "EDIT" } });
+      expect((task.chapter as { payload: Record<string, string> }).payload).toEqual({
+        volume: "3",
+        translatedLanguage: "pt-br",
+      });
+    });
+
+    it("refuses a body that names both a selection and a filter, or neither", async () => {
+      const chapter = await uploaded();
+      expect(
+        (await bulk("delete", { ids: [chapter.mdChapterId], filter: { extension: "exampleext" } }))
+          .statusCode,
+      ).toBe(400);
+      expect((await bulk("delete", {})).statusCode).toBe(400);
+    });
+
+    it("keeps bulk behind the same role gate as the single-chapter routes", async () => {
+      const chapter = await uploaded();
+      const writer = await mint(["chapters:write"]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/admin/chapters/bulk/delete",
+        headers: writer,
+        payload: { ids: [chapter.mdChapterId], dryRun: false, confirm: true },
+      });
+      expect(res.statusCode).toBe(403);
+      expect(await prisma.uploadTask.count()).toBe(0);
+    });
+  });
+
   // ---- authorisation ----
 
   it("keeps published chapters out of reach of scopes and roles that should not have them", async () => {

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -1,0 +1,698 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { loadConfig } from "../../src/config.js";
+import { createLogger } from "../../src/logging.js";
+import { buildContext, type AppContext } from "../../src/core/api/context.js";
+import { buildServer } from "../../src/core/api/server.js";
+import { registerChapterRoutes } from "../../src/core/api/routes/chapters.js";
+import { UploadTaskWorkers } from "../../src/core/md/taskWorkers.js";
+import type { MdChapterDetail, MdExtendedApi } from "../../src/core/md/client.js";
+import { closeDb, dbReady, resetDb, testPrisma } from "./db.js";
+
+/**
+ * The operator's view of what this platform has published, and the three
+ * actions it offers on a chapter that is already on MangaDex.
+ *
+ * The properties worth proving are the ones that cost real damage when they
+ * regress, and every one of them needs a live postgres — the queue's unique
+ * (kind, dedupe_key) constraint is the system under test:
+ *
+ *  - an action QUEUES work and never touches MangaDex from the API process;
+ *  - a second action on a chapter whose task is still PENDING is refused, not
+ *    silently rewritten, and one whose task has completed is superseded in
+ *    place (without which a chapter could be edited exactly once, ever);
+ *  - deleting needs `confirm: true`, and a chapter already recorded as deleted
+ *    refuses everything;
+ *  - the role gate holds: `chapters:write` alone is not enough, so a leaked
+ *    machine token cannot unpublish anything;
+ *  - and the unavailable card is regenerable, which is the whole reason `force`
+ *    exists — without it the uploader treats an archived chapter as done.
+ */
+describe.skipIf(!dbReady())("chapter management endpoints", () => {
+  const prisma = testPrisma();
+  const ADMIN_TOKEN = "test-admin-token-0123456789";
+  const config = loadConfig({
+    DATABASE_URL: process.env.TEST_DATABASE_URL!,
+    ADMIN_TOKEN,
+    LOG_LEVEL: "error",
+  });
+  const log = createLogger("test-chapters", "error");
+  let app: FastifyInstance;
+  let ctx: AppContext;
+  const root = { authorization: `Bearer ${ADMIN_TOKEN}` };
+
+  /**
+   * server.ts is owned by another module's integrator, so probe first and
+   * register by hand only when these routes are absent — registering twice
+   * throws, and skipping when they are wired would test a different server than
+   * production runs.
+   */
+  async function buildApp(): Promise<FastifyInstance> {
+    const probe = buildServer(ctx);
+    await probe.ready();
+    if (probe.hasRoute({ method: "GET", url: "/api/v1/admin/chapters" })) return probe;
+    await probe.close();
+    const fresh = buildServer(ctx);
+    registerChapterRoutes(fresh, ctx);
+    await fresh.ready();
+    return fresh;
+  }
+
+  beforeEach(async () => {
+    await resetDb(prisma);
+    await prisma.apiToken.deleteMany({});
+    ctx = buildContext(prisma, config, log);
+    app = await buildApp();
+  });
+  afterAll(async () => {
+    await app?.close();
+    await closeDb();
+  });
+
+  const csrf = { "x-requested-with": "publoader-dash" };
+
+  let seq = 0;
+  const uuid = (n: number) => `${String(n).padStart(8, "0")}-0000-4000-8000-000000000000`;
+
+  /** A published chapter, as the uploader would have recorded it. */
+  async function uploaded(overrides: Record<string, unknown> = {}) {
+    seq += 1;
+    return prisma.uploadedChapter.create({
+      data: {
+        mdChapterId: uuid(seq),
+        extension: "exampleext",
+        chapterId: `src-${seq}`,
+        chapterNumber: String(seq),
+        chapterTitle: `Chapter ${seq}`,
+        chapterLanguage: "en",
+        chapterUrl: `https://publisher.example/ch/${seq}`,
+        mangaName: "Test Series",
+        mangaUrl: "https://publisher.example/series",
+        mdMangaId: uuid(900),
+        mdGroupId: uuid(800),
+        chapterTimestamp: new Date("2026-01-01T00:00:00.000Z"),
+        ...overrides,
+      },
+    });
+  }
+
+  async function mint(scopes: string[]): Promise<Record<string, string>> {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/tokens",
+      headers: root,
+      payload: { name: `chapters-${scopes.join("-")}-${(seq += 1)}`, scopes },
+    });
+    expect(res.statusCode).toBe(201);
+    return { authorization: `Bearer ${res.json().token}` };
+  }
+
+  /** A logged-in session cookie for a fresh account with `role`. */
+  async function sessionAs(role: "ADMIN" | "CONTRIBUTOR", email: string): Promise<Record<string, string>> {
+    await ctx.adminUsers.ensureOwner("owner@example.com");
+    const password = "correct-horse-battery-staple";
+    const user = await ctx.adminUsers.invite(email, role);
+    await ctx.adminUsers.setPassword(user.id, password);
+    const login = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/session",
+      payload: { email, password },
+    });
+    expect(login.statusCode).toBe(200);
+    const value = login.cookies.find((c) => c.name === "publoader_session")!.value;
+    return { cookie: `publoader_session=${value}`, ...csrf };
+  }
+
+  // ---- read ----
+
+  it("lists an archive newest first, with filters, totals and a facet", async () => {
+    const first = await uploaded({ chapterLanguage: "en" });
+    const second = await uploaded({ chapterLanguage: "ja", extension: "otherext", mangaName: "Second" });
+    await prisma.deletedChapter.create({
+      data: { mdChapterId: uuid(500), extension: "exampleext", chapterNumber: "9" },
+    });
+
+    const all = await app.inject({ method: "GET", url: "/api/v1/admin/chapters", headers: root });
+    expect(all.statusCode).toBe(200);
+    expect(all.json().archive).toBe("uploaded");
+    expect(all.json().total).toBe(2);
+    // Newest first: the row created last leads, which is the ordering an
+    // operator arriving after a bad run needs.
+    expect(all.json().chapters[0].mdChapterId).toBe(second.mdChapterId);
+    // Global, so a narrow filter cannot hide an archive that is filling up.
+    expect(all.json().totals).toEqual({ uploaded: 2, unavailable: 0, deleted: 1, edited: 0 });
+
+    const byExtension = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters?extension=exampleext",
+      headers: root,
+    });
+    expect(byExtension.json().total).toBe(1);
+    expect(byExtension.json().chapters[0].mdChapterId).toBe(first.mdChapterId);
+
+    const byLanguage = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters?language=ja",
+      headers: root,
+    });
+    expect(byLanguage.json().total).toBe(1);
+
+    // Search covers the ids too, so a chapter id pasted from a MangaDex URL
+    // finds its row without the operator knowing which field it is.
+    const bySearch = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/chapters?search=${encodeURIComponent(first.mdChapterId.slice(0, 8))}`,
+      headers: root,
+    });
+    expect(bySearch.json().total).toBe(1);
+
+    const archived = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters?archive=deleted",
+      headers: root,
+    });
+    expect(archived.json().total).toBe(1);
+
+    const facet = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters/extensions",
+      headers: root,
+    });
+    expect(facet.json().extensions).toEqual(
+      expect.arrayContaining([
+        { extension: "exampleext", count: 1 },
+        { extension: "otherext", count: 1 },
+      ]),
+    );
+  });
+
+  it("pages by cursor without repeating or skipping a row", async () => {
+    const created = [];
+    for (let i = 0; i < 5; i++) created.push(await uploaded());
+
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    for (let page = 0; page < 5; page++) {
+      const res: Awaited<ReturnType<typeof app.inject>> = await app.inject({
+        method: "GET",
+        url: `/api/v1/admin/chapters?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+        headers: root,
+      });
+      expect(res.statusCode).toBe(200);
+      seen.push(...res.json().chapters.map((c: { mdChapterId: string }) => c.mdChapterId));
+      cursor = res.json().nextCursor;
+      if (!cursor) break;
+    }
+    expect(new Set(seen).size).toBe(5);
+    expect(seen.length).toBe(5);
+    expect([...seen].sort()).toEqual(created.map((c) => c.mdChapterId).sort());
+
+    const bogus = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters?cursor=not-a-cursor",
+      headers: root,
+    });
+    expect(bogus.statusCode).toBe(400);
+  });
+
+  it("shows one chapter, its archives, its queue rows and why MangaDex is unreadable", async () => {
+    const chapter = await uploaded();
+    await prisma.editedChapter.create({
+      data: {
+        mdChapterId: chapter.mdChapterId,
+        extension: "exampleext",
+        edits: [{ editedAt: "2026-02-02T00:00:00.000Z", old: { title: "was" }, new: { title: "now" } }],
+      },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.chapter.mangaName).toBe("Test Series");
+    expect(body.archives.uploaded).not.toBeNull();
+    expect(body.archives.edited).not.toBeNull();
+    expect(body.archives.deleted).toBeNull();
+    expect(body.edits).toHaveLength(1);
+    expect(body.tasks).toEqual([]);
+    // No MangaDex credentials on this instance: the row still answers in full
+    // and the live column says why it is missing, rather than 500ing.
+    expect(body.mangadex).toBeNull();
+    expect(body.mangadexError).toMatch(/no MangaDex credentials/);
+    expect(body.links.chapter).toBe(`https://mangadex.org/chapter/${chapter.mdChapterId}`);
+    expect(body.actionsBlockedReason).toBeNull();
+
+    const missing = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/chapters/${uuid(404)}`,
+      headers: root,
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("renders the unavailable card as a PNG without queueing anything", async () => {
+    const chapter = await uploaded();
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}/card.png?footerNote=${encodeURIComponent("Taken down.")}`,
+      headers: root,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("image/png");
+    // A real PNG, not an error page rendered as one.
+    expect(res.rawPayload.subarray(1, 4).toString("ascii")).toBe("PNG");
+    expect(await prisma.uploadTask.count()).toBe(0);
+  });
+
+  // ---- edit ----
+
+  it("queues an edit carrying the payload and what the fields looked like", async () => {
+    const chapter = await uploaded({ chapterNumber: "12", chapterTitle: "Old title" });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { title: "New title", chapter: "12.1" },
+    });
+    // 202: queued, not applied. Anything else would be claiming the chapter has
+    // already changed on MangaDex.
+    expect(res.statusCode).toBe(202);
+    expect(res.json().action).toBe("EDIT");
+    expect(res.json().superseded).toBe(false);
+
+    const task = await prisma.uploadTask.findFirstOrThrow({ where: { kind: "EDIT" } });
+    expect(task.dedupeKey).toBe(chapter.mdChapterId);
+    expect(task.state).toBe("PENDING");
+    const payload = task.chapter as Record<string, unknown>;
+    expect(payload.payload).toEqual({ title: "New title", chapter: "12.1" });
+    // The history is only worth keeping if "old" is what was really there.
+    expect(payload.oldInfo).toEqual({ title: "Old title", chapter: "12" });
+    // Built like a processor payload, so the uploader finds the whole chapter.
+    expect(payload.mdChapterId).toBe(chapter.mdChapterId);
+    expect(payload.mdMangaId).toBe(chapter.mdMangaId);
+
+    const audit = await prisma.auditEvent.findFirstOrThrow({ where: { action: "chapter.edit" } });
+    expect(audit.subject).toBe(chapter.mdChapterId);
+  });
+
+  it("refuses an empty edit and a language MangaDex does not have", async () => {
+    const chapter = await uploaded();
+
+    const empty = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: {},
+    });
+    expect(empty.statusCode).toBe(400);
+
+    const unknownField = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { chapterNumber: "12" },
+    });
+    // Our column names are not MangaDex's field names, and a misspelling must
+    // not look like an edit that changed nothing.
+    expect(unknownField.statusCode).toBe(400);
+
+    const badLanguage = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { translatedLanguage: "klingon" },
+    });
+    expect(badLanguage.statusCode).toBe(400);
+
+    const badUrl = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { externalUrl: "javascript:alert(1)" },
+    });
+    expect(badUrl.statusCode).toBe(400);
+    expect(await prisma.uploadTask.count()).toBe(0);
+  });
+
+  it("refuses a second action while one is queued, and supersedes a completed one", async () => {
+    const chapter = await uploaded();
+
+    const first = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { title: "One" },
+    });
+    expect(first.statusCode).toBe(202);
+    const taskId = first.json().task.id;
+
+    const second = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { title: "Two" },
+    });
+    expect(second.statusCode).toBe(409);
+    expect(second.json().outcome).toBe("already_queued");
+    // The queued work is untouched: rewriting it would change what an operator
+    // watching the queue is watching.
+    const stillOne = await prisma.uploadTask.findUniqueOrThrow({ where: { id: taskId } });
+    expect((stillOne.chapter as { payload: { title: string } }).payload.title).toBe("One");
+
+    // A LEASED row belongs to a live uploader and is refused for the same reason.
+    await prisma.uploadTask.update({
+      where: { id: taskId },
+      data: { state: "LEASED", leaseId: uuid(700), leaseExpiresAt: new Date(Date.now() + 60_000) },
+    });
+    const whileLeased = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { title: "Three" },
+    });
+    expect(whileLeased.statusCode).toBe(409);
+    expect(whileLeased.json().outcome).toBe("leased");
+
+    // Once it has run, the slot is reusable — otherwise a chapter could be
+    // edited exactly once, ever, because nothing deletes DONE rows.
+    await prisma.uploadTask.update({ where: { id: taskId }, data: { state: "DONE", leaseId: null } });
+    const again = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { title: "Four" },
+    });
+    expect(again.statusCode).toBe(202);
+    expect(again.json().superseded).toBe(true);
+    // Same row, reset in place: the unique (kind, dedupe_key) constraint is what
+    // makes a double upload impossible and is never worked around.
+    expect(again.json().task.id).toBe(taskId);
+    expect(await prisma.uploadTask.count({ where: { kind: "EDIT" } })).toBe(1);
+    const reset = await prisma.uploadTask.findUniqueOrThrow({ where: { id: taskId } });
+    expect(reset.state).toBe("PENDING");
+    expect(reset.attempt).toBe(0);
+    expect((reset.chapter as { payload: { title: string } }).payload.title).toBe("Four");
+  });
+
+  // ---- unavailable ----
+
+  it("queues an unavailable card, and needs force to replace one already posted", async () => {
+    const chapter = await uploaded();
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}/unavailable`,
+      headers: root,
+      payload: { footerNote: "Pulled by the publisher." },
+    });
+    expect(first.statusCode).toBe(202);
+    const queued = await prisma.uploadTask.findFirstOrThrow({ where: { kind: "UNAVAILABLE" } });
+    const payload = queued.chapter as Record<string, unknown>;
+    expect(payload.footerNote).toBe("Pulled by the publisher.");
+    expect(payload.unavailableAt).toBeTruthy();
+    expect(payload.force).toBeUndefined();
+
+    // Pretend the uploader ran it.
+    await prisma.uploadTask.update({ where: { id: queued.id }, data: { state: "DONE" } });
+    await prisma.unavailableChapter.create({
+      data: { mdChapterId: chapter.mdChapterId, extension: "exampleext" },
+    });
+
+    const withoutForce = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}/unavailable`,
+      headers: root,
+      payload: {},
+    });
+    // Silently doing nothing is the failure mode this refusal exists to avoid.
+    expect(withoutForce.statusCode).toBe(409);
+    expect(withoutForce.json().outcome).toBe("already_unavailable");
+
+    const forced = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}/unavailable`,
+      headers: root,
+      payload: { force: true, footerNote: "Corrected wording." },
+    });
+    expect(forced.statusCode).toBe(202);
+    const regenerated = await prisma.uploadTask.findUniqueOrThrow({ where: { id: queued.id } });
+    expect((regenerated.chapter as Record<string, unknown>).force).toBe(true);
+    expect(regenerated.state).toBe("PENDING");
+  });
+
+  // ---- delete ----
+
+  it("needs confirmation to delete, and records what it removed", async () => {
+    const chapter = await uploaded();
+
+    const unconfirmed = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: {},
+    });
+    expect(unconfirmed.statusCode).toBe(400);
+    expect(unconfirmed.json().alternative).toMatch(/unavailable/);
+    expect(await prisma.uploadTask.count()).toBe(0);
+
+    const confirmed = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: root,
+      payload: { confirm: true, reason: "duplicate upload" },
+    });
+    expect(confirmed.statusCode).toBe(202);
+    expect(confirmed.json().action).toBe("DELETE");
+    const task = await prisma.uploadTask.findFirstOrThrow({ where: { kind: "DELETE" } });
+    expect(task.dedupeKey).toBe(chapter.mdChapterId);
+
+    // After the uploader runs, this row and deleted_chapters are the only
+    // records that the chapter existed.
+    const audit = await prisma.auditEvent.findFirstOrThrow({ where: { action: "chapter.delete" } });
+    expect((audit.detail as { reason: string }).reason).toBe("duplicate upload");
+    expect((audit.detail as { chapter: { chapterTitle: string } }).chapter.chapterTitle).toBeTruthy();
+
+    // The live row is left alone until the uploader succeeds — a queued delete
+    // that fails must not have already erased our record of the chapter.
+    expect(await prisma.uploadedChapter.count()).toBe(1);
+  });
+
+  it("refuses every action on a chapter already recorded as deleted", async () => {
+    const mdChapterId = uuid(600);
+    await prisma.deletedChapter.create({
+      data: { mdChapterId, extension: "exampleext", chapterNumber: "3" },
+    });
+
+    for (const call of [
+      app.inject({
+        method: "PATCH",
+        url: `/api/v1/admin/chapters/${mdChapterId}`,
+        headers: root,
+        payload: { title: "x" },
+      }),
+      app.inject({
+        method: "POST",
+        url: `/api/v1/admin/chapters/${mdChapterId}/unavailable`,
+        headers: root,
+        payload: {},
+      }),
+      app.inject({
+        method: "DELETE",
+        url: `/api/v1/admin/chapters/${mdChapterId}`,
+        headers: root,
+        payload: { confirm: true },
+      }),
+    ]) {
+      const res = await call;
+      expect(res.statusCode).toBe(409);
+      expect(res.json().error).toMatch(/recorded as deleted/);
+    }
+    expect(await prisma.uploadTask.count()).toBe(0);
+  });
+
+  // ---- authorisation ----
+
+  it("keeps published chapters out of reach of scopes and roles that should not have them", async () => {
+    const chapter = await uploaded();
+
+    const reader = await mint(["chapters:read"]);
+    const listed = await app.inject({ method: "GET", url: "/api/v1/admin/chapters", headers: reader });
+    expect(listed.statusCode).toBe(200);
+    const readerWrite = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: reader,
+      payload: { title: "no" },
+    });
+    expect(readerWrite.statusCode).toBe(403);
+
+    // The sharpest case: a machine credential scoped for exactly this work is
+    // still refused, because an api-token is never ADMIN.
+    const writer = await mint(["chapters:write"]);
+    const tokenWrite = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: writer,
+      payload: { confirm: true },
+    });
+    expect(tokenWrite.statusCode).toBe(403);
+    expect(tokenWrite.json().error).toMatch(/closed to api tokens/);
+    expect(tokenWrite.json().requiredRole).toBe("ADMIN");
+
+    // A run-triggering credential has no business here at all.
+    const runner = await mint(["runs:write"]);
+    const runnerRead = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters",
+      headers: runner,
+    });
+    expect(runnerRead.statusCode).toBe(403);
+
+    const contributor = await sessionAs("CONTRIBUTOR", "contrib@example.com");
+    const contributorRead = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters",
+      headers: contributor,
+    });
+    expect(contributorRead.statusCode).toBe(403);
+
+    const admin = await sessionAs("ADMIN", "admin@example.com");
+    const adminWrite = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/chapters/${chapter.mdChapterId}`,
+      headers: admin,
+      payload: { title: "yes" },
+    });
+    expect(adminWrite.statusCode).toBe(202);
+
+    expect(await prisma.uploadTask.count()).toBe(1);
+  });
+
+  // ---- the uploader half ----
+
+  describe("the uploader executing a regeneration", () => {
+    /**
+     * A chapter that has already been marked unavailable: MangaDex still has
+     * the entry, its externalUrl was repointed at the publisher's site root,
+     * and its only page is the card posted last time.
+     */
+    const detail = (): MdChapterDetail => ({
+      id: uuid(1),
+      attributes: {
+        volume: null,
+        chapter: "1",
+        title: "Chapter one",
+        translatedLanguage: "en",
+        externalUrl: null,
+        version: 3,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      relationships: [{ id: uuid(800), type: "scanlation_group" }],
+    });
+
+    function stubMd(calls: string[]): MdExtendedApi {
+      const unexpected = (name: string) => () => {
+        throw new Error(`the uploader should not call ${name} in this test`);
+      };
+      return {
+        chapterById: async () => {
+          calls.push("chapterById");
+          return detail();
+        },
+        beginEditSession: async () => {
+          calls.push("beginEditSession");
+          return { id: uuid(701) };
+        },
+        uploadImages: async (_session: string, files: { name: string; data: Buffer }[]) => {
+          calls.push(`uploadImages:${files.length}`);
+          return files.map((file, index) => ({
+            id: uuid(710 + index),
+            originalFileName: file.name,
+            fileSize: file.data.length,
+          }));
+        },
+        commitUploadSession: async () => {
+          calls.push("commitUploadSession");
+          return { id: uuid(1), attributes: { version: 4 } };
+        },
+        editChapter: async () => {
+          calls.push("editChapter");
+          return true;
+        },
+        deleteChapter: unexpected("deleteChapter"),
+        chaptersForManga: unexpected("chaptersForManga"),
+        chaptersByIds: unexpected("chaptersByIds"),
+        mangaByIds: unexpected("mangaByIds"),
+        mangaById: unexpected("mangaById"),
+        searchManga: unexpected("searchManga"),
+        mangaAggregate: unexpected("mangaAggregate"),
+        currentUploadSession: unexpected("currentUploadSession"),
+        deleteUploadSession: async () => {
+          calls.push("deleteUploadSession");
+        },
+        createUploadSession: unexpected("createUploadSession"),
+        createMangaDraft: unexpected("createMangaDraft"),
+        commitMangaDraft: unexpected("commitMangaDraft"),
+        editManga: unexpected("editManga"),
+      } as unknown as MdExtendedApi;
+    }
+
+    const notifier = { enabled: false, send: async () => {} };
+
+    async function run(force: boolean): Promise<string[]> {
+      const calls: string[] = [];
+      const workers = new UploadTaskWorkers({
+        prisma,
+        md: stubMd(calls),
+        notifier: notifier as never,
+        config,
+        log,
+      });
+      const task = await prisma.uploadTask.create({
+        data: {
+          kind: "UNAVAILABLE",
+          dedupeKey: uuid(1),
+          state: "LEASED",
+          chapter: {
+            mdChapterId: uuid(1),
+            mdMangaId: uuid(900),
+            mdGroupId: uuid(800),
+            chapterNumber: "1",
+            chapterLanguage: "en",
+            mangaName: "Test Series",
+            mangaUrl: "https://publisher.example/series",
+            extensionName: "exampleext",
+            imageArtifacts: [],
+            ...(force ? { force: true, footerNote: "Corrected wording." } : {}),
+          },
+        },
+      });
+      await workers.execute(task);
+      return calls;
+    }
+
+    it("archives without touching MangaDex when the card is already posted", async () => {
+      const calls = await run(false);
+      // The automated pass is right to stop here: the work is done.
+      expect(calls).toEqual(["chapterById"]);
+      expect(await prisma.unavailableChapter.count()).toBe(1);
+    });
+
+    it("renders and posts a fresh card when the operator forces it", async () => {
+      const calls = await run(true);
+      expect(calls).toContain("beginEditSession");
+      // One page: the card itself, replacing whatever was there.
+      expect(calls).toContain("uploadImages:1");
+      expect(calls).toContain("commitUploadSession");
+      expect(calls).toContain("editChapter");
+      const archived = await prisma.unavailableChapter.findUniqueOrThrow({
+        where: { mdChapterId: uuid(1) },
+      });
+      expect(archived.chapterNumber).toBe("1");
+    });
+  });
+});

--- a/test/unit/chapters.test.ts
+++ b/test/unit/chapters.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAPTER_ARCHIVES,
+  decodeChapterCursor,
+  encodeChapterCursor,
+  isChapterArchive,
+} from "../../src/core/store/chapters.js";
+import { unavailableCardOptions, resolveMangaName } from "../../src/core/md/unavailableCard.js";
+import type { MdChapterDetail } from "../../src/core/md/client.js";
+import type { Chapter } from "../../src/core/md/types.js";
+
+/**
+ * The two pure pieces of the chapter views: the keyset cursor the listing pages
+ * with, and the derivation of what goes on an unavailable card.
+ *
+ * The card derivation is worth unit-testing precisely because two callers share
+ * it — the uploader that posts the image and the endpoint that previews it. If
+ * they ever disagreed, an operator would approve one card and publish another,
+ * and nobody would find out except a reader.
+ */
+
+const chapter: Chapter = {
+  chapterLookup: null,
+  chapterTimestamp: "2026-01-02T00:00:00.000Z",
+  chapterExpire: "2026-02-02T00:00:00.000Z",
+  chapterLanguage: "en",
+  chapterNumber: "12",
+  chapterTitle: "Stored title",
+  chapterVolume: "2",
+  chapterId: "src-12",
+  chapterUrl: "https://publisher.example/ch/12",
+  mdChapterId: "11111111-1111-4111-8111-111111111111",
+  mangaId: "src-manga",
+  mdMangaId: "22222222-2222-4222-8222-222222222222",
+  mdGroupId: "33333333-3333-4333-8333-333333333333",
+  mangaName: "Stored Series",
+  mangaUrl: "https://publisher.example/series",
+  extensionName: "exampleext",
+  imageArtifacts: [],
+};
+
+const detail = (
+  attrs: Partial<MdChapterDetail["attributes"]> = {},
+  relationships: MdChapterDetail["relationships"] = [],
+): MdChapterDetail => ({
+  id: chapter.mdChapterId!,
+  attributes: {
+    volume: "3",
+    chapter: "12.5",
+    title: "Live title",
+    translatedLanguage: "ja",
+    externalUrl: "https://publisher.example/live",
+    version: 4,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...attrs,
+  },
+  relationships,
+});
+
+describe("chapter cursors", () => {
+  it("round-trips a position", () => {
+    const at = new Date("2026-05-05T10:11:12.000Z");
+    const id = "44444444-4444-4444-8444-444444444444";
+    const decoded = decodeChapterCursor(encodeChapterCursor({ at, id }));
+    expect(decoded?.at.toISOString()).toBe(at.toISOString());
+    expect(decoded?.id).toBe(id);
+  });
+
+  it("refuses anything it did not issue", () => {
+    // A caller that invents a cursor gets a 400 from the route, not a page of
+    // rows from a date it guessed — which is what makes "this is not an offset"
+    // enforceable rather than merely documented.
+    expect(decodeChapterCursor("not-base64")).toBeNull();
+    expect(decodeChapterCursor(Buffer.from("only-one-part").toString("base64url"))).toBeNull();
+    expect(decodeChapterCursor(Buffer.from("nonsense|not-a-uuid").toString("base64url"))).toBeNull();
+    expect(
+      decodeChapterCursor(
+        Buffer.from("2026-05-05T10:11:12.000Z|44444444-4444-4444-8444-444444444444").toString("base64url"),
+      ),
+    ).not.toBeNull();
+  });
+
+  it("names exactly the four chapter tables", () => {
+    expect([...CHAPTER_ARCHIVES]).toEqual(["uploaded", "unavailable", "deleted", "edited"]);
+    expect(isChapterArchive("uploaded")).toBe(true);
+    expect(isChapterArchive("upload_tasks")).toBe(false);
+  });
+});
+
+describe("unavailableCardOptions", () => {
+  it("prefers what MangaDex holds over the stored mirror", () => {
+    const opts = unavailableCardOptions({ chapter, detail: detail(), unavailableAt: null });
+    expect(opts.chapterNumber).toBe("12.5");
+    expect(opts.chapterTitle).toBe("Live title");
+    expect(opts.chapterLanguage).toBe("ja");
+    expect(opts.chapterUrl).toBe("https://publisher.example/live");
+    // The extension never appears on the MangaDex resource, so it always comes
+    // from our row.
+    expect(opts.extensionName).toBe("exampleext");
+  });
+
+  it("falls back to the row when MangaDex could not be read", () => {
+    const opts = unavailableCardOptions({ chapter, detail: null, unavailableAt: null });
+    expect(opts.chapterNumber).toBe("12");
+    expect(opts.chapterTitle).toBe("Stored title");
+    expect(opts.chapterUrl).toBe("https://publisher.example/ch/12");
+    expect(opts.mangaName).toBe("Stored Series");
+  });
+
+  it("dates the availability window from the takedown, else the source expiry", () => {
+    expect(
+      unavailableCardOptions({ chapter, detail: null, unavailableAt: "2026-03-03T00:00:00.000Z" })
+        .availableTo,
+    ).toBe("2026-03-03T00:00:00.000Z");
+    expect(unavailableCardOptions({ chapter, detail: null }).availableTo).toBe(chapter.chapterExpire);
+    expect(unavailableCardOptions({ chapter, detail: null }).availableFrom).toBe(chapter.chapterTimestamp);
+  });
+
+  it("carries an operator's footer note", () => {
+    const note = "Removed at the publisher's request.";
+    expect(unavailableCardOptions({ chapter, detail: null, footerNote: note }).footerNote).toBe(note);
+    // Null rather than undefined, so the card's own default wording applies.
+    expect(unavailableCardOptions({ chapter, detail: null }).footerNote).toBeNull();
+  });
+});
+
+describe("resolveMangaName", () => {
+  const manga = (attributes: Record<string, unknown>) => [
+    { id: chapter.mdMangaId!, type: "manga", attributes },
+  ];
+
+  it("prefers the English title from the manga relationship", () => {
+    const live = detail({}, manga({ title: { en: "Live Series" }, altTitles: [] }));
+    expect(resolveMangaName(live, chapter)).toBe("Live Series");
+  });
+
+  it("falls back to the romanised original before any other language", () => {
+    const live = detail(
+      {},
+      manga({
+        title: { ja: "日本語タイトル" },
+        altTitles: [{ "ja-ro": "Nihongo Taitoru" }, { fr: "Titre" }],
+        originalLanguage: "ja",
+      }),
+    );
+    expect(resolveMangaName(live, chapter)).toBe("Nihongo Taitoru");
+  });
+
+  it("uses the stored name when MangaDex offers nothing", () => {
+    expect(resolveMangaName(detail(), chapter)).toBe("Stored Series");
+    expect(resolveMangaName(null, chapter)).toBe("Stored Series");
+    expect(resolveMangaName(null, { ...chapter, mangaName: null })).toBe("Untitled");
+  });
+});


### PR DESCRIPTION
## What this adds

A **Chapters** view (`#/chapters`) and an `/api/v1/admin/chapters/*` family over the four chapter history tables — `uploaded_chapters`, `unavailable_chapters`, `deleted_chapters`, `edited_chapters`. Until now those were write-only: the platform recorded everything it published and nothing could read it back, so "which MangaDex chapter is this, is it still up, and what did we think it was?" meant `psql` on the core container, and fixing a wrong one meant hand-writing a queue row.

**Read**: browse any of the four archives, filtered by extension, language, chapter number and a search that matches the series name, the chapter title and all four ids (so a chapter id pasted from a MangaDex URL finds its row). Keyset paged. Opening one chapter shows our row beside **what MangaDex says right now**, whatever is already queued against it, and its edit history.

**Write**: edit the metadata, replace the chapter with an unavailable card (**previewed in the dialog first**), regenerate a card already posted, or delete the chapter — one chapter at a time, or over a set.

## Nothing here writes to MangaDex

Every action queues an `UploadTask` and answers `202` with it. `core-uploader` stays the only process with write credentials, which is what keeps "exactly one writer" true however many API replicas run. The API's optional MangaDex client is used for reads only — live chapter state, and rendering the card preview.

## Bulk

`POST /chapters/bulk/{edit,unavailable,delete}`, driven by a list of ids or by the same filter the listing uses — "this series was licensed, take the lot down", "that run got the volume wrong on fifty chapters".

- **`dryRun` defaults to `true`, always.** The first call anyone makes writes nothing, queues nothing, audits nothing, and returns a per-chapter prediction including every refusal. It resolves the same rows and checks the same conditions as the live path, so it is a preview of the operation rather than an estimate of it. A live run needs `dryRun: false` **and** `confirm: true`.
- The dashboard makes that the only order it offers: the apply button is disabled until the preview has been fetched, then says how many chapters it will queue.
- **Cap 200**, not the 1000 of `/queues/*` — this bounds a change to public pages rather than to queue rows, and a dry run listing 200 chapters is still something a person will read.
- A bulk **edit** takes only `volume`, `translatedLanguage` and `groups`. A title or chapter number is one chapter's identity; writing one across two hundred chapters is a mistake with a keyboard shortcut, so the schema does not express it.
- Each queued chapter gets **its own audit event** (subject = chapter id, sharing a `bulk` id) plus one summary row, so "why was this chapter deleted?" stays answerable by subject. Resolution is four queries however large the set, and every write is still the same guarded upsert.

## Three things this needed underneath

- **`upload_tasks` holds one slot per (kind, chapter) forever**, because nothing deletes `DONE` rows. An operator action now resets a settled row in place (`requeueForChapter`), refuses a `PENDING` or `LEASED` one, and never accepts `UPLOAD`. Without this a chapter could be edited exactly once, ever.
- **The unavailable flow was not repeatable.** It archived and returned for a chapter that already carried a card — right for the automated pass, and it left a card saying the wrong thing on a public page unfixable. A `force` sidecar re-renders and reposts it; `footerNote` replaces the standard wording.
- **The card's inputs moved to `md/unavailableCard.ts`** so the preview endpoint and the uploader derive it identically. Approving one image and publishing another would be worse than having no preview.

## Authorisation

`chapters:read` / `chapters:write` are their own scopes, deliberately not part of `runs:*` — a credential that may trigger a run does not thereby get to unpublish chapters. Every mutating route (bulk included) additionally requires the **ADMIN** role and **refuses `pa_…` api tokens outright**, matching `requireApplyRole` in `routes/ops.ts`: a change to a public catalogue entry under the shared MangaDex account is attributable to a signed-in operator or nothing. Deleting one chapter needs `confirm: true`, and the refusal names the unavailable route as the reversible alternative.

## Tests

`test/unit/chapters.test.ts` (10) covers the keyset cursor and the card derivation. `test/integration/chapters.test.ts` (20) covers listing/paging/detail, the PNG preview, each single-chapter action's queued payload, the already-queued/leased/superseded refusals, the deleted-chapter refusal, the scope and role gates, both halves of the uploader's `force` behaviour against a stubbed MangaDex, and for bulk: the inert dry run (no tasks, no audit rows), per-chapter audit + summary, filter-driven selection, mixed outcomes across one batch, the edit field restriction, and the role gate.

Full suite: **854 passing**, typecheck, lint and build clean. The dashboard was smoke-rendered under jsdom — list, detail, card-preview dialog, and the bulk preview-then-apply flow.

## Docs

`api-reference.md` (endpoints, bulk rules, the scope), `dashboard.md` (the view, the single-chapter runbook, the bulk bar), `operations.md` ("Fix a chapter that is already published", including bulk and what each refusal means), `data-model.md` (the read path and the queue-slot rule), `security-trust-model.md` (the read-only API client and the token refusal), `architecture-guide.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)