### PR TITLE
Publish on bare version tags, and strip `v` from either source

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -58,8 +58,13 @@ jobs:
           echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
           version="$INPUT_VERSION"
           if [ -z "$version" ] && [ "$REF_TYPE" = "tag" ]; then
-            version="${REF_NAME#v}"
+            version="$REF_NAME"
           fi
+          # A leading `v` is a git-tag convention, not part of the version. It
+          # comes off whichever way the version arrived — a `v2.1.7` tag and a
+          # `v2.1.7` typed into the manual run both publish `:2.1.7`, so the
+          # image tags stay bare numbers and never fork into two spellings.
+          version="${version#v}"
           case "$version" in
             "") ;;
             *[!0-9.]*) echo "::error::version must look like 2.1.2, got '$version'"; exit 1 ;;

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -12,7 +12,11 @@ name: Publish images
 on:
   push:
     branches: [master]
-    tags: ["v*"]
+    # Both spellings, because the repo has used both. Tag `2.1.6` was pushed
+    # against a `v*`-only filter and silently published nothing — no run, no
+    # failure, just a version that existed in git and never on Docker Hub.
+    # `+` here is a filter-pattern quantifier, not a literal.
+    tags: ["v*", "[0-9]+.[0-9]+.[0-9]+"]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Tag `2.1.6` was pushed against a `tags: ["v*"]` filter in `push-docker.yml`. GitHub matched nothing, so no run started — not a failed one, none at all — and `2.1.6` existed in git while Docker Hub still topped out at `2.1.5`. The failure mode is the quiet kind: `latest` had already moved on the master merge, so the images looked current right up until someone pinned a version.

Two changes:

**The trigger accepts both spellings.** `[0-9]+.[0-9]+.[0-9]+` is a GitHub filter pattern, not a regex — `+` quantifies the preceding class and `.` is literal — so it matches `2.1.6` and `10.20.30` but not a branch-shaped tag.

**The `v` strip moved out of the tag-only branch.** It ran only when `ref_type` was `tag`, so a manual run with `v2.1.7` typed into the version box hit the numeric validation and failed the workflow instead of publishing `:2.1.7` — same string, two outcomes depending on which door it came through. A `v` is a git-tag convention rather than part of the version, so it now comes off whichever way the version arrived and the image tags stay bare numbers.

Resolution checked against all six paths: bare tag → `2.1.6`; `v`-tag → `2.1.7`; bare dispatch input → `2.1.8`; `v` dispatch input → `2.1.9`; plain master push → no version, `latest` only; non-numeric input → rejected before it reaches a docker tag.

The missing `2.1.6` images were published separately via `workflow_dispatch` (run 31057948959, both arches, all three images). This only prevents the next tag from going the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)