### PR TITLE
Recover from MangaDex version conflicts instead of failing the task

### DIFF
--- a/src/core/md/client.ts
+++ b/src/core/md/client.ts
@@ -55,10 +55,60 @@ export class MdRequestError extends Error {
   constructor(
     message: string,
     readonly status?: number,
+    /** Parsed error body, when MangaDex sent one; `optimisticLockVersion` reads it. */
+    readonly body?: Record<string, unknown> | null,
   ) {
     super(message);
     this.name = "MdRequestError";
   }
+}
+
+/**
+ * The version MangaDex says the entity *actually* holds, read off a 409.
+ *
+ * Every versioned write (PUT /chapter, PUT /manga, POST /upload/begin/{id})
+ * carries the version we believe MangaDex holds, and MangaDex rejects the write
+ * when that number is not the current one:
+ *
+ *   409 optimistic_lock_exception
+ *   "The optimistic lock failed, version 2 was expected, but is actually 3"
+ *
+ * The number we send comes from a GET, and a GET is not a reliable reading of
+ * the version *during* a write sequence: MangaDex serves chapter reads from a
+ * cache that lags its own writes, and the commit of an edit session bumps the
+ * version behind that cache. So a task that failed after committing and is now
+ * being retried re-reads the pre-commit version and is rejected on its next
+ * write, every time, for as long as the cache is warm. Re-reading harder does
+ * not fix it; the rejection itself names the current version, and that is the
+ * one authoritative reading available, so the write is replayed with it.
+ *
+ * Null for a 409 that is not a version conflict (an already-open upload
+ * session, say) — those must not be replayed.
+ */
+export function optimisticLockVersion(err: unknown): number | null {
+  if (!(err instanceof MdRequestError) || err.status !== 409) return null;
+  const errors = err.body?.errors;
+  const details: string[] = [];
+  if (Array.isArray(errors)) {
+    for (const entry of errors) {
+      if (entry === null || typeof entry !== "object") continue;
+      const { title, detail } = entry as { title?: unknown; detail?: unknown };
+      if (title !== "optimistic_lock_exception") continue;
+      if (typeof detail === "string") details.push(detail);
+    }
+  }
+  // The message carries the raw body, so a response that failed to parse (or
+  // arrived in some shape other than the documented one) is still readable.
+  if (details.length === 0 && err.message.includes("optimistic_lock_exception")) {
+    details.push(err.message);
+  }
+  for (const detail of details) {
+    const match = /is actually (\d+)/.exec(detail);
+    if (!match?.[1]) continue;
+    const version = Number(match[1]);
+    if (Number.isInteger(version) && version > 0) return version;
+  }
+  return null;
 }
 
 /** Generic MangaDex entity as it comes off the wire. */
@@ -327,10 +377,39 @@ export class MdClient implements MdExtendedApi {
       }
 
       // 4xx other than 401/429 will not change on retry.
-      throw new MdRequestError(`${method} ${url} failed; ${lastError}`, status);
+      throw new MdRequestError(`${method} ${url} failed; ${lastError}`, status, data);
     }
 
     throw new MdRequestError(`${method} ${url} exhausted ${tries} attempts; ${lastError}`);
+  }
+
+  /**
+   * Run a versioned write; if MangaDex rejects the version, run it once more
+   * with the version the rejection names. See `optimisticLockVersion` for why
+   * the error is a better reading of the current version than another GET.
+   *
+   * Once, deliberately. A second conflict means the entity is moving under us
+   * for reasons this flow does not control, and replaying a body built from a
+   * stale read on top of someone else's edit is the failure mode a lock exists
+   * to prevent. One replay recovers our own lagging read of our own write,
+   * which is the case that actually happens here.
+   */
+  private async withVersionRetry<T>(
+    what: string,
+    version: number | null,
+    run: (version: number | null) => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await run(version);
+    } catch (err) {
+      const actual = optimisticLockVersion(err);
+      if (actual === null || actual === version) throw err;
+      this.log.warn(
+        { what, sent: version, actual },
+        "md rejected the version; replaying the write with the version it reports",
+      );
+      return await run(actual);
+    }
   }
 
   // --------------------------------------------------------------------- auth
@@ -706,23 +785,28 @@ export class MdClient implements MdExtendedApi {
    * Correct an existing title. Mirrors `editChapter`: a PUT carrying the
    * version MangaDex currently holds, which it bumps itself.
    *
-   * `tries: 1`, unlike every other write here: a rejection is either a version
-   * conflict (the same stale version can never succeed) or a validation error
-   * (which will not change on retry). Replaying either against a public
-   * catalogue risks applying an edit the operator was told had failed. A 4xx
-   * becomes an MdRequestError carrying the status, so the caller can tell "the
-   * title moved under you" from "MangaDex refused this".
+   * `tries: 1`, unlike every other write here: a rejection is a validation
+   * error, and replaying it against a public catalogue risks applying an edit
+   * the operator was told had failed. A 4xx becomes an MdRequestError carrying
+   * the status, so the caller can tell "the title moved under you" from
+   * "MangaDex refused this".
+   *
+   * The one rejection that IS replayed is a version conflict, and only with the
+   * version MangaDex names in it: the same stale number can never succeed, but
+   * the corrected one is the write the caller asked for.
    */
   async editManga(
     mangaId: string,
     payload: Record<string, unknown>,
     version: number,
   ): Promise<boolean> {
-    const response = await this.request("PUT", `${this.config.mdApiUrl}/manga/${mangaId}`, {
-      json: { ...payload, version },
-      tries: 1,
+    return this.withVersionRetry(`PUT /manga/${mangaId}`, version, async (attempt) => {
+      const response = await this.request("PUT", `${this.config.mdApiUrl}/manga/${mangaId}`, {
+        json: { ...payload, version: attempt },
+        tries: 1,
+      });
+      return response.status === 200;
     });
-    return response.status === 200;
   }
 
   /** Port of fetch_aggregate; returns the `volumes` object, or null on error. */
@@ -788,14 +872,16 @@ export class MdClient implements MdExtendedApi {
    * Unlike /upload/begin this attaches pages to a chapter that already exists.
    */
   async beginEditSession(chapterId: string, version: number | null): Promise<{ id: string }> {
-    const response = await this.request(
-      "POST",
-      `${this.config.mdApiUrl}/upload/begin/${chapterId}`,
-      { json: { version }, tries: 1 },
-    );
-    const id = MdClient.dataId(response.data);
-    if (!id) throw new MdRequestError("edit session response carried no id");
-    return { id };
+    return this.withVersionRetry(`POST /upload/begin/${chapterId}`, version, async (attempt) => {
+      const response = await this.request(
+        "POST",
+        `${this.config.mdApiUrl}/upload/begin/${chapterId}`,
+        { json: { version: attempt }, tries: 1 },
+      );
+      const id = MdClient.dataId(response.data);
+      if (!id) throw new MdRequestError("edit session response carried no id");
+      return { id };
+    });
   }
 
   /**
@@ -894,10 +980,13 @@ export class MdClient implements MdExtendedApi {
   }
 
   async editChapter(chapterId: string, payload: Record<string, unknown>): Promise<boolean> {
-    const response = await this.request("PUT", `${this.config.mdApiUrl}/chapter/${chapterId}`, {
-      json: payload,
+    const sent = typeof payload.version === "number" ? payload.version : null;
+    return this.withVersionRetry(`PUT /chapter/${chapterId}`, sent, async (version) => {
+      const response = await this.request("PUT", `${this.config.mdApiUrl}/chapter/${chapterId}`, {
+        json: version === null ? payload : { ...payload, version },
+      });
+      return response.status === 200;
     });
-    return response.status === 200;
   }
 
   /**

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -460,6 +460,15 @@ export class UploadTaskWorkers {
         }),
       );
 
+      // MangaDex allows one open upload session per account, and this task is
+      // retried: an attempt killed between opening a session and deleting it
+      // leaves one behind that rejects every later begin, edit or upload alike.
+      const openSession = await md.currentUploadSession();
+      if (openSession) {
+        log.warn({ sessionId: openSession.id }, "removing stale upload session before edit");
+        await md.deleteUploadSession(openSession.id);
+      }
+
       const session = await md.beginEditSession(mdChapterId, attrs.version);
       try {
         const pageId = await this.uploadCard(session.id, card, log);
@@ -478,6 +487,10 @@ export class UploadTaskWorkers {
         );
 
         // The commit bumps the version and PUT /chapter needs the current one.
+        // Both readings below can lag the write that just happened — the echo
+        // may predate the bump, the refetch may be served from MangaDex's
+        // cache — so this is a best guess; `editChapter` corrects it from the
+        // 409 rather than failing the task.
         let version = committed?.attributes?.version ?? null;
         if (version === null) {
           const refetched = await md.chapterById(mdChapterId);

--- a/test/unit/mdVersionConflict.test.ts
+++ b/test/unit/mdVersionConflict.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MdClient, MdRequestError, optimisticLockVersion } from "../../src/core/md/client.js";
+import { loadConfig } from "../../src/config.js";
+import { createLogger } from "../../src/logging.js";
+
+/**
+ * MangaDex's optimistic lock, and the reason the unavailable-chapter flow used
+ * to dead-end on it.
+ *
+ * The flow writes three versioned times against one chapter: open an edit
+ * session, commit the card, repoint `externalUrl`. Each write carries the
+ * version a *read* reported, and a read can lag the writes — MangaDex serves
+ * chapter GETs from a cache, and an UNAVAILABLE task that failed after
+ * committing is retried against that warm cache. The number it re-reads is the
+ * pre-commit one, so its next write is rejected:
+ *
+ *   409 "The optimistic lock failed, version 2 was expected, but is actually 3"
+ *
+ * and the retry rejects identically, forever. The rejection names the real
+ * version, so the fix is to replay the write with it.
+ */
+describe("MangaDex version conflicts", () => {
+  const BASE = "https://md.test/api";
+
+  const lockError = (expected: number, actual: number) =>
+    new Response(
+      JSON.stringify({
+        result: "error",
+        errors: [
+          {
+            id: "1eda4276-94fc-5629-bbc2-727731fef831",
+            status: 409,
+            title: "optimistic_lock_exception",
+            detail: `The optimistic lock failed, version ${expected} was expected, but is actually ${actual}`,
+            context: null,
+          },
+        ],
+      }),
+      { status: 409, headers: { "content-type": "application/json" } },
+    );
+
+  describe("optimisticLockVersion", () => {
+    it("reads the current version out of a 409 body", () => {
+      const err = new MdRequestError("PUT failed", 409, {
+        errors: [
+          {
+            title: "optimistic_lock_exception",
+            detail: "The optimistic lock failed, version 2 was expected, but is actually 3",
+          },
+        ],
+      });
+      expect(optimisticLockVersion(err)).toBe(3);
+    });
+
+    it("falls back to the message when the body did not parse", () => {
+      const err = new MdRequestError(
+        'PUT https://md.test/api/chapter/c1 failed; 409: {"errors":[{"title":"optimistic_lock_exception","detail":"The optimistic lock failed, version 7 was expected, but is actually 9"',
+        409,
+        null,
+      );
+      expect(optimisticLockVersion(err)).toBe(9);
+    });
+
+    it("ignores a 409 that is not a version conflict", () => {
+      const err = new MdRequestError("POST failed", 409, {
+        errors: [{ title: "upload_session_exists", detail: "A session already exists" }],
+      });
+      expect(optimisticLockVersion(err)).toBeNull();
+    });
+
+    it("ignores non-409 errors and non-errors", () => {
+      expect(optimisticLockVersion(new MdRequestError("nope", 400, null))).toBeNull();
+      expect(optimisticLockVersion(new Error("nope"))).toBeNull();
+      expect(optimisticLockVersion(null)).toBeNull();
+    });
+  });
+
+  describe("client replays the write", () => {
+    let client: MdClient;
+    let sent: { url: string; body: unknown }[];
+    let respond: (url: string, attempt: number) => Response;
+
+    beforeEach(() => {
+      sent = [];
+      vi.stubGlobal("fetch", async (url: string | URL, init?: RequestInit) => {
+        const href = String(url);
+        if (href.includes("/token")) {
+          return new Response(
+            JSON.stringify({
+              access_token: "access",
+              refresh_token: "refresh",
+              expires_in: 900,
+              token_type: "Bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+        sent.push({ url: href, body });
+        return respond(href, sent.length);
+      });
+
+      const config = loadConfig({
+        DATABASE_URL: "postgresql://unused/unused",
+        MANGADEX_API_URL: BASE,
+        MANGADEX_AUTH_URL: "https://auth.test/realms/mangadex/protocol/openid-connect",
+        MANGADEX_USERNAME: "u",
+        MANGADEX_PASSWORD: "p",
+        MANGADEX_CLIENT_ID: "c",
+        MANGADEX_CLIENT_SECRET: "s",
+        MANGADEX_RATELIMIT_MS: "0",
+        LOG_LEVEL: "error",
+      });
+      const prisma = {
+        setting: {
+          findMany: async () => [],
+          upsert: async () => ({}),
+          deleteMany: async () => ({ count: 0 }),
+        },
+      } as never;
+      client = new MdClient(config, prisma, createLogger("md-version-test", "error"));
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    const ok = (data: unknown) =>
+      new Response(JSON.stringify({ result: "ok", data }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    it("opens the edit session with the version MangaDex reports", async () => {
+      respond = (_url, attempt) =>
+        attempt === 1 ? lockError(2, 3) : ok({ id: "session-1", type: "upload_session" });
+
+      await expect(client.beginEditSession("chapter-1", 2)).resolves.toEqual({ id: "session-1" });
+      expect(sent.map((call) => (call.body as { version: number }).version)).toEqual([2, 3]);
+    });
+
+    it("repoints externalUrl with the version MangaDex reports", async () => {
+      respond = (_url, attempt) =>
+        attempt === 1 ? lockError(2, 3) : ok({ id: "chapter-1", type: "chapter" });
+
+      const payload = { chapter: "12", externalUrl: null, version: 2 };
+      await expect(client.editChapter("chapter-1", payload)).resolves.toBe(true);
+      expect(sent).toHaveLength(2);
+      expect(sent[1]?.body).toEqual({ ...payload, version: 3 });
+      // The caller's payload is not mutated; only the replay carries the bump.
+      expect(payload.version).toBe(2);
+    });
+
+    it("edits a title with the version MangaDex reports", async () => {
+      respond = (_url, attempt) =>
+        attempt === 1 ? lockError(4, 5) : ok({ id: "manga-1", type: "manga" });
+
+      await expect(client.editManga("manga-1", { title: { en: "x" } }, 4)).resolves.toBe(true);
+      expect((sent[1]?.body as { version: number }).version).toBe(5);
+    });
+
+    it("gives up after one replay rather than chasing a moving version", async () => {
+      // A second conflict means something outside this flow is writing; replaying
+      // a body built from a stale read over it is what the lock is there to stop.
+      respond = (_url, attempt) => lockError(2, 2 + attempt);
+
+      await expect(client.beginEditSession("chapter-1", 2)).rejects.toThrow(
+        /optimistic_lock_exception/,
+      );
+      expect(sent).toHaveLength(2);
+    });
+
+    it("does not replay a 409 that is not a version conflict", async () => {
+      respond = () =>
+        new Response(
+          JSON.stringify({
+            result: "error",
+            errors: [{ status: 409, title: "upload_session_exists", detail: "already open" }],
+          }),
+          { status: 409, headers: { "content-type": "application/json" } },
+        );
+
+      await expect(client.beginEditSession("chapter-1", 2)).rejects.toThrow(/409/);
+      expect(sent).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## The 409

```
409 optimistic_lock_exception
"The optimistic lock failed, version 2 was expected, but is actually 3"
```

The unavailable-chapter flow makes three **versioned** writes against one chapter:

1. `POST /upload/begin/{chapterId}` — `{version}` from `chapterById`
2. `POST /upload/{session}/commit` — bumps the chapter version
3. `PUT /chapter/{id}` — `{version}` from the commit echo, or a refetch

Every version in there comes from a *read*, and a read is not a reliable view of the version mid-sequence: MangaDex serves chapter GETs from a cache that lags its own writes, and step 2 bumps the version behind that cache. An `UNAVAILABLE` task that dies after committing gets retried by the uploader (`tasks.fail` → backoff → re-claim), re-reads the **pre-commit** version off the warm cache, and is rejected at step 1 or step 3 — identically on every retry, until attempts run out. Re-reading harder does not help; the read is the thing that is stale.

## The fix

The rejection itself names the current version, which makes it the only authoritative reading available during a write. So replay the write once with it.

- `optimisticLockVersion(err)` — parses the real version out of a 409, and only for `optimistic_lock_exception`. Other 409s (an already-open session) return `null` and are not replayed.
- `MdRequestError` now carries the parsed error body; the message is used as a fallback so an unparseable body is still readable.
- `withVersionRetry` wraps `beginEditSession`, `editChapter` and `editManga`. **Once**, deliberately — a second conflict means the entity is moving for reasons this flow does not control, and pushing a body built from a stale read over someone else's edit is what the lock exists to prevent.

Also: the unavailable flow now clears a stale upload session before opening its edit session, the way the upload flow already does. MangaDex allows one open session per account, and an attempt killed between opening one and deleting it leaves it behind to reject every later begin.

## Verification

`test/unit/mdVersionConflict.test.ts` — 9 cases: parsing (body, message fallback, non-lock 409, non-409), replay for each of the three writes, no-replay for a non-lock 409, and give-up-after-one for a version that keeps moving. It also asserts the caller's payload is not mutated by the replay.

733 unit tests pass, `tsc --noEmit` clean, eslint clean. Integration tests were skipped locally — no test database available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
