### PR TITLE
Series-map sync: dashboard control, compact rendering, and a repoint guard

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1880,6 +1880,13 @@ padmin maps sync               # do it now
 padmin maps sync --extension mangaplus --extension viz
 ```
 
+The same run is on the dashboard, for the change that should not wait a week:
+**Tracked → Publish to GitHub** covers every extension, and the same card at the
+bottom of **Extensions → *name* → Series map** covers just that one. Preview
+first; it prints the per-extension outcome, the repo and the exact delta, and
+the commit asks for confirmation. Both need the `tracked:write` scope, so a
+CONTRIBUTOR sees the card disabled rather than absent.
+
 | | |
 | --- | --- |
 | **Where it runs** | core-api. It is the only core service with a GitHub token and egress; core-scheduler sits on the internal `data` network. |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1909,6 +1909,12 @@ What it will not do, because it commits unattended:
 - **Keeps each file's shape.** mangaplus's `{titleId: [ids]}`, alpha_manga's
   `{id: titleId}` and viz's nested `{namespace: {…}}` all survive; only the
   ordering is normalised (once), so a week with no changes makes no commit.
+- **Keeps each file's layout.** The indent is read from the file, arrays stay on
+  one line, and alpha_manga's right-aligned ids stay aligned. This is not
+  cosmetic: the renderer used to be `JSON.stringify(…, 2)`, which put every id
+  on its own line and reindented everything, so the first run turned mangaplus
+  into a 2565-line file and a commit whose subject said `+7 -1` and whose diff
+  was every line. A diff has to be the change.
 
 Its commits carry `[map-sync]` in the subject, and the push webhook skips a
 delivery whose commits are *all* marked; otherwise the platform would answer

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -6678,6 +6678,9 @@ function seriesMapPanel(name) {
     extensionTabs(name, "series-map"),
     trackedCard(name, tracked),
     bulkCurationCard(name, tracked),
+    // Last on the page on purpose: it is what an operator reaches for after
+    // making the edits above, not before.
+    mapSyncCard(name),
   );
 }
 
@@ -7166,6 +7169,150 @@ function bulkCurationCard(name, tracked) {
   );
 }
 
+// -------------------------------------------------- publishing the map to git
+
+/**
+ * Run the series-map write-back to GitHub by hand.
+ *
+ * core-api already does this on a weekly timer, and that cadence is what keeps
+ * the files honest without anyone having to think about it. This card exists
+ * for the gap the cadence leaves: an operator who has just repointed a series
+ * or pruned a batch of mappings would otherwise either wait up to a week or go
+ * find a shell to run `publoader-admin maps sync` from. The endpoint and the
+ * CLI have both been there since the timer was written; only the button was
+ * missing, which is what makes the weekly job look broken to anyone who checks
+ * the repo the day after an edit.
+ *
+ * `name` limits the run to one extension; null runs every extension, which is
+ * what the timer does.
+ *
+ * Preview-then-commit is deliberate rather than a single button. This writes to
+ * somebody's repository unattended, and the preview names each file, the repo
+ * it lives in and the exact delta; so what the operator confirms is a diff they
+ * have read, not a verb they have trusted.
+ */
+function mapSyncCard(name) {
+  const writable = can("tracked:write");
+  const results = el("div", {});
+  /**
+   * Kept outside the click handlers so its state survives a preview and the
+   * commit that follows: force is meant to be switched on in answer to a
+   * refusal the operator has just read, not ticked before they know whether the
+   * shrink guard is going to fire at all.
+   */
+  const force = el("input", { type: "checkbox", id: `map-sync-force${name ? `-${name}` : ""}` });
+
+  const requestBody = (dryRun) => ({
+    dryRun,
+    force: force.checked,
+    extensions: name ? [name] : [],
+  });
+
+  /**
+   * Render one report. The per-extension status is the whole value of this
+   * card: `unchanged`, `skipped` and `refused` are all non-failures with very
+   * different meanings, and a bare "ok" would hide the one of them an operator
+   * has to act on.
+   */
+  const draw = (report, dryRun) => {
+    const outcomes = report.outcomes ?? [];
+    setChildren(
+      results,
+      report.skippedReason
+        ? el("p", { class: "error", text: `Nothing to do: ${report.skippedReason}` })
+        : null,
+      outcomes.length
+        ? table(
+            ["Extension", "Status", "Repo", "Mappings", "Delta", "Commit", "Detail"],
+            outcomes.map((o) => [
+              o.extension,
+              o.status,
+              o.repo ?? "-",
+              String(o.mappings ?? 0),
+              `+${o.added ?? 0} -${o.removed ?? 0}`,
+              o.commit ? String(o.commit).slice(0, 7) : "-",
+              o.detail ?? "",
+            ]),
+            { empty: "No extension has tracked mappings." },
+          )
+        : null,
+      el("p", {
+        class: report.failed ? "error" : "dim small",
+        text:
+          `${dryRun ? "Would write" : "Wrote"} ${report.written ?? 0} file(s)` +
+          (report.failed ? `, ${report.failed} failed.` : "."),
+      }),
+    );
+  };
+
+  const previewButton = el("button", {
+    type: "button",
+    text: "Preview",
+    disabled: !writable,
+    onclick: async (event) => {
+      const report = await act(
+        "map_sync.preview",
+        () => api("/maps/sync", { method: "POST", body: requestBody(true) }),
+        { button: event.currentTarget },
+      );
+      if (report) draw(report, true);
+    },
+  });
+
+  const commitButton = el("button", {
+    type: "button",
+    class: "primary",
+    text: "Sync now",
+    disabled: !writable,
+    onclick: async (event) => {
+      const confirmed = await confirmDialog({
+        title: "Write the series map to GitHub",
+        lead: name
+          ? `This commits ${name}'s map file to its extensions repo.`
+          : "This commits every extension's map file to its extensions repo.",
+        points: [
+          "The database is the authority: each file is rewritten from what is tracked now.",
+          "A map file that is not already in the repo is skipped, never created.",
+          force.checked
+            ? "Force is ON, so a write that drops more than half of a file's mappings will NOT be refused."
+            : "A write that would drop more than half of a file's mappings is refused.",
+          "Preview first if you have not; this is a commit to a repository other people read.",
+        ],
+        confirmLabel: "Commit it",
+      });
+      if (!confirmed) return;
+      const report = await act(
+        "map_sync.run",
+        () => api("/maps/sync", { method: "POST", body: requestBody(false) }),
+        { button: event.currentTarget },
+      );
+      if (report) draw(report, false);
+    },
+  });
+
+  return card(
+    "Publish to GitHub",
+    el("p", {
+      class: "dim small",
+      text:
+        (name ? `Write ${name}'s ` : "Write each extension's ") +
+        "map file back to its extensions repo. This is the same job core-api runs weekly, for a change " +
+        "that should not wait for it. A run with nothing to say makes no commit.",
+    }),
+    writable
+      ? null
+      : el("p", { class: "dim small", text: 'Running the sync needs the "tracked:write" scope.' }),
+    el(
+      "label",
+      { class: "assign-row", for: force.id },
+      force,
+      el("span", { text: "Force (allow a write that removes more than half of a file's mappings)" }),
+    ),
+    row(previewButton, commitButton),
+    results,
+  );
+}
+
 // -------------------------------------------------------------------- tracked
 
 /**
@@ -7192,27 +7339,34 @@ VIEWS.tracked = () => {
     return rows;
   });
 
-  return card(
-    "Series map by extension",
-    el("p", {
-      class: "dim small",
-      text: "Open an extension to search, export, edit and bulk-paste its mappings.",
-    }),
-    live(
-      [counts],
-      (rows) =>
-        table(
-          ["Extension", "Mappings", "Most recent", ""],
-          rows.map((r) => [
-            r.name,
-            r.count === null ? "unreadable" : String(r.count),
-            r.newest ? `${r.newest.mangaId} · ${fmtTime(r.newest.createdAt)}` : "-",
-            [routeLink(routeTo("extensions", r.name, "series-map"), "Open map", { class: "button-link inline" })],
-          ]),
-          { empty: "No extension is published, so there is no map to curate yet." },
-        ),
-      { reserve: 200, skeleton: () => skeletonTable(4, 4) },
+  return el(
+    "div",
+    {},
+    card(
+      "Series map by extension",
+      el("p", {
+        class: "dim small",
+        text: "Open an extension to search, export, edit and bulk-paste its mappings.",
+      }),
+      live(
+        [counts],
+        (rows) =>
+          table(
+            ["Extension", "Mappings", "Most recent", ""],
+            rows.map((r) => [
+              r.name,
+              r.count === null ? "unreadable" : String(r.count),
+              r.newest ? `${r.newest.mangaId} · ${fmtTime(r.newest.createdAt)}` : "-",
+              [routeLink(routeTo("extensions", r.name, "series-map"), "Open map", { class: "button-link inline" })],
+            ]),
+            { empty: "No extension is published, so there is no map to curate yet." },
+          ),
+        { reserve: 200, skeleton: () => skeletonTable(4, 4) },
+      ),
     ),
+    // The all-extensions run belongs here rather than on one extension's page:
+    // this is the only view that is about the map as a whole.
+    mapSyncCard(null),
   );
 };
 

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -6900,31 +6900,81 @@ function trackedCard(name, tracked) {
         class: "primary",
         text: "Add mapping",
         onclick: (event) => {
-          if (!mangaId.value.trim() || !mdMangaId.value.trim()) {
+          const externalId = mangaId.value.trim();
+          const target = mdMangaId.value.trim();
+          const namespace = namespaceInput.value.trim();
+          if (!externalId || !target) {
             return void toast("both ids are required", false);
           }
-          return act(
-            "tracked_manga.set",
-            () =>
-              api(`/extensions/${encoded}/tracked`, {
-                method: "PUT",
-                body: {
-                  mangaId: mangaId.value.trim(),
-                  mdMangaId: mdMangaId.value.trim(),
-                  // Omitted rather than sent empty: the server normalises a
-                  // missing namespace to the default catalogue.
-                  ...(namespaceInput.value.trim() ? { namespace: namespaceInput.value.trim() } : {}),
-                },
-              }),
-            { button: event.currentTarget, refresh: [tracked] },
-          ).then((ok) => {
-            if (ok) {
-              mangaId.value = "";
-              mdMangaId.value = "";
-              // The catalogue is deliberately kept: adding several rows to one
-              // catalogue is the common case, and re-typing it every time is
-              // how a row lands in the wrong one.
-            }
+          // Captured now: `currentTarget` is null by the time the confirmation
+          // below resolves, and `act` needs the button to show as pending.
+          const button = event.currentTarget;
+          const send = () =>
+            act(
+              "tracked_manga.set",
+              () =>
+                api(`/extensions/${encoded}/tracked`, {
+                  method: "PUT",
+                  body: {
+                    mangaId: externalId,
+                    mdMangaId: target,
+                    // Omitted rather than sent empty: the server normalises a
+                    // missing namespace to the default catalogue.
+                    ...(namespace ? { namespace } : {}),
+                  },
+                }),
+              { button, refresh: [tracked] },
+            ).then((ok) => {
+              if (ok) {
+                mangaId.value = "";
+                mdMangaId.value = "";
+                // The catalogue is deliberately kept: adding several rows to one
+                // catalogue is the common case, and re-typing it every time is
+                // how a row lands in the wrong one.
+              }
+            });
+
+          /**
+           * The button says Add, but the endpoint is a PUT: an external id that
+           * is already mapped is repointed, and it used to happen silently on
+           * the first click. Repointing is the one edit on this page with no
+           * visible consequence and a large invisible one — the series keeps
+           * publishing, its chapters just start landing on a different title —
+           * so a typo in the id field could quietly redirect a live series.
+           *
+           * The whole map is already in hand for the search and export below,
+           * so the collision is caught here rather than reported afterwards.
+           */
+          const clash = (tracked.data?.tracked ?? []).find(
+            (r) => r.mangaId === externalId && (r.namespace || "") === namespace,
+          );
+          if (!clash) return void send();
+
+          const where = namespace ? `${externalId} in ${namespace}` : externalId;
+          if (clash.mdMangaId === target) {
+            // Not an error the server would reject, just nothing to do; saying
+            // so beats a success toast for a write that changed nothing.
+            return void toast(`${where} is already mapped to that title.`, false);
+          }
+          if (!can("tracked:write")) {
+            // `tracked:append` may add but not move one. Say it here rather
+            // than letting a confirmed repoint come back 403.
+            return void toast(
+              `${where} is already mapped to ${clash.mdMangaId}; repointing needs the "tracked:write" scope.`,
+              false,
+            );
+          }
+          return void confirmDialog({
+            title: "That external id is already mapped",
+            lead: `${where} is already mapped to ${clash.mdMangaId}.`,
+            points: [
+              `Adding it again repoints it to ${target}.`,
+              "The series keeps publishing; new chapters just start landing on the other title.",
+              "Chapters already uploaded stay where they are.",
+            ],
+            confirmLabel: "Repoint it",
+          }).then((confirmed) => {
+            if (confirmed) void send();
           });
         },
       }),
@@ -6932,7 +6982,7 @@ function trackedCard(name, tracked) {
     el("p", {
       class: "dim small",
       text: can("tracked:write")
-        ? "Adding a mapping that already exists repoints it."
+        ? "An external id that is already mapped is not added twice: you are asked to confirm the repoint first."
         : 'Adding a new mapping is allowed. Repointing one that already exists needs the "tracked:write" scope, and is refused with the id it is currently mapped to.',
     }),
     row(

--- a/src/core/mapsync/mapFile.ts
+++ b/src/core/mapsync/mapFile.ts
@@ -29,7 +29,29 @@ export interface MapShape {
   nested: boolean;
   /** `forward` is `{externalId: mdId}`; `inverted` is `{mdId: [externalId, …]}`. */
   inner: "forward" | "inverted";
+  /**
+   * Spaces per level, read from the file. Absent means {@link DEFAULT_INDENT}.
+   *
+   * Optional because it is a layout detail rather than a shape, and because a
+   * caller that only cares about the two axes above should not have to state
+   * it.
+   */
+  indent?: number;
+  /**
+   * Right-align the keys inside an object so their closing quotes line up,
+   * which is how alpha_manga's numeric ids are written. Absent means no.
+   */
+  align?: boolean;
 }
+
+/**
+ * Spaces per level for a file that does not tell us otherwise.
+ *
+ * Four, because all three maps in the wild are written that way. This used to
+ * be the `2` baked into a `JSON.stringify(…, 2)` call, which meant the first
+ * sync reindented every line of every file it touched.
+ */
+export const DEFAULT_INDENT = 4;
 
 /**
  * What a brand-new file would look like. Inverted because that is the shape the
@@ -115,7 +137,105 @@ export function renderMapFile(rows: ParsedIdMapRow[], shape: MapShape = DEFAULT_
       )
     : flat(rows);
 
-  return JSON.stringify(document, null, 2) + "\n";
+  return serialise(document, shape);
+}
+
+/** A JSON string literal. `JSON.stringify` is the escaping rule, not a guess. */
+const quoted = (value: string): string => JSON.stringify(value);
+
+/** `["100001", "200008"]` or `"aaaa-…"`. Always one line, however long. */
+const inlineValue = (value: unknown): string =>
+  Array.isArray(value) ? `[${value.map((item) => quoted(String(item))).join(", ")}]` : quoted(String(value));
+
+/**
+ * Serialise the map document the way these files are actually written.
+ *
+ * This was `JSON.stringify(document, null, 2)`, which is wrong in two ways that
+ * only show up in a diff. It puts every array element on its own line, so a
+ * mapping that reads `"<md id>": ["100001", "200008"]` becomes four lines; and
+ * it hard-codes an indent none of the files use. The first weekly sync
+ * therefore rewrote mangaplus from 761 lines to 2565 — a commit whose subject
+ * said `+7 -1` and whose diff was the entire file. Nothing was wrong with the
+ * data, but the one property that makes an unattended commit reviewable, that
+ * the diff is the change, was gone.
+ *
+ * So: arrays inline, indent taken from the file, and the key alignment
+ * preserved when the file has one. Still deterministic to the byte, which is
+ * what stops a week with no changes from producing a commit.
+ */
+function serialise(document: Record<string, unknown>, shape: MapShape): string {
+  const entries = Object.entries(document);
+  if (entries.length === 0) return "{}\n";
+  return ["{", ...commaJoin(objectBlocks(entries, 1, shape)), "}"].join("\n") + "\n";
+}
+
+/**
+ * One block of lines per entry: a scalar or array is one line, a namespace is
+ * its braces and everything inside them. Blocks rather than lines because only
+ * the block knows which of its lines is the last, and that is the one a comma
+ * goes on.
+ */
+function objectBlocks(entries: [string, unknown][], depth: number, shape: MapShape): string[][] {
+  const base = " ".repeat((shape.indent ?? DEFAULT_INDENT) * depth);
+  // Per object, not per file: each namespace aligns within itself.
+  const widest = shape.align === true ? Math.max(0, ...entries.map(([key]) => key.length)) : 0;
+
+  return entries.map(([key, value]) => {
+    const label = `${base}${" ".repeat(Math.max(0, widest - key.length))}${quoted(key)}: `;
+    if (!isPlainObject(value)) return [`${label}${inlineValue(value)}`];
+    const inner = Object.entries(value);
+    // `{}` on one line: viz has an empty namespace, and three lines to say
+    // nothing is exactly the noise this function exists to remove.
+    if (inner.length === 0) return [`${label}{}`];
+    return [`${label}{`, ...commaJoin(objectBlocks(inner, depth + 1, shape)), `${base}}`];
+  });
+}
+
+/** Flatten blocks into lines, putting a comma after every block but the last. */
+function commaJoin(blocks: string[][]): string[] {
+  return blocks.flatMap((block, index) =>
+    index === blocks.length - 1 ? block : block.map((line, i) => (i === block.length - 1 ? `${line},` : line)),
+  );
+}
+
+/**
+ * Read a file's two whitespace conventions out of its text.
+ *
+ * `JSON.parse` throws both away, and they are most of what a diff shows: a
+ * two-space rewrite of a four-space file is a hundred percent changed lines
+ * that mean nothing at all.
+ *
+ * The indent is the smallest leading run on any key line, which is the width of
+ * one level whether the file is flat or nested. Alignment is only considered
+ * for a flat file: alpha_manga right-aligns its numeric ids so every key ends
+ * in the same column, and the tell is that the leading runs differ while the
+ * ending column does not. Deciding that per-namespace for a nested file would
+ * be more guesswork than it is worth, and viz, the only nested file, does not
+ * align.
+ */
+export function detectLayout(text: string, nested: boolean): { indent: number; align: boolean } {
+  const leads: number[] = [];
+  const ends: number[] = [];
+  for (const line of text.split("\n")) {
+    const match = /^( +)"((?:[^"\\]|\\.)*)"\s*:/.exec(line);
+    if (!match) continue;
+    leads.push(match[1]!.length);
+    ends.push(match[1]!.length + match[2]!.length);
+  }
+  if (leads.length === 0) return { indent: DEFAULT_INDENT, align: false };
+
+  const indent = Math.min(...leads);
+  if (nested || new Set(leads).size === 1) return { indent, align: false };
+  // Every key ending in the same column, with the runs in front of them
+  // differing, is alignment and cannot readily be anything else.
+  const dominant = Math.max(...countBy(ends).values());
+  return { indent, align: dominant / ends.length >= 0.98 };
+}
+
+function countBy(values: number[]): Map<number, number> {
+  const out = new Map<number, number>();
+  for (const value of values) out.set(value, (out.get(value) ?? 0) + 1);
+  return out;
 }
 
 /**
@@ -218,7 +338,12 @@ export function parseMapText(text: string): { rows: ParsedIdMapRow[]; shape: Map
   } catch {
     return { rows: [], shape: null };
   }
-  return { rows: parseMangaIdMapFile(document), shape: detectMapShape(document) };
+  const shape = detectMapShape(document);
+  return {
+    rows: parseMangaIdMapFile(document),
+    // The layout comes from the text because the parse has already lost it.
+    shape: shape ? { ...shape, ...detectLayout(text, shape.nested) } : null,
+  };
 }
 
 /**

--- a/test/unit/dashboardMapSync.test.ts
+++ b/test/unit/dashboardMapSync.test.ts
@@ -1,0 +1,315 @@
+// @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The series map can be pushed to GitHub from the dashboard.
+ *
+ * `POST /maps/sync` and `publoader-admin maps sync` both existed from the day
+ * the weekly timer was written, but nothing on the dashboard called either. The
+ * effect was not a missing convenience: an operator who repointed a series,
+ * looked at the extensions repo and saw the old file had no way to tell a job
+ * that runs every seven days from a job that is broken, and no way to settle it
+ * without a shell. These tests pin the control that closed that gap.
+ *
+ * Driven the same way as dashboardOutstanding.test.ts: the real app.js
+ * evaluated under jsdom against a stubbed API. See dashboardChapters.test.ts's
+ * header for why app.js is a classic script and how it is mounted.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any --
+   The DOM lib is deliberately kept out of this program (see the same note in
+   dashboardModules.test.ts), so the jsdom globals, and every node read back out
+   of them below, are loosely typed in this file only. */
+const doc: any = (globalThis as any).document;
+const win: any = globalThis;
+
+const DASHBOARD = resolve(process.cwd(), "src/core/api/dashboard");
+const APP_JS = join(DASHBOARD, "app.js");
+const INDEX_HTML = join(DASHBOARD, "index.html");
+
+/**
+ * A report with one of every outcome that matters. `unchanged` and `skipped`
+ * are successes, `refused` is the shrink guard doing its job; all three come
+ * back with `failed: 0`, which is exactly why the card has to show the column
+ * rather than a single verdict.
+ */
+const REPORT = {
+  ok: true,
+  ranAt: "2026-08-19T12:30:33.527Z",
+  dryRun: true,
+  written: 1,
+  failed: 0,
+  outcomes: [
+    {
+      extension: "mangaplus",
+      status: "write",
+      repo: "publoader-extensions",
+      path: "src/mangaplus/manga_id_map.json",
+      added: 3,
+      removed: 0,
+      mappings: 1034,
+      detail: "would write",
+    },
+    {
+      extension: "viz",
+      status: "unchanged",
+      repo: "publoader-extensions-private",
+      path: "src/viz/manga_id_map.json",
+      added: 0,
+      removed: 0,
+      mappings: 12,
+    },
+    {
+      extension: "k_manga",
+      status: "skipped",
+      repo: "publoader-extensions-private",
+      added: 4,
+      removed: 0,
+      mappings: 4,
+      detail: "the file is not in the repo; create it once by hand and the sync will keep it current",
+    },
+  ],
+};
+
+/** Swapped per test so the scope gate can be exercised. */
+let scopes: string[] = ["*"];
+/** Every request app.js made, in order, with the body it sent. */
+let calls: { path: string; method: string; body: any }[] = [];
+
+function apiRoutes(): { match: RegExp; body: unknown }[] {
+  return [
+    { match: /\/session$/, body: { actor: "ardax", role: "OWNER", userId: "u1", email: "a@b.c" } },
+    {
+      match: /\/whoami$/,
+      body: {
+        kind: "session",
+        name: "ardax",
+        role: "OWNER",
+        scopes,
+        csrfHeader: "x-requested-with",
+        csrfValue: "publoader-dash",
+      },
+    },
+    {
+      match: /\/stats$/,
+      body: { paused: false, workers: {}, jobs: {}, uploadTasks: [], quarantined: 0 },
+    },
+    { match: /\/runs\?limit=1/, body: { runs: [] } },
+    { match: /\/maps\/sync$/, body: REPORT },
+    {
+      match: /\/extensions\/[^/]+\/tracked$/,
+      body: { tracked: [{ mangaId: "100001", mdMangaId: "abc", createdAt: "2026-08-01T00:00:00Z" }] },
+    },
+    { match: /\/extensions$/, body: { extensions: [{ name: "mangaplus" }, { name: "viz" }] } },
+  ];
+}
+
+function installFetch(): void {
+  const routes = apiRoutes();
+  win.fetch = vi.fn(async (url: string, init: any = {}) => {
+    const path = String(url);
+    let body: any = null;
+    try {
+      body = init.body ? JSON.parse(init.body) : null;
+    } catch {
+      body = init.body;
+    }
+    calls.push({ path, method: init.method ?? "GET", body });
+    const route = routes.find((r) => r.match.test(path));
+    return {
+      ok: Boolean(route),
+      status: route ? 200 : 404,
+      statusText: route ? "OK" : "Not Found",
+      text: async () => JSON.stringify(route ? route.body : {}),
+    };
+  });
+}
+
+async function settle(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+async function goto(hash: string): Promise<void> {
+  win.location.hash = hash;
+  await settle();
+}
+
+/**
+ * jsdom implements <dialog> as an element but not its modal methods, so the
+ * real `showModal()` that `confirmDialog` calls throws asynchronously out of a
+ * click handler; which vitest reports as an unhandled error and exits non-zero
+ * even when the assertions pass. Stubbing the two methods to the `open`
+ * attribute they set is enough here: these tests read the dialog's rendered
+ * content and click its buttons, not its modality. Same shim as
+ * dashboardChapters.test.ts.
+ */
+function stubDialogs(): void {
+  interface DialogLike {
+    showModal?: () => void;
+    close?: () => void;
+    setAttribute: (name: string, value: string) => void;
+    removeAttribute: (name: string) => void;
+  }
+  const dialogs = win.HTMLDialogElement?.prototype as DialogLike | undefined;
+  if (dialogs && typeof dialogs.showModal !== "function") {
+    dialogs.showModal = function showModal(this: DialogLike): void {
+      this.setAttribute("open", "");
+    };
+    dialogs.close = function close(this: DialogLike): void {
+      this.removeAttribute("open");
+    };
+  }
+}
+
+function mount(): void {
+  const html = readFileSync(INDEX_HTML, "utf8");
+  const body = html.split("<body>")[1]?.split("</body>")[0];
+  if (!body) throw new Error("index.html has no <body>: the dashboard shell cannot be mounted");
+  doc.body.innerHTML = body;
+  win.location.hash = "";
+  installFetch();
+  stubDialogs();
+  // Evaluated rather than imported: app.js is deliberately a classic script
+  // ending in `void boot()`, so this is how a browser runs it. The source is
+  // this repo's own file read from disk; nothing is interpolated into it.
+  new Function(readFileSync(APP_JS, "utf8")).call(win);
+}
+
+/**
+ * The most recently rendered card whose heading is `title`.
+ *
+ * Last, not first: every test in this file evaluates app.js again on the one
+ * jsdom window, so earlier instances can leave their own nodes behind.
+ */
+function cardByTitle(title: string): any {
+  const cards = [...doc.querySelectorAll("section.card")].filter(
+    (c: any) => c.querySelector("h2")?.textContent === title,
+  );
+  return cards[cards.length - 1];
+}
+
+const buttonLabelled = (root: any, text: string): any =>
+  [...root.querySelectorAll("button")].find((b: any) => b.textContent === text);
+
+const syncCalls = (): { path: string; method: string; body: any }[] =>
+  calls.filter((c) => c.path.includes("/maps/sync"));
+
+describe("the series map can be pushed to GitHub from the dashboard", () => {
+  beforeEach(async () => {
+    calls = [];
+    scopes = ["*"];
+    mount();
+    await settle(10);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  it("offers the run on the series-map index", async () => {
+    await goto("#/tracked");
+    const card = cardByTitle("Publish to GitHub");
+    expect(card).toBeTruthy();
+    expect(buttonLabelled(card, "Preview")).toBeTruthy();
+    expect(buttonLabelled(card, "Sync now")).toBeTruthy();
+    // The index still renders: the new card is an addition, not a replacement.
+    expect(cardByTitle("Series map by extension")).toBeTruthy();
+  });
+
+  it("previews without writing anything", async () => {
+    await goto("#/tracked");
+    calls = [];
+    buttonLabelled(cardByTitle("Publish to GitHub"), "Preview").click();
+    await settle();
+
+    expect(syncCalls()).toHaveLength(1);
+    const [call] = syncCalls();
+    expect(call?.method).toBe("POST");
+    // The whole point of the preview: it must not be able to commit.
+    expect(call?.body).toEqual({ dryRun: true, force: false, extensions: [] });
+  });
+
+  it("shows each extension's outcome rather than one verdict", async () => {
+    await goto("#/tracked");
+    buttonLabelled(cardByTitle("Publish to GitHub"), "Preview").click();
+    await settle();
+
+    const text = cardByTitle("Publish to GitHub").textContent;
+    expect(text).toContain("mangaplus");
+    expect(text).toContain("+3 -0");
+    // `unchanged` and `skipped` are not failures, and hiding them would leave
+    // an operator unable to tell "nothing to do" from "this one needs a file".
+    expect(text).toContain("unchanged");
+    expect(text).toContain("skipped");
+    expect(text).toContain("the file is not in the repo");
+    expect(text).toContain("Would write 1 file(s)");
+  });
+
+  it("asks before committing, and does not post if the operator backs out", async () => {
+    await goto("#/tracked");
+    calls = [];
+    buttonLabelled(cardByTitle("Publish to GitHub"), "Sync now").click();
+    await settle();
+
+    // Nothing has been sent yet; the confirmation is in front of the request.
+    expect(syncCalls()).toHaveLength(0);
+    const modal = doc.getElementById("modal");
+    expect(modal.textContent).toContain("repository other people read");
+
+    buttonLabelled(modal, "Cancel").click();
+    await settle();
+    expect(syncCalls()).toHaveLength(0);
+  });
+
+  it("commits for real once confirmed", async () => {
+    await goto("#/tracked");
+    calls = [];
+    buttonLabelled(cardByTitle("Publish to GitHub"), "Sync now").click();
+    await settle();
+    buttonLabelled(doc.getElementById("modal"), "Commit it").click();
+    await settle();
+
+    expect(syncCalls()).toHaveLength(1);
+    expect(syncCalls()[0]?.body).toEqual({ dryRun: false, force: false, extensions: [] });
+  });
+
+  it("carries force through only when it is ticked", async () => {
+    await goto("#/tracked");
+    const card = cardByTitle("Publish to GitHub");
+    const force = card.querySelector('input[type="checkbox"]');
+    expect(force).toBeTruthy();
+    force.checked = true;
+
+    calls = [];
+    buttonLabelled(card, "Preview").click();
+    await settle();
+    expect(syncCalls()[0]?.body.force).toBe(true);
+  });
+
+  it("scopes the run to one extension from that extension's map page", async () => {
+    await goto("#/extensions/mangaplus/series-map");
+    const card = cardByTitle("Publish to GitHub");
+    expect(card).toBeTruthy();
+
+    calls = [];
+    buttonLabelled(card, "Preview").click();
+    await settle();
+    expect(syncCalls()[0]?.body.extensions).toEqual(["mangaplus"]);
+  });
+
+  it("disables the run for a credential that cannot write the map", async () => {
+    // A CONTRIBUTOR may curate the map but must not publish it to a repo.
+    scopes = ["tracked:append", "extensions:read"];
+    mount();
+    await settle(10);
+    await goto("#/tracked");
+
+    const card = cardByTitle("Publish to GitHub");
+    expect(buttonLabelled(card, "Preview").disabled).toBe(true);
+    expect(buttonLabelled(card, "Sync now").disabled).toBe(true);
+    expect(card.textContent).toContain('needs the "tracked:write" scope');
+  });
+});

--- a/test/unit/dashboardMapSync.test.ts
+++ b/test/unit/dashboardMapSync.test.ts
@@ -4,6 +4,11 @@ import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
+ * The two guards on the dashboard's series-map page: publishing it to GitHub,
+ * and adding a mapping whose external id is already there.
+ *
+ * ---
+ *
  * The series map can be pushed to GitHub from the dashboard.
  *
  * `POST /maps/sync` and `publoader-admin maps sync` both existed from the day
@@ -73,6 +78,10 @@ const REPORT = {
   ],
 };
 
+const MD_A = "aaaaaaaa-0000-4000-8000-000000000001";
+const MD_B = "bbbbbbbb-0000-4000-8000-000000000002";
+const MD_C = "cccccccc-0000-4000-8000-000000000003";
+
 /** Swapped per test so the scope gate can be exercised. */
 let scopes: string[] = ["*"];
 /** Every request app.js made, in order, with the body it sent. */
@@ -100,7 +109,12 @@ function apiRoutes(): { match: RegExp; body: unknown }[] {
     { match: /\/maps\/sync$/, body: REPORT },
     {
       match: /\/extensions\/[^/]+\/tracked$/,
-      body: { tracked: [{ mangaId: "100001", mdMangaId: "abc", createdAt: "2026-08-01T00:00:00Z" }] },
+      body: {
+        tracked: [
+          { mangaId: "100001", mdMangaId: MD_A, namespace: "", createdAt: "2026-08-01T00:00:00Z" },
+          { mangaId: "709", mdMangaId: MD_B, namespace: "vizmanga", createdAt: "2026-08-01T00:00:00Z" },
+        ],
+      },
     },
     { match: /\/extensions$/, body: { extensions: [{ name: "mangaplus" }, { name: "viz" }] } },
   ];
@@ -311,5 +325,141 @@ describe("the series map can be pushed to GitHub from the dashboard", () => {
     expect(buttonLabelled(card, "Preview").disabled).toBe(true);
     expect(buttonLabelled(card, "Sync now").disabled).toBe(true);
     expect(card.textContent).toContain('needs the "tracked:write" scope');
+  });
+});
+
+/**
+ * Adding a mapping whose external id is already on the map.
+ *
+ * The button says "Add", but the endpoint behind it is a PUT, so an id that is
+ * already mapped was repointed on the first click with nothing said. Repointing
+ * is the edit with no visible consequence and a large invisible one: the series
+ * carries on publishing and its chapters start landing on a different title. A
+ * mistyped id could redirect a live series and look exactly like success.
+ */
+describe("adding a mapping that already exists asks first", () => {
+  const addForm = () => {
+    const id = doc.getElementById("tracked-manga-id");
+    return {
+      externalId: id,
+      mdId: doc.getElementById("tracked-md-id"),
+      namespace: doc.getElementById("tracked-namespace"),
+      add: buttonLabelled(id.closest("section.card"), "Add mapping"),
+    };
+  };
+
+  /** Only the writes; the view reloads the map with a GET on the same path. */
+  const puts = (): { path: string; method: string; body: any }[] =>
+    calls.filter((c) => c.method === "PUT" && c.path.includes("/tracked"));
+
+  const fill = (externalId: string, mdId: string, namespace = ""): any => {
+    const form = addForm();
+    form.externalId.value = externalId;
+    form.mdId.value = mdId;
+    form.namespace.value = namespace;
+    return form;
+  };
+
+  beforeEach(async () => {
+    calls = [];
+    scopes = ["*"];
+    mount();
+    await settle(10);
+    await goto("#/extensions/mangaplus/series-map");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  it("adds an id the map does not have without asking", async () => {
+    calls = [];
+    fill("100999", MD_C).add.click();
+    await settle();
+
+    expect(puts()).toHaveLength(1);
+    expect(puts()[0]?.body).toEqual({ mangaId: "100999", mdMangaId: MD_C });
+    expect(doc.getElementById("modal").hasAttribute("open")).toBe(false);
+  });
+
+  it("names the title an existing id is already mapped to, and holds the write", async () => {
+    calls = [];
+    fill("100001", MD_C).add.click();
+    await settle();
+
+    expect(puts()).toHaveLength(0);
+    const modal = doc.getElementById("modal");
+    expect(modal.textContent).toContain("already mapped");
+    // The id it currently points at is the fact the operator needs to see.
+    expect(modal.textContent).toContain(MD_A);
+    expect(modal.textContent).toContain(MD_C);
+  });
+
+  it("writes nothing when the repoint is declined", async () => {
+    calls = [];
+    fill("100001", MD_C).add.click();
+    await settle();
+    buttonLabelled(doc.getElementById("modal"), "Cancel").click();
+    await settle();
+
+    expect(puts()).toHaveLength(0);
+  });
+
+  it("repoints once confirmed", async () => {
+    calls = [];
+    fill("100001", MD_C).add.click();
+    await settle();
+    buttonLabelled(doc.getElementById("modal"), "Repoint it").click();
+    await settle();
+
+    expect(puts()).toHaveLength(1);
+    expect(puts()[0]?.body).toEqual({ mangaId: "100001", mdMangaId: MD_C });
+  });
+
+  it("treats the same id and the same title as nothing to do", async () => {
+    calls = [];
+    fill("100001", MD_A).add.click();
+    await settle();
+
+    // No dialog and no request: a write that changes nothing should not report
+    // success as though it had.
+    expect(puts()).toHaveLength(0);
+    expect(doc.getElementById("modal").hasAttribute("open")).toBe(false);
+  });
+
+  it("matches on the catalogue too, so the same id in another one is new", async () => {
+    calls = [];
+    // 709 is mapped in vizmanga; the same id in shonenjump is a different
+    // series and must not be mistaken for a repoint.
+    fill("709", MD_C, "shonenjump").add.click();
+    await settle();
+
+    expect(puts()).toHaveLength(1);
+    expect(puts()[0]?.body).toEqual({ mangaId: "709", mdMangaId: MD_C, namespace: "shonenjump" });
+  });
+
+  it("still catches the clash when the catalogue matches", async () => {
+    calls = [];
+    fill("709", MD_C, "vizmanga").add.click();
+    await settle();
+
+    expect(puts()).toHaveLength(0);
+    expect(doc.getElementById("modal").textContent).toContain("vizmanga");
+  });
+
+  it("tells an append-only credential to stop rather than offering the repoint", async () => {
+    scopes = ["tracked:append", "extensions:read", "tracked:read"];
+    mount();
+    await settle(10);
+    await goto("#/extensions/mangaplus/series-map");
+
+    calls = [];
+    fill("100001", MD_C).add.click();
+    await settle();
+
+    // No dialog: a confirmed repoint would only come back 403.
+    expect(doc.getElementById("modal").hasAttribute("open")).toBe(false);
+    expect(puts()).toHaveLength(0);
   });
 });

--- a/test/unit/mapSync.test.ts
+++ b/test/unit/mapSync.test.ts
@@ -6,7 +6,9 @@ import { parseMangaIdMapFile } from "../../src/core/store/bundles.js";
 import { isMapSyncPush, MAP_SYNC_COMMIT_MARKER } from "../../src/core/webhooks/github.js";
 import { encodeRepoPath, isSafeRepoPath, type GithubContentsClient } from "../../src/core/webhooks/repoContents.js";
 import {
+  DEFAULT_INDENT,
   DEFAULT_SHAPE,
+  detectLayout,
   detectMapShape,
   parseMapText,
   planWrite,
@@ -37,8 +39,10 @@ const row = (mangaId: string, mdMangaId: string, namespace = "") => ({ namespace
 describe("renderMapFile", () => {
   it("writes mangaplus's inverted shape, sorted and stable", () => {
     const text = renderMapFile([row("100002", MD_B), row("100001", MD_A), row("100003", MD_B)]);
+    // One line per mapping, four-space indent: the way the file is written by
+    // hand. Rendering each id on its own line turned 761 lines into 2565.
     expect(text).toBe(
-      `{\n  "${MD_A}": [\n    "100001"\n  ],\n  "${MD_B}": [\n    "100002",\n    "100003"\n  ]\n}\n`,
+      `{\n    "${MD_A}": ["100001"],\n    "${MD_B}": ["100002", "100003"]\n}\n`,
     );
     // Same rows in any order render byte-identically, which is what stops a
     // weekly no-op run from producing a commit.
@@ -48,7 +52,42 @@ describe("renderMapFile", () => {
   it("keeps alpha_manga's forward shape when that is what the file uses", () => {
     const text = renderMapFile([row("9", MD_B), row("10", MD_A)], { nested: false, inner: "forward" });
     // Numeric-aware ordering: 9 before 10, not after it.
-    expect(text).toBe(`{\n  "9": "${MD_B}",\n  "10": "${MD_A}"\n}\n`);
+    expect(text).toBe(`{\n    "9": "${MD_B}",\n    "10": "${MD_A}"\n}\n`);
+  });
+
+  it("writes an array on one line however many ids it holds", () => {
+    const rows = ["100003", "100120", "100141", "200020", "600002", "700006"].map((id) => row(id, MD_A));
+    const text = renderMapFile(rows);
+    expect(text).toBe(
+      `{\n    "${MD_A}": ["100003", "100120", "100141", "200020", "600002", "700006"]\n}\n`,
+    );
+    // Three lines per mapping is what the bad render produced; one is the point.
+    expect(text.split("\n")).toHaveLength(4);
+  });
+
+  it("indents to the width the file already uses", () => {
+    const rows = [row("1", MD_A)];
+    expect(renderMapFile(rows, { nested: false, inner: "forward", indent: 2 })).toBe(
+      `{\n  "1": "${MD_A}"\n}\n`,
+    );
+    expect(renderMapFile(rows, { nested: false, inner: "forward", indent: 4 })).toBe(
+      `{\n    "1": "${MD_A}"\n}\n`,
+    );
+  });
+
+  it("keeps alpha_manga's right-aligned keys when the file aligns them", () => {
+    const text = renderMapFile(
+      [row("6000597", MD_A), row("10000372", MD_B)],
+      { nested: false, inner: "forward", indent: 2, align: true },
+    );
+    // Every key ends in the same column; the shorter one is padded, not the
+    // longer one truncated.
+    expect(text).toBe(`{\n   "6000597": "${MD_A}",\n  "10000372": "${MD_B}"\n}\n`);
+  });
+
+  it("nests with the file's indent, and says an empty namespace on one line", () => {
+    const text = renderMapFile([row("709", MD_A, "vizmanga")], { nested: true, inner: "forward", indent: 4 });
+    expect(text).toBe(`{\n    "vizmanga": {\n        "709": "${MD_A}"\n    }\n}\n`);
   });
 
   it("nests a namespaced extension even when asked for a flat shape", () => {
@@ -84,6 +123,65 @@ describe("detectMapShape", () => {
     expect(detectMapShape([])).toBeNull();
     expect(detectMapShape({})).toBeNull();
     expect(parseMapText("not json").shape).toBeNull();
+  });
+});
+
+/**
+ * The layout is read from the text because `JSON.parse` has already lost it,
+ * and getting it wrong is what turns a seven-mapping change into a diff that
+ * replaces every line of the file.
+ */
+describe("detectLayout", () => {
+  it("reads mangaplus: four spaces, keys not aligned", () => {
+    const text = `{\n    "${MD_A}": ["100001"],\n    "${MD_B}": ["100002"]\n}\n`;
+    expect(detectLayout(text, false)).toEqual({ indent: 4, align: false });
+  });
+
+  it("reads alpha_manga: keys right-aligned to a common column", () => {
+    const text = `{\n   "6000597": "${MD_A}",\n  "10000372": "${MD_B}"\n}\n`;
+    expect(detectLayout(text, false)).toEqual({ indent: 2, align: true });
+  });
+
+  it("reads viz: one level is four spaces even though the entries sit at eight", () => {
+    const text = `{\n    "vizmanga": {\n        "709": "${MD_A}"\n    }\n}\n`;
+    expect(detectLayout(text, true)).toEqual({ indent: 4, align: false });
+  });
+
+  it("does not call a nested file aligned, whatever its columns happen to do", () => {
+    // The leading runs differ here only because of nesting, which is not
+    // alignment; reading it as alignment would pad every key in the file.
+    const text = `{\n    "ns": {\n        "70": "${MD_A}"\n    }\n}\n`;
+    expect(detectLayout(text, true).align).toBe(false);
+  });
+
+  it("falls back to the default for a file with no key lines to learn from", () => {
+    expect(detectLayout("{}\n", false)).toEqual({ indent: DEFAULT_INDENT, align: false });
+  });
+
+  it("carries the layout onto the shape parseMapText returns", () => {
+    const text = `{\n  "1": "${MD_A}",\n  "2": "${MD_B}"\n}\n`;
+    expect(parseMapText(text).shape).toEqual({
+      nested: false,
+      inner: "forward",
+      indent: 2,
+      align: false,
+    });
+  });
+
+  /**
+   * The property that matters most: a file the sync has no change to make to
+   * comes back byte-identical, so the run makes no commit at all. This is what
+   * the old renderer broke, and a round trip is the only honest way to state it.
+   */
+  it("round-trips a file it has nothing to change byte for byte", () => {
+    for (const original of [
+      `{\n    "${MD_A}": ["100001", "200008"],\n    "${MD_B}": ["100002"]\n}\n`,
+      `{\n   "6000597": "${MD_A}",\n  "10000372": "${MD_B}"\n}\n`,
+      `{\n    "vizmanga": {\n        "218": "${MD_A}",\n        "709": "${MD_B}"\n    }\n}\n`,
+    ]) {
+      const { rows, shape } = parseMapText(original);
+      expect(renderMapFile(rows, shape!)).toBe(original);
+    }
   });
 });
 


### PR DESCRIPTION
Three changes to the series-map sync, found while working out why the weekly GitHub push looked broken. It was not — it runs every 168h and last committed on 2026-08-13 — but two real problems turned up alongside it.

## 1. A dashboard control for the run

`POST /api/v1/admin/maps/sync` and `padmin maps sync` both existed from the day the timer was written, but nothing on the dashboard called either. With a seven-day cadence, an operator who repointed a series and then checked the extensions repo had no way to tell a slow job from a broken one, and no way to settle it without a shell.

Adds a **Publish to GitHub** card on **Tracked** (every extension, like the timer) and on **Extensions → *name* → Series map** (that one only). No server change — it calls the endpoint that was already there.

Preview-then-commit, because this writes to somebody's repository unattended: the preview names each file, its repo and the exact delta. Per-extension status rather than one verdict — `unchanged`, `skipped` and `refused` all return `failed: 0` and mean very different things. Gated on `tracked:write`.

## 2. The renderer stops reformatting the files

The renderer was `JSON.stringify(document, null, 2)`: every array element on its own line, and an indent none of the three maps use. The first sync rewrote mangaplus **from 761 lines to 2565** — a commit whose subject said `+7 -1` and whose diff was the whole file.

Replaced with a serialiser that keeps arrays on one line, takes the indent from the file it is rewriting, and preserves key alignment where the file has it. Verified against the three real hand-authored maps:

| file | before | after |
| --- | --- | --- |
| alpha_manga | reformatted | **byte-identical round trip**, right-alignment and all |
| mangaplus | 2565 lines | 764 lines |
| viz | reformatted | same length, 4-space nesting kept |

Still deterministic, so a week with nothing to say still makes no commit.

**Follow-up needed:** the layout is read from what is in the repo *now*, which is the old renderer's output. Restoring the three map files to their pre-sync content is what gets the original four-space formatting back permanently. The mappings are in `tracked_manga`, so nothing is lost by doing it.

## 3. "Add mapping" no longer silently repoints

The button says Add; the endpoint is a PUT. An external id already on the map was repointed on the first click with nothing said — the one edit on that page with no visible consequence and a large invisible one, since the series keeps publishing and its chapters start landing on a different title.

The map is already in hand for the search and export on the same card, so the collision is caught before the request. New id: unchanged, one click. Already mapped: names the title it points at now and asks. Same id, same title: reported as nothing to do. Append-only credential: told to stop rather than offered a repoint that would 403. The catalogue is part of the comparison, so `709` in shonenjump is not mistaken for `709` in vizmanga.

## Verification

- **772 tests pass** (45 files), up from 745/44 on master — 27 new across `test/unit/mapSync.test.ts` and `test/unit/dashboardMapSync.test.ts`.
- `pnpm lint` and `pnpm typecheck` clean.

Note: the dashboard is copied at build time (`pnpm run copy:dashboard`), so this needs a core-api rebuild to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)