### PR TITLE
Re-post unavailable card images from the dashboard

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -602,6 +602,31 @@ Two refusals are worth knowing about:
   owner-equivalent", not "vetted human". The break-glass `ADMIN_TOKEN` is a
   `root` principal and still works.
 
+Re-posting the card image on chapters that already carry one is its own route,
+not a fourth flag on the bulk ones:
+
+| Method | Path | Scope | Notes |
+| --- | --- | --- | --- |
+| `POST` | `/chapters/unavailable/recard` | `chapters:write` + ADMIN | `{ids?, filter?, footerNote?, dryRun?, confirm?, afterId?, batch?}`. Always the `unavailable` archive and always forced. A chapter with no card refuses as `not_unavailable` rather than being carded for the first time |
+
+It exists because the bulk route gets two things wrong for a re-render:
+
+- **The date.** `/chapters/bulk/unavailable` stamps every card with `new Date()`,
+  which is right for a chapter going unavailable now and wrong for one that went
+  unavailable in March; through it, re-rendering a year-old page rewrites its
+  "available until" line. Here `unavailableAt` comes from the archive row.
+- **Termination.** The bulk cap is 200 with no continuation, ordered on
+  `unavailable_at DESC` — the column the uploader rewrites as it archives. "Re-card
+  everything" through it re-cards the newest 200 for ever. This pages on the
+  primary key and answers `nextAfterId`; the caller repeats with it until it is
+  null, which is exactly what the dashboard panel does.
+
+`filter: {}` means every unavailable chapter; the filter is required-but-emptiable
+so that "re-card everything" has to be typed rather than fallen into. Everything
+else matches the bulk contract: `ids` XOR `filter`, `dryRun` defaulting to true, a
+live run needing `dryRun: false` **and** `confirm: true`, one audit row per chapter
+(`chapter.unavailable.recard`) plus a `chapter.unavailable.recard.sweep` summary.
+
 `routes/chapters.ts`, `store/chapters.ts`, tested at
 `test/integration/chapters.test.ts`.
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -166,7 +166,8 @@ the header opens it, a tap outside or Escape closes it, and while closed it is
 `inert` so Tab cannot walk into it.
 
 **Tabs inside a page** are that page's own sections; Overview's Platform and
-MangaDex, System's Schema / MangaDex / Backup, one extension's Overview / Series
+MangaDex, System's Schema / MangaDex / Unavailable cards / Backup, one extension's
+Overview / Series
 map / Schedule / Config / Versions. They are a tablist: arrow keys, Home and End
 move between them.
 
@@ -192,6 +193,7 @@ Routing is hash-based, `#/<destination>[/<thing>][/<tab>]`:
 #/extensions/mangaplus/series-map        one extension, one of its tabs
 #/untracked/<id>                         one untracked series, editable
 #/audit/<id>                             one audit event
+#/system/cards                            re-post the card image on unavailable chapters
 #/system/backup
 ```
 
@@ -224,7 +226,7 @@ leak an id into an access log.
 | **Users** | OWNER | *Accounts*: invite, approve, change role, set a password, delete. *Sessions*: who is signed in, with revoke. *Signups*: the self-signup gate. |
 | **Tokens** | OWNER | *Issued*: every `pa_…` client credential with its scopes, creator, last use and expiry, with revoke. *Mint*: scopes grouped by area, with the shipped presets. |
 | **Audit** | `audit:read` | Who did what, searchable by actor, action, subject, free text and date range; and one event at a time by id. |
-| **System** | `settings:read` | *Schema*: is this database the schema this build expects. *MangaDex*: the saved session. *Backup*: a `pg_dump` download (OWNER only). |
+| **System** | `settings:read` (acting needs `chapters:write` + ADMIN) | *Schema*: is this database the schema this build expects. *MangaDex*: the saved session. *Unavailable cards*: re-render and re-post the card image on chapters already marked unavailable — every one of them, a set ticked out of the archive, or a single chapter id, previewed first. *Backup*: a `pg_dump` download (OWNER only). |
 | **Maintenance** | `bundles:read` | Compare each live bundle against its GitHub branch, install a bundle, restart a service. Lives in `dashboard/sysops.js`. |
 | **Docs** | `stats:read` | The operator handbook that ships with this build, rendered in the page. Lives in `dashboard/docs.js`. |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1223,6 +1223,49 @@ curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: applic
   "$API/api/v1/admin/chapters/$MD_CHAPTER_ID/unavailable"
 ```
 
+### Re-post the cards already on MangaDex
+
+A card is rendered at the moment it is posted, so every card in the catalogue is
+a fossil of the build that put it there. When the renderer changes — a font that
+was missing, wording that was wrong, a layout that clipped long titles — the only
+fix for the pages already up is to render them again and post them over the top.
+
+**Dashboard → System → Unavailable cards.** Three targets, because the three
+occasions differ: one chapter somebody complained about, a set ticked out of the
+archive, or every card on the site after a renderer fix. Preview first; the
+preview resolves the same rows and checks the same refusals as the live run.
+
+By hand it is one route, always forced, always the `unavailable` archive:
+
+```bash
+# every unavailable chapter, previewed
+curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"filter":{}}' "$API/api/v1/admin/chapters/unavailable/recard"
+
+# and live, one page at a time
+curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"filter":{},"dryRun":false,"confirm":true}' \
+  "$API/api/v1/admin/chapters/unavailable/recard"
+```
+
+The response carries `nextAfterId`; repeat with `{"afterId":"<that>"}` until it
+comes back `null`. The dashboard does that loop for you and reports the running
+count as it goes.
+
+Two things this route does that `/chapters/bulk/unavailable` does not, and the
+reason it is a separate route rather than another flag:
+
+- **The card keeps the date the chapter went unavailable.** The bulk route stamps
+  `new Date()`, which is right for a chapter going unavailable now and wrong for
+  one pulled in March; through it, re-rendering a year-old page rewrites its
+  "available until" line.
+- **A whole-archive sweep terminates.** The uploader rewrites `unavailable_at` as
+  it archives, so paging on that column re-reads the rows it just processed for
+  ever. This pages on the primary key instead.
+
+Chapters that have never been carded refuse as `not_unavailable`: this re-posts,
+it never cards a chapter for the first time. Use the section above for that.
+
 ### Delete it
 
 The one irreversible action. `confirm: true` is required, the reason goes into

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -1092,6 +1092,7 @@ const NAV = [
     tabs: [
       ["schema", "Schema"],
       ["mangadex", "MangaDex"],
+      ["cards", "Unavailable cards"],
       ["backup", "Backup"],
     ],
     blurb: "The things that used to need a shell on the host.",
@@ -8352,6 +8353,7 @@ function auditDetail(id) {
 
 VIEWS.system = (route) => {
   if (route.tab === "mangadex") return mangadexPanel();
+  if (route.tab === "cards") return unavailableCardsPanel();
   if (route.tab === "backup") return backupPanel();
 
   /*
@@ -8416,6 +8418,504 @@ VIEWS.system = (route) => {
     ),
   );
 };
+
+/**
+ * Re-post the card image on chapters that are already marked unavailable.
+ *
+ * The card is rendered at the moment the uploader runs, from that chapter's
+ * own details and this build's fonts and layout. So every card on MangaDex is
+ * a fossil of the build that posted it, and when the renderer changes — a font
+ * that was missing, wording that was wrong, a layout that clipped long titles —
+ * the only fix for the pages already up is to render them again and post them
+ * over the top. That is the whole job of this panel.
+ *
+ * Three targets, because the three occasions are genuinely different: one
+ * chapter somebody complained about, a handful an operator picked out of the
+ * archive, or every card on the site after a renderer fix. The first two are
+ * one request; the last pages through the archive on the primary key until the
+ * server stops returning a continuation, so it terminates and reports as it
+ * goes rather than timing out behind a spinner.
+ */
+function unavailableCardsPanel() {
+  const target = { mode: "all", id: "", running: false, cancel: false };
+  const selected = new Set();
+  const filters = { extension: "", language: "", search: "" };
+  const cursors = [];
+
+  const extensions = new Resource("recard-extensions", () =>
+    api("/chapters/extensions?archive=unavailable"),
+  );
+  const listing = new Resource("recard-listing", () => {
+    const q = new URLSearchParams({ archive: "unavailable", limit: "50" });
+    if (filters.extension) q.set("extension", filters.extension);
+    if (filters.language) q.set("language", filters.language);
+    if (filters.search) q.set("search", filters.search);
+    if (cursors.length) q.set("cursor", cursors[cursors.length - 1]);
+    return api(`/chapters?${q}`);
+  });
+
+  const note = el("textarea", {
+    id: "recard-note",
+    rows: "2",
+    maxlength: "600",
+    placeholder: "Leave blank for the standard wording.",
+  });
+  const progress = el("div", { class: "dim small" });
+  const preview = el("div", {});
+  const modes = el("div", {});
+  const buttons = el("div", { class: "row" });
+
+  /** The request body for the current target, or null when it is not answerable. */
+  const bodyFor = () => {
+    if (target.mode === "one") {
+      const id = target.id.trim();
+      return id ? { ids: [id] } : null;
+    }
+    if (target.mode === "selected") {
+      return selected.size ? { ids: [...selected] } : null;
+    }
+    const filter = {};
+    if (filters.extension) filter.extension = filters.extension;
+    if (filters.language) filter.language = filters.language;
+    if (filters.search) filter.search = filters.search;
+    return { filter };
+  };
+
+  const footerNote = () => {
+    const text = note.value.trim();
+    return text ? { footerNote: text } : {};
+  };
+
+  const call = (extra) =>
+    api("/chapters/unavailable/recard", {
+      method: "POST",
+      body: { ...bodyFor(), ...footerNote(), ...extra },
+    });
+
+  const say = (text, bad = false) => {
+    progress.className = bad ? "error" : "dim small";
+    progress.textContent = text;
+  };
+
+  const runPreview = async (button) => {
+    if (!bodyFor()) {
+      say("Nothing is targeted yet.", true);
+      return;
+    }
+    const result = await act("chapters.recard.preview", () => call({ dryRun: true }), { button });
+    if (!result) return;
+    setChildren(preview, recardPreview(result, target.mode));
+    say(
+      target.mode === "all"
+        ? `${result.matched} unavailable chapter(s) match; this sweep would queue ${result.wouldQueue} ` +
+            `in the first pass of ${result.resolved}` +
+            (result.nextAfterId ? ", and keep going until the archive is exhausted." : ".")
+        : `${result.wouldQueue} of ${result.resolved} chapter(s) would be queued.`,
+    );
+  };
+
+  /**
+   * The live run. For a picked set that is one request; for the whole archive
+   * it is a request per page, continued by `nextAfterId`.
+   *
+   * The loop is here rather than on the server because a sweep over thousands
+   * of chapters is minutes of database writes, and an HTTP request that long is
+   * a request that dies to a proxy timeout having queued an amount nobody can
+   * name. Paging makes every page an answered request, and the count below is
+   * true at every moment rather than only at the end.
+   */
+  const runApply = async () => {
+    const body = bodyFor();
+    if (!body) {
+      say("Nothing is targeted yet.", true);
+      return;
+    }
+    const mode = target.mode;
+    const scope =
+      mode === "all"
+        ? "every unavailable chapter matching the filter"
+        : `${body.ids.length} chapter(s)`;
+    if (
+      !(await confirmDialog({
+        title: "Re-post these card images",
+        lead: `A fresh card will be rendered and posted over the current page of ${scope}.`,
+        points: [
+          "Each chapter keeps its place, its metadata and its date; only the page image changes.",
+          "One upload task per chapter, drained by core-uploader at MangaDex's pace.",
+          "Chapters that have never been carded are skipped, not carded for the first time.",
+        ],
+        confirmLabel: "Queue the re-cards",
+        danger: false,
+      }))
+    ) {
+      return;
+    }
+
+    // Snapshotted, not re-read per page: the sweep outlives the form, and a
+    // continuation sent against a target the operator changed halfway through
+    // is a request that means nothing.
+    const request = { ...body, ...footerNote(), dryRun: false, confirm: true };
+
+    target.running = true;
+    target.cancel = false;
+    redraw();
+    let queued = 0;
+    let refused = 0;
+    let afterId = null;
+    try {
+      for (;;) {
+        const result = await api("/chapters/unavailable/recard", {
+          method: "POST",
+          body: { ...request, ...(afterId ? { afterId } : {}) },
+        });
+        queued += result.queued ?? 0;
+        refused += result.refused ?? 0;
+        setChildren(preview, recardPreview(result, mode));
+        afterId = result.nextAfterId ?? null;
+        say(
+          `${queued} queued, ${refused} skipped` +
+            (afterId ? ` — still sweeping (${result.matched} match in total)…` : " — done."),
+        );
+        if (!afterId || target.cancel) break;
+      }
+      toast(
+        `${queued} chapter(s) queued for a fresh card` + (refused ? `, ${refused} skipped` : ""),
+        refused === 0,
+      );
+      if (target.cancel) say(`Stopped after ${queued} queued; the rest were left alone.`);
+    } catch (err) {
+      say(`Stopped after ${queued} queued: ${err.message}`, true);
+    } finally {
+      target.running = false;
+      selected.clear();
+      redraw();
+    }
+    if (mode === "selected") void listing.load({ force: true });
+  };
+
+  /** The picker, only mounted for the two targets that name chapters. */
+  const picker = () =>
+    target.mode === "selected"
+      ? live(
+          [listing],
+          (data) => {
+            const rows = data.chapters ?? [];
+            const present = new Set(rows.map((entry) => entry.mdChapterId));
+            for (const id of [...selected]) if (!present.has(id)) selected.delete(id);
+            return el(
+              "div",
+              {},
+              el("div", { class: "row" }, [
+                el("span", {
+                  class: "dim small",
+                  text: `${selected.size} selected · ${rows.length} shown of ${data.total ?? 0}`,
+                }),
+                el("span", { class: "grow" }),
+                el("button", {
+                  type: "button",
+                  text: rows.length && selected.size === rows.length ? "Select none" : "Select all on this page",
+                  disabled: rows.length === 0,
+                  onclick: () => {
+                    if (selected.size === rows.length) selected.clear();
+                    else for (const entry of rows) selected.add(entry.mdChapterId);
+                    void listing.load({ force: true });
+                  },
+                }),
+              ]),
+              table(
+                ["", "Series", "Chapter", "Language", "Extension", "Marked unavailable"],
+                rows.map((entry) => [
+                  el("input", {
+                    type: "checkbox",
+                    checked: selected.has(entry.mdChapterId),
+                    "aria-label": `Select ${entry.mangaName ?? entry.mdChapterId} ${chapterLabel(entry)}`,
+                    onchange: (event) => {
+                      if (event.target.checked) selected.add(entry.mdChapterId);
+                      else selected.delete(entry.mdChapterId);
+                      redrawButtons();
+                    },
+                  }),
+                  routeLink(routeTo("chapters", entry.mdChapterId, null), truncate(entry.mangaName || "-", 40)),
+                  chapterLabel(entry),
+                  entry.chapterLanguage || "-",
+                  entry.extension || "-",
+                  fmtTime(entry.at),
+                ]),
+                { empty: "No chapter in the unavailable archive matches this filter." },
+              ),
+              chapterPager(data, cursors, (walked) => {
+                cursors.length = 0;
+                cursors.push(...walked);
+                selected.clear();
+                void listing.load({ force: true });
+              }),
+            );
+          },
+          { reserve: 300, skeleton: () => skeletonTable(6, 6) },
+        )
+      : el("span", {});
+
+  const filterRow = () =>
+    row(
+      live(
+        [extensions],
+        (data) =>
+          el(
+            "span",
+            { class: "row tight" },
+            el("label", { class: "inline", for: "recard-extension", text: "Extension" }),
+            el(
+              "select",
+              {
+                id: "recard-extension",
+                onchange: (event) => {
+                  filters.extension = event.target.value;
+                  cursors.length = 0;
+                  selected.clear();
+                  void listing.load({ force: true });
+                  redraw();
+                },
+              },
+              el("option", { value: "", text: "all", selected: filters.extension === "" }),
+              (data.extensions ?? []).map((entry) =>
+                el("option", {
+                  value: entry.extension,
+                  text: `${entry.extension || "(unattributed)"} · ${entry.count}`,
+                  selected: entry.extension === filters.extension,
+                }),
+              ),
+            ),
+          ),
+        { reserve: 32, skeleton: () => el("span", { class: "dim small", text: "extensions…" }) },
+      ),
+      el("span", { class: "row tight" }, [
+        el("label", { class: "inline", for: "recard-search", text: "Search" }),
+        el("input", {
+          id: "recard-search",
+          type: "text",
+          value: filters.search,
+          placeholder: "title, name, or any id",
+          onchange: (event) => {
+            filters.search = event.target.value;
+            cursors.length = 0;
+            selected.clear();
+            void listing.load({ force: true });
+            redraw();
+          },
+        }),
+      ]),
+      el("span", { class: "row tight" }, [
+        el("label", { class: "inline", for: "recard-language", text: "Language" }),
+        el("input", {
+          id: "recard-language",
+          type: "text",
+          value: filters.language,
+          placeholder: "e.g. en",
+          onchange: (event) => {
+            filters.language = event.target.value;
+            cursors.length = 0;
+            selected.clear();
+            void listing.load({ force: true });
+            redraw();
+          },
+        }),
+      ]),
+    );
+
+  const modeRadio = (mode, label, hint) =>
+    el(
+      "label",
+      { class: "inline", for: `recard-mode-${mode}` },
+      el("input", {
+        id: `recard-mode-${mode}`,
+        type: "radio",
+        name: "recard-mode",
+        checked: target.mode === mode,
+        disabled: target.running,
+        onchange: (event) => {
+          if (!event.target.checked) return;
+          target.mode = mode;
+          cardImage.hidden = true;
+          setChildren(preview);
+          say("");
+          redraw();
+          if (mode === "selected") void listing.load();
+        },
+      }),
+      ` ${label}`,
+      el("span", { class: "dim small", text: ` — ${hint}` }),
+    );
+
+  /**
+   * The card image itself, kept as one element rather than rebuilt.
+   *
+   * Rendering it is a server-side render of a real PNG, so it is asked for when
+   * the operator asks — the same "Refresh the preview" button the single-chapter
+   * dialog has — and not once per keystroke in the id box.
+   */
+  const cardImage = el("img", {
+    class: "card-preview",
+    alt: "The card that would be posted as this chapter's only page",
+    hidden: true,
+  });
+
+  const showCard = () => {
+    const id = target.id.trim();
+    cardImage.hidden = !id;
+    if (id) cardImage.src = previewSrc(id, note.value.trim());
+  };
+
+  const oneChapterField = () =>
+    target.mode === "one"
+      ? el(
+          "div",
+          {},
+          el("label", { for: "recard-chapter-id", text: "MangaDex chapter id" }),
+          el("input", {
+            id: "recard-chapter-id",
+            type: "text",
+            value: target.id,
+            placeholder: "paste it from the chapter URL",
+            oninput: (event) => {
+              target.id = event.target.value;
+              redrawButtons();
+            },
+          }),
+          row(
+            el("button", {
+              type: "button",
+              text: "Refresh the preview",
+              onclick: showCard,
+            }),
+            el("span", {
+              class: "dim small",
+              text: "Renders the exact image this would post, footer note included.",
+            }),
+          ),
+          cardImage,
+        )
+      : el("span", {});
+
+  const redrawButtons = () => {
+    const ready = Boolean(bodyFor()) && !target.running;
+    setChildren(
+      buttons,
+      gatedButton("chapters:read", {
+        text: "Preview",
+        disabled: !ready,
+        title: ready ? "Resolve the target and report what would be queued" : "Nothing is targeted yet",
+        onclick: (event) => runPreview(event.currentTarget),
+      }),
+      gatedButton("chapters:write", {
+        class: "primary",
+        text: target.mode === "all" ? "Re-post every card…" : "Re-post these cards…",
+        disabled: !ready,
+        onclick: () => runApply(),
+      }),
+      target.running
+        ? el("button", {
+            type: "button",
+            text: "Stop after this page",
+            onclick: () => {
+              target.cancel = true;
+              say("Stopping after the page in flight…");
+            },
+          })
+        : null,
+    );
+  };
+
+  const redraw = () => {
+    setChildren(
+      modes,
+      oneChapterField(),
+      target.mode === "one" ? el("span", {}) : filterRow(),
+      picker(),
+    );
+    redrawButtons();
+  };
+
+  redraw();
+
+  return el(
+    "div",
+    {},
+    card(
+      "Re-post unavailable card images",
+      el("p", {
+        class: "dim small",
+        text:
+          "A card is rendered when it is posted, so every card on MangaDex is a fossil of the build " +
+          "that put it there. After a fix to the renderer — a missing font, wrong wording, a clipped " +
+          "title — this is what brings the pages already up in line with it.",
+      }),
+      el("p", {
+        class: "dim small",
+        text:
+          "Each chapter keeps its place, its metadata and the date it went unavailable; the fresh card " +
+          "carries that original date rather than today's. Only chapters already in the unavailable " +
+          "archive are touched: this never cards a chapter for the first time.",
+      }),
+      el(
+        "div",
+        { class: "row" },
+        modeRadio("all", "Every unavailable chapter", "optionally narrowed by the filter below"),
+        modeRadio("selected", "Pick from the archive", "tick the ones to re-post"),
+        modeRadio("one", "One chapter", "by MangaDex chapter id"),
+      ),
+      modes,
+      el("label", { for: "recard-note", text: "Footer note" }),
+      note,
+      el("p", {
+        class: "dim small",
+        text: "Replaces the standard explanatory paragraph on every card this queues.",
+      }),
+      buttons,
+      progress,
+      preview,
+    ),
+  );
+}
+
+/** What one page of a re-card resolved to, previewed or already queued. */
+function recardPreview(result, mode) {
+  const blocked = (result.results ?? []).filter((item) => !item.ok);
+  return el(
+    "div",
+    {},
+    el("h3", { text: result.dryRun ? "Preview" : "Queued" }),
+    defs([
+      ["Unavailable chapters matching", String(result.matched ?? 0)],
+      ["This page", String(result.resolved ?? result.requested ?? 0)],
+      [result.dryRun ? "Would be queued" : "Queued", String(result.wouldQueue ?? result.queued ?? 0)],
+      ["Skipped", String(blocked.length)],
+    ]),
+    result.nextAfterId
+      ? el("p", {
+          class: "dim small",
+          text:
+            mode === "all"
+              ? "More chapters remain after this page; the sweep continues automatically until none do."
+              : "More chapters remain after this page.",
+        })
+      : null,
+    table(
+      ["Series", "Chapter", "Unavailable since", result.dryRun ? "Would happen" : "Outcome"],
+      (result.results ?? []).slice(0, 100).map((item) => [
+        truncate(item.mangaName || item.mdChapterId, 40),
+        item.chapterNumber ? `Ch. ${item.chapterNumber}` : "-",
+        item.unavailableAt ? fmtTime(item.unavailableAt) : "-",
+        item.ok
+          ? chip(result.dryRun ? "queued" : item.outcome)
+          : el("span", { class: "dim small", text: item.reason ?? item.outcome }),
+      ]),
+      { empty: "Nothing in the unavailable archive matched." },
+    ),
+    (result.results ?? []).length > 100
+      ? el("p", { class: "dim small", text: `…and ${result.results.length - 100} more.` })
+      : null,
+  );
+}
 
 function backupPanel() {
   // The dump contains every password hash and the saved MangaDex session, so the

--- a/src/core/api/routes/chapters.ts
+++ b/src/core/api/routes/chapters.ts
@@ -1368,6 +1368,330 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
       },
     );
 
+    // ------------------------------------------------- re-card the unavailable
+
+    /**
+     * Re-render the card image on chapters that ALREADY carry one.
+     *
+     * Marking a chapter unavailable and re-carding it queue the same
+     * UNAVAILABLE task, but they are different operator verbs and reading them
+     * as one produced two wrong answers:
+     *
+     *  - `POST /chapters/bulk/unavailable` stamps every card with `new Date()`,
+     *    which is correct when the chapter is going unavailable now and wrong
+     *    when it went unavailable in March; a re-card through it would silently
+     *    rewrite the "available until" line on a year-old page. Here the date
+     *    comes from the archive row, so the card still says when the publisher
+     *    actually pulled the chapter.
+     *  - the bulk cap is 200 with no continuation, and its ordering is
+     *    `unavailable_at DESC` — the very column the uploader rewrites as it
+     *    archives. "Re-card everything" through it re-cards the newest 200 for
+     *    ever and never reaches the rest. This pages on the primary key and
+     *    returns `nextAfterId`, so a sweep terminates.
+     *
+     * Otherwise it is the bulk contract: `ids` XOR `filter`, dry run by default,
+     * a live run needs `dryRun: false` and `confirm: true`, one guarded upsert
+     * per chapter, one audit row per chapter plus a summary.
+     *
+     * `filter: {}` means every unavailable chapter, which is the point of the
+     * endpoint and is why the filter is required-but-emptiable rather than
+     * defaulted: "re-card everything" has to be typed, not fallen into.
+     */
+    const RECARD_BATCH_CAP = 200;
+
+    const RecardFilter = z
+      .object({
+        extension: z.string().max(64).optional(),
+        language: z.string().max(16).optional(),
+        mdMangaId: z.string().max(64).optional(),
+        chapterNumber: z.string().max(32).optional(),
+        search: z.string().min(1).max(256).optional(),
+        since: z.coerce.date().optional(),
+        until: z.coerce.date().optional(),
+      })
+      .strict();
+
+    interface RecardItem {
+      mdChapterId: string;
+      ok: boolean;
+      outcome:
+        | "queued"
+        | "requeued"
+        | "would_queue"
+        | "already_queued"
+        | "leased"
+        | "not_found"
+        | "deleted"
+        | "not_unavailable"
+        | "invalid";
+      taskId?: string;
+      reason?: string;
+      mangaName?: string | null;
+      chapterNumber?: string | null;
+      chapterLanguage?: string | null;
+      extension?: string | null;
+      /** When the chapter was archived; the date its fresh card will carry. */
+      unavailableAt?: string;
+    }
+
+    scope.post(
+      "/api/v1/admin/chapters/unavailable/recard",
+      { preHandler: [requireScope("chapters:write"), requireAdminRole] },
+      async (req, reply) => {
+        const body = parseOrThrow(
+          z
+            .object({
+              ids: z.array(MdChapterId).min(1).max(RECARD_BATCH_CAP).optional(),
+              filter: RecardFilter.optional(),
+              footerNote: z.string().max(600).optional(),
+              dryRun: z.boolean().default(true),
+              confirm: z.boolean().default(false),
+              /** Continuation from a previous page's `nextAfterId`. */
+              afterId: z.string().max(64).optional(),
+              batch: z.number().int().min(1).max(RECARD_BATCH_CAP).default(RECARD_BATCH_CAP),
+            })
+            .strict()
+            .refine((value) => (value.ids ? 1 : 0) + (value.filter ? 1 : 0) === 1, {
+              message:
+                "provide exactly one of `ids` or `filter` (`filter: {}` means every unavailable chapter)",
+            })
+            .refine((value) => !(value.ids && value.afterId), {
+              message: "`afterId` continues a filter sweep; an explicit `ids` list has nothing to continue",
+            }),
+          req.body ?? {},
+        );
+
+        const filter: ChapterFilter | null = body.filter
+          ? {
+              extension: body.filter.extension,
+              chapterLanguage: body.filter.language,
+              mdMangaId: body.filter.mdMangaId,
+              chapterNumber: body.filter.chapterNumber,
+              search: body.filter.search,
+              since: body.filter.since,
+              until: body.filter.until,
+            }
+          : null;
+
+        let ids: string[];
+        let nextAfterId: string | null = null;
+        let matched: number;
+        if (body.ids) {
+          ids = [...new Set(body.ids)];
+          matched = ids.length;
+        } else {
+          const page = await ctx.chapters.idsForSweep(
+            "unavailable",
+            filter!,
+            body.batch,
+            body.afterId ?? null,
+          );
+          ids = page.ids;
+          nextAfterId = page.nextAfterId;
+          matched = await ctx.chapters.countMatching("unavailable", filter!);
+        }
+
+        // The unavailable archive answers "does this chapter have a card to
+        // replace?"; `locateMany` answers "is it recorded as deleted?", which is
+        // the one state where re-carding is meaningless.
+        const [located, unavailableRows, queued] = await Promise.all([
+          locateMany(ids),
+          ctx.chapters.manyByIds("unavailable", ids),
+          ctx.uploadTasks.forDedupeKeys(ids),
+        ]);
+        const archived = new Map(unavailableRows.map((row) => [row.mdChapterId, row]));
+        const taskByChapter = new Map(
+          queued.filter((task) => task.kind === "UNAVAILABLE").map((task) => [task.dedupeKey, task]),
+        );
+
+        const blockedReason = (id: string): { outcome: RecardItem["outcome"]; reason: string } | null => {
+          const hit = located.get(id);
+          if (!hit) return { outcome: "not_found", reason: "no chapter with that MangaDex id" };
+          if (hit.archive === "deleted") return { outcome: "deleted", reason: DELETED_REASON };
+          if (!archived.has(id)) {
+            return {
+              outcome: "not_unavailable",
+              reason:
+                "this chapter has no card to replace; use Mark unavailable, which posts the first one",
+            };
+          }
+          const task = taskByChapter.get(id);
+          if (task?.state === "LEASED") {
+            return {
+              outcome: "leased",
+              reason: "an uploader is executing an UNAVAILABLE for this chapter now",
+            };
+          }
+          if (task?.state === "PENDING") {
+            return {
+              outcome: "already_queued",
+              reason: "an UNAVAILABLE for this chapter is already queued",
+            };
+          }
+          return null;
+        };
+
+        const describe = (id: string): Partial<RecardItem> => {
+          const row = archived.get(id) ?? located.get(id)?.row;
+          return row
+            ? {
+                mangaName: row.mangaName ?? null,
+                chapterNumber: row.chapterNumber ?? null,
+                chapterLanguage: row.chapterLanguage ?? null,
+                extension: row.extension ?? null,
+                ...(archived.has(id) ? { unavailableAt: row.at.toISOString() } : {}),
+              }
+            : {};
+        };
+
+        // ---- dry run: predict, write nothing, audit nothing ----
+        if (body.dryRun) {
+          const preview: RecardItem[] = ids.map((id) => {
+            const blocked = blockedReason(id);
+            return blocked
+              ? { mdChapterId: id, ok: false, ...blocked, ...describe(id) }
+              : { mdChapterId: id, ok: true, outcome: "would_queue", ...describe(id) };
+          });
+          return reply.send({
+            dryRun: true,
+            action: "RECARD",
+            matched,
+            resolved: ids.length,
+            wouldQueue: preview.filter((item) => item.ok).length,
+            blocked: preview.filter((item) => !item.ok).length,
+            batch: body.batch,
+            nextAfterId,
+            breakdown: filter ? await ctx.chapters.byExtension("unavailable", filter) : undefined,
+            results: preview,
+            note:
+              "nothing was changed and nothing was queued. Repeat with {dryRun: false, confirm: true} " +
+              "to queue exactly this set" +
+              (nextAfterId ? ", then repeat with afterId for the rest" : ""),
+          });
+        }
+
+        if (!body.confirm) {
+          return reply.code(400).send({
+            error: "a live re-card needs confirm: true alongside dryRun: false",
+            wouldQueue: ids.filter((id) => blockedReason(id) === null).length,
+          });
+        }
+
+        // ---- live: one guarded upsert per chapter ----
+        const sweepId = randomUUID();
+        const results: RecardItem[] = [];
+        const auditRows: { actor: string; action: string; subject: string; detail: unknown }[] = [];
+        const who = actor(req);
+
+        for (const id of ids) {
+          const blocked = blockedReason(id);
+          if (blocked) {
+            results.push({ mdChapterId: id, ok: false, ...blocked, ...describe(id) });
+            continue;
+          }
+          const row = archived.get(id)!;
+          const chapter = chapterOf(row);
+          const payload: Record<string, unknown> = {
+            ...chapterToTaskPayload(
+              chapter as unknown as Record<string, unknown>,
+              chapter.imageArtifacts,
+            ),
+            // The archive row's own instant, not now: this chapter went
+            // unavailable when it went unavailable, and the card prints it.
+            unavailableAt: row.at.toISOString(),
+            // Without `force` the uploader recognises its own card and archives
+            // the chapter again without touching the page, which is the exact
+            // no-op this endpoint exists to get past.
+            force: true,
+            ...(body.footerNote ? { footerNote: body.footerNote } : {}),
+          };
+          const problems = manualTaskProblems("UNAVAILABLE", payload);
+          const dedupeKey = taskDedupeKey("UNAVAILABLE", chapter);
+          if (problems.length > 0 || dedupeKey === null) {
+            results.push({
+              mdChapterId: id,
+              ok: false,
+              outcome: "invalid",
+              reason: problems[0] ?? "cannot derive a queue key for this chapter",
+              ...describe(id),
+            });
+            continue;
+          }
+
+          const created = await ctx.uploadTasks.requeueForChapter("UNAVAILABLE", dedupeKey, payload);
+          if (!created) {
+            results.push({
+              mdChapterId: id,
+              ok: false,
+              outcome: "already_queued",
+              reason: "a task for this chapter was queued or claimed while this sweep was running",
+              ...describe(id),
+            });
+            continue;
+          }
+          results.push({
+            mdChapterId: id,
+            ok: true,
+            outcome: created.superseded ? "requeued" : "queued",
+            taskId: created.task.id,
+            ...describe(id),
+          });
+          auditRows.push({
+            actor: who,
+            action: "chapter.unavailable.recard",
+            subject: id,
+            detail: {
+              sweep: sweepId,
+              footerNote: body.footerNote ?? null,
+              unavailableAt: row.at.toISOString(),
+              extension: row.extension,
+              mdMangaId: row.mdMangaId,
+              chapterNumber: row.chapterNumber,
+              chapterLanguage: row.chapterLanguage,
+              taskId: created.task.id,
+              supersededCompletedTask: created.superseded,
+            },
+          });
+        }
+
+        const queuedCount = results.filter((item) => item.ok).length;
+        await ctx.audit.recordMany([
+          ...auditRows,
+          {
+            actor: who,
+            action: "chapter.unavailable.recard.sweep",
+            subject: sweepId,
+            detail: {
+              sweep: sweepId,
+              requested: ids.length,
+              queued: queuedCount,
+              refused: results.length - queuedCount,
+              footerNote: body.footerNote ?? null,
+              ...(filter
+                ? { filter: body.filter, afterId: body.afterId ?? null, nextAfterId }
+                : { ids }),
+            },
+          },
+        ]);
+
+        return reply.send({
+          ok: true,
+          dryRun: false,
+          action: "RECARD",
+          sweep: sweepId,
+          matched,
+          requested: ids.length,
+          queued: queuedCount,
+          refused: results.length - queuedCount,
+          // Null once the sweep has reached the end of the archive; until then
+          // the caller repeats with it to continue where this page stopped.
+          nextAfterId,
+          results,
+          note: "core-uploader drains this queue; watch it under Queues, filtered by UNAVAILABLE.",
+        });
+      },
+    );
+
     /**
      * Bulk delete. Nothing extra guards it beyond what the other two have: the
      * existing guards are already the strongest here (ADMIN role, no api tokens,

--- a/src/core/store/chapters.ts
+++ b/src/core/store/chapters.ts
@@ -199,6 +199,46 @@ export class ChapterStore {
     return rows.map((row) => row.mdChapterId);
   }
 
+  /**
+   * One page of a whole-archive sweep, ordered by primary key.
+   *
+   * Deliberately not `idsMatching`'s newest-first ordering. A sweep that
+   * re-cards what it finds rewrites `unavailable_at` on every row it touches,
+   * so a continuation ordered on that column would resolve the rows it just
+   * processed all over again and never reach the end of the table. `id` is
+   * never rewritten, so a cursor over it is total, stable, and unaffected by
+   * the writes the sweep itself causes.
+   *
+   * `nextAfterId` is null only when this page is the last one; the caller
+   * repeats with it until then, so a sweep is bounded per request without
+   * being bounded overall.
+   */
+  async idsForSweep(
+    archive: ChapterArchive,
+    filter: ChapterFilter,
+    limit: number,
+    afterId?: string | null,
+  ): Promise<{ ids: string[]; nextAfterId: string | null }> {
+    const spec = ARCHIVES[archive];
+    const parts = chapterWhere(filter, spec);
+    if (afterId) parts.push(Prisma.sql`c.id > ${afterId}`);
+
+    // One row beyond the page, so "is there another page?" costs no extra query.
+    const rows = await this.prisma.$queryRaw<{ id: string; mdChapterId: string }[]>(Prisma.sql`
+      SELECT c.id, c.md_chapter_id AS "mdChapterId" FROM ${Prisma.raw(spec.table)} c
+      ${combine(parts)}
+      ORDER BY c.id ASC
+      LIMIT ${limit + 1}
+    `);
+
+    const page = rows.slice(0, limit);
+    const last = page[page.length - 1];
+    return {
+      ids: page.map((row) => row.mdChapterId),
+      nextAfterId: rows.length > limit && last ? last.id : null,
+    };
+  }
+
   async countMatching(archive: ChapterArchive, filter: ChapterFilter): Promise<number> {
     const spec = ARCHIVES[archive];
     const rows = await this.prisma.$queryRaw<{ total: bigint }[]>(Prisma.sql`

--- a/test/browser/verify.mjs
+++ b/test/browser/verify.mjs
@@ -475,7 +475,7 @@ const hashes = [
   "#/queues/tasks", "#/queues/depth", "#/activity", "#/errors/failures", "#/errors/quarantine",
   "#/extensions", "#/tracked", "#/untracked", "#/workers/fleet", "#/workers/enrolment",
   "#/users/accounts", "#/users/sessions", "#/users/signups", "#/tokens/issued", "#/tokens/mint",
-  "#/audit", "#/system/schema", "#/system/mangadex", "#/system/backup",
+  "#/audit", "#/system/schema", "#/system/mangadex", "#/system/cards", "#/system/backup",
   "#/maintenance", "#/docs",
 ];
 for (const hash of hashes) {

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -699,6 +699,205 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
     });
   });
 
+
+  // ---- re-carding what is already unavailable ----
+
+  /**
+   * Re-posting the card image on chapters that already carry one.
+   *
+   * The properties here are the two the bulk endpoint gets wrong, which is why
+   * this is a separate route rather than another flag on that one:
+   *
+   *  - the card must carry the date the chapter went unavailable, not today's,
+   *    or re-rendering a year-old page rewrites its "available until" line; and
+   *  - a whole-archive sweep must terminate. The uploader rewrites
+   *    `unavailable_at` as it archives, so paging on that column re-reads the
+   *    rows it just processed for ever; this pages on the primary key, and the
+   *    test below rewrites the dates between pages to prove it.
+   */
+  describe("re-carding the unavailable archive", () => {
+    /** A chapter already carrying a card, archived at a known instant. */
+    async function carded(overrides: Record<string, unknown> = {}) {
+      seq += 1;
+      return prisma.unavailableChapter.create({
+        data: {
+          mdChapterId: uuid(seq),
+          extension: "exampleext",
+          chapterId: `src-${seq}`,
+          chapterNumber: String(seq),
+          chapterTitle: `Chapter ${seq}`,
+          chapterLanguage: "en",
+          mangaName: "Test Series",
+          mdMangaId: uuid(900),
+          mdGroupId: uuid(800),
+          unavailableAt: new Date("2026-03-04T05:06:07.000Z"),
+          ...overrides,
+        },
+      });
+    }
+
+    const recard = (payload: Record<string, unknown>) =>
+      app.inject({
+        method: "POST",
+        url: "/api/v1/admin/chapters/unavailable/recard",
+        headers: root,
+        payload,
+      });
+
+    it("previews by default and writes nothing", async () => {
+      const chapter = await carded();
+
+      const preview = await recard({ ids: [chapter.mdChapterId] });
+      expect(preview.statusCode).toBe(200);
+      expect(preview.json().dryRun).toBe(true);
+      expect(preview.json().wouldQueue).toBe(1);
+      expect(preview.json().results[0].outcome).toBe("would_queue");
+      // The date the card will carry, shown before anything is queued.
+      expect(preview.json().results[0].unavailableAt).toBe("2026-03-04T05:06:07.000Z");
+      expect(await prisma.uploadTask.count()).toBe(0);
+      expect(await prisma.auditEvent.count()).toBe(0);
+
+      const unconfirmed = await recard({ ids: [chapter.mdChapterId], dryRun: false });
+      expect(unconfirmed.statusCode).toBe(400);
+      expect(await prisma.uploadTask.count()).toBe(0);
+    });
+
+    it("queues a forced re-card carrying the date the chapter went unavailable", async () => {
+      const chapter = await carded();
+
+      const res = await recard({
+        ids: [chapter.mdChapterId],
+        dryRun: false,
+        confirm: true,
+        footerNote: "Re-rendered after the font fix.",
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().queued).toBe(1);
+
+      const task = await prisma.uploadTask.findFirstOrThrow({ where: { kind: "UNAVAILABLE" } });
+      const payload = task.chapter as Record<string, unknown>;
+      // Without `force` the uploader recognises its own card and changes
+      // nothing, which would make the whole endpoint a no-op.
+      expect(payload.force).toBe(true);
+      // Today's date here would silently rewrite the window printed on a page
+      // that has been up since March.
+      expect(payload.unavailableAt).toBe("2026-03-04T05:06:07.000Z");
+      expect(payload.footerNote).toBe("Re-rendered after the font fix.");
+
+      const per = await prisma.auditEvent.findFirstOrThrow({
+        where: { action: "chapter.unavailable.recard" },
+      });
+      expect(per.subject).toBe(chapter.mdChapterId);
+      const summary = await prisma.auditEvent.findFirstOrThrow({
+        where: { action: "chapter.unavailable.recard.sweep" },
+      });
+      expect((per.detail as { sweep: string }).sweep).toBe(summary.subject);
+    });
+
+    it("sweeps the whole archive page by page, and finishes even as dates churn", async () => {
+      const chapters = [];
+      for (let i = 0; i < 5; i++) chapters.push(await carded());
+
+      const seen: string[] = [];
+      let afterId: string | null = null;
+      for (let page = 0; page < 10; page++) {
+        const res = await recard({
+          filter: {},
+          batch: 2,
+          dryRun: false,
+          confirm: true,
+          ...(afterId ? { afterId } : {}),
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.json().matched).toBe(5);
+        for (const item of res.json().results) seen.push(item.mdChapterId);
+        afterId = res.json().nextAfterId;
+
+        // What the uploader does to every row it archives, and the reason a
+        // sweep ordered on `unavailable_at` would restart for ever: the rows
+        // just processed jump back to the top of that ordering.
+        await prisma.unavailableChapter.updateMany({
+          where: { mdChapterId: { in: res.json().results.map((r: { mdChapterId: string }) => r.mdChapterId) } },
+          data: { unavailableAt: new Date() },
+        });
+        if (!afterId) break;
+      }
+
+      expect(afterId).toBeNull();
+      // Every chapter exactly once: no gaps, and nothing carded twice.
+      expect(seen.sort()).toEqual(chapters.map((c) => c.mdChapterId).sort());
+      expect(await prisma.uploadTask.count({ where: { kind: "UNAVAILABLE" } })).toBe(5);
+    });
+
+    it("narrows a sweep by the same filter the archive listing uses", async () => {
+      await carded({ extension: "otherext" });
+      const mine = await carded({ extension: "sweepext" });
+
+      const preview = await recard({ filter: { extension: "sweepext" } });
+      expect(preview.json().matched).toBe(1);
+      expect(preview.json().breakdown).toEqual([{ extension: "sweepext", count: 1 }]);
+
+      const res = await recard({
+        filter: { extension: "sweepext" },
+        dryRun: false,
+        confirm: true,
+      });
+      expect(res.json().queued).toBe(1);
+      const tasks = await prisma.uploadTask.findMany({ where: { kind: "UNAVAILABLE" } });
+      expect(tasks.map((t) => t.dedupeKey)).toEqual([mine.mdChapterId]);
+    });
+
+    it("refuses chapters that have no card to replace, one by one", async () => {
+      const ok = await carded();
+      const live = await uploaded();
+      const gone = await prisma.deletedChapter.create({
+        data: { mdChapterId: uuid((seq += 1)), extension: "exampleext" },
+      });
+      const queuedAlready = await carded();
+      await prisma.uploadTask.create({
+        data: { kind: "UNAVAILABLE", dedupeKey: queuedAlready.mdChapterId, chapter: {} },
+      });
+
+      const ids = [ok.mdChapterId, live.mdChapterId, gone.mdChapterId, queuedAlready.mdChapterId, uuid(999)];
+      const preview = await recard({ ids });
+      const outcomes = Object.fromEntries(
+        preview.json().results.map((r: { mdChapterId: string; outcome: string }) => [r.mdChapterId, r.outcome]),
+      );
+      expect(outcomes[ok.mdChapterId]).toBe("would_queue");
+      // Never carded: this route re-posts, it does not card for the first time.
+      expect(outcomes[live.mdChapterId]).toBe("not_unavailable");
+      expect(outcomes[gone.mdChapterId]).toBe("deleted");
+      expect(outcomes[queuedAlready.mdChapterId]).toBe("already_queued");
+      expect(outcomes[uuid(999)]).toBe("not_found");
+
+      const applied = await recard({ ids, dryRun: false, confirm: true });
+      expect(applied.json().queued).toBe(1);
+      expect(applied.json().refused).toBe(4);
+      expect(await prisma.uploadTask.count({ where: { kind: "UNAVAILABLE" } })).toBe(2);
+    });
+
+    it("refuses a body that names both a selection and a filter, or neither", async () => {
+      const chapter = await carded();
+      expect((await recard({ ids: [chapter.mdChapterId], filter: {} })).statusCode).toBe(400);
+      expect((await recard({})).statusCode).toBe(400);
+      // A continuation only means something for a sweep.
+      expect((await recard({ ids: [chapter.mdChapterId], afterId: "x" })).statusCode).toBe(400);
+    });
+
+    it("keeps re-carding behind the same role gate as every other chapter write", async () => {
+      const chapter = await carded();
+      const writer = await mint(["chapters:write"]);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/admin/chapters/unavailable/recard",
+        headers: writer,
+        payload: { ids: [chapter.mdChapterId], dryRun: false, confirm: true },
+      });
+      expect(res.statusCode).toBe(403);
+      expect(await prisma.uploadTask.count()).toBe(0);
+    });
+  });
+
   // ---- authorisation ----
 
   it("keeps published chapters out of reach of scopes and roles that should not have them", async () => {

--- a/test/unit/dashboardChapters.test.ts
+++ b/test/unit/dashboardChapters.test.ts
@@ -41,7 +41,7 @@ const MD_CHAPTER = "1c2d3e4f-0000-4000-8000-000000000001";
 const MD_MANGA = "9a1b1c1d-0000-4000-8000-000000000000";
 
 /** Canned API responses, keyed by the path prefix the view requests. */
-function apiRoutes(): { match: RegExp; body: unknown }[] {
+function apiRoutes(): { match: RegExp; body: unknown | ((init?: { body?: string }) => unknown) }[] {
   return [
     { match: /\/session$/, body: { actor: "ardax", role: "OWNER", userId: "u1", email: "a@b.c" } },
     {
@@ -181,6 +181,50 @@ function apiRoutes(): { match: RegExp; body: unknown }[] {
     },
     { match: /\/chapters\/extensions/, body: { table: "uploaded", extensions: [{ extension: "mangaplus", count: 902 }] } },
     {
+      // Answers from the request, because the property under test is that the
+      // panel keeps calling while a continuation comes back.
+      match: /\/chapters\/unavailable\/recard/,
+      body: (init?: { body?: string }) => {
+        const sent = JSON.parse(init?.body ?? "{}");
+        const continued = Boolean(sent.afterId);
+        const results = [
+          {
+            mdChapterId: MD_CHAPTER,
+            ok: true,
+            outcome: sent.dryRun === false ? "queued" : "would_queue",
+            mangaName: "Sakamoto Days",
+            chapterNumber: "141",
+            chapterLanguage: "en",
+            unavailableAt: "2026-03-04T05:06:07Z",
+          },
+        ];
+        return sent.dryRun === false
+          ? {
+              ok: true,
+              dryRun: false,
+              action: "RECARD",
+              sweep: "sweep-1",
+              matched: 7,
+              requested: continued ? 3 : 4,
+              queued: continued ? 3 : 4,
+              refused: 0,
+              nextAfterId: continued ? null : "row-4",
+              results,
+            }
+          : {
+              dryRun: true,
+              action: "RECARD",
+              matched: 7,
+              resolved: 4,
+              wouldQueue: 4,
+              blocked: 0,
+              batch: 200,
+              nextAfterId: "row-4",
+              results,
+            };
+      },
+    },
+    {
       match: new RegExp(`/chapters/${MD_CHAPTER}$`),
       body: {
         // The shape `GET /chapters/:mdChapterId` actually returns: the id at the
@@ -250,11 +294,13 @@ let requested: string[] = [];
 
 function installFetch(): void {
   const routes = apiRoutes();
-  win.fetch = vi.fn(async (url: string) => {
+  win.fetch = vi.fn(async (url: string, init?: { body?: string }) => {
     const path = String(url);
     requested.push(path);
     const route = routes.find((r) => r.match.test(path));
-    const body = route ? route.body : {};
+    // A route may answer from the request rather than with a constant, which is
+    // what lets a paged endpoint be stubbed as a page sequence.
+    const body = route ? (typeof route.body === "function" ? route.body(init) : route.body) : {};
     return {
       // `ok` is what api() branches on; a stub without it makes every call throw
       // "200 OK" and the page falls back to the sign-in layer.
@@ -432,5 +478,108 @@ describe("dashboard chapter views", () => {
     // form that submitted all of them would write "unchanged" edits into the
     // chapter's permanent history.
     expect(JSON.parse(call[1].body)).toEqual({ title: "Corrected title" });
+  });
+
+  /**
+   * The re-card panel under Admin → System.
+   *
+   * It is the one control in the dashboard whose apply step is a LOOP: a sweep
+   * of the whole archive is a request per page, continued by `nextAfterId`
+   * until the server stops returning one. A panel that fired once and reported
+   * "done" would silently leave most of the archive un-recarded, which is the
+   * failure this covers.
+   */
+  describe("re-posting unavailable card images", () => {
+    /** Click a button by its label, anywhere in the mounted view. */
+    const click = (label: string): void => {
+      const button = [...doc.querySelectorAll("button")].find(
+        (b: { textContent: string }) => b.textContent === label,
+      );
+      expect(button, `no button labelled ${label}`).toBeTruthy();
+      button.click();
+    };
+
+    const recardCalls = () =>
+      win.fetch.mock.calls.filter(([url]: [string]) => String(url).includes("/unavailable/recard"));
+
+    it("offers the three targets and previews the whole archive by default", async () => {
+      await goto("#/system/cards");
+      const view = text();
+      expect(view).toContain("Re-post unavailable card images");
+      expect(view).toContain("Every unavailable chapter");
+      expect(view).toContain("Pick from the archive");
+      expect(view).toContain("One chapter");
+
+      click("Preview");
+      await settle();
+
+      const [, init] = recardCalls()[0];
+      // A preview is a dry run naming a filter, never an id list, and never a
+      // live write.
+      expect(JSON.parse(init.body)).toEqual({ filter: {}, dryRun: true });
+      expect(text()).toContain("7");
+    });
+
+    it("keeps sweeping until the server stops handing back a continuation", async () => {
+      await goto("#/system/cards");
+      click("Re-post every card…");
+      await settle();
+      // The confirm dialog stands between the click and any write.
+      click("Queue the re-cards");
+      await settle(20);
+
+      const live = recardCalls().filter(
+        ([, init]: [string, { body: string }]) => JSON.parse(init.body).dryRun === false,
+      );
+      // Two pages: the stub returns a continuation for the first call and none
+      // for the second, so a panel that fired once would stop at 4 of 7.
+      expect(live).toHaveLength(2);
+      expect(JSON.parse(live[0][1].body)).toEqual({ filter: {}, dryRun: false, confirm: true });
+      expect(JSON.parse(live[1][1].body).afterId).toBe("row-4");
+      expect(text()).toContain("done");
+    });
+
+    it("re-cards a single chapter named by its MangaDex id", async () => {
+      await goto("#/system/cards");
+      doc.getElementById("recard-mode-one").checked = true;
+      doc.getElementById("recard-mode-one").dispatchEvent(new win.Event("change"));
+      await settle();
+
+      const field = doc.getElementById("recard-chapter-id");
+      field.value = MD_CHAPTER;
+      field.dispatchEvent(new win.Event("input"));
+      await settle();
+
+      // The exact image, rendered by the same code that posts it, so an
+      // operator approves what actually goes up.
+      click("Refresh the preview");
+      expect(doc.querySelector(".card-preview").src).toContain(`/chapters/${MD_CHAPTER}/card.png`);
+
+      click("Preview");
+      await settle();
+      expect(JSON.parse(recardCalls()[0][1].body)).toEqual({ ids: [MD_CHAPTER], dryRun: true });
+    });
+
+    it("re-cards exactly the chapters ticked in the picker", async () => {
+      await goto("#/system/cards");
+      doc.getElementById("recard-mode-selected").checked = true;
+      doc.getElementById("recard-mode-selected").dispatchEvent(new win.Event("change"));
+      await settle();
+      // The archive listing, not the uploaded one: this panel only ever touches
+      // chapters that already carry a card.
+      expect(requested.some((path) => path.includes("archive=unavailable"))).toBe(true);
+
+      const box = doc.querySelector('#view input[type="checkbox"]');
+      box.checked = true;
+      box.dispatchEvent(new win.Event("change"));
+      await settle();
+
+      click("Preview");
+      await settle();
+      expect(JSON.parse(recardCalls()[0][1].body)).toEqual({
+        ids: [MD_CHAPTER],
+        dryRun: true,
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds **System → Unavailable cards** to the dashboard: re-render and re-post the card image on chapters already marked unavailable — every one of them, a set ticked out of the archive, or a single chapter id — previewed before anything is queued.

The occasion is a renderer change (the missing fonts, most recently). A card is rendered at the moment it is posted, so every card in the catalogue is a fossil of the build that put it there; nothing brought the pages already up back in line. One chapter at a time worked, 200 at a time worked, "all of them" did not.

### Why a new route rather than a flag on `/chapters/bulk/unavailable`

That route gets two things wrong for a re-render:

- **The date.** It stamps every card with `new Date()`, right for a chapter going unavailable now and wrong for one pulled in March — re-rendering a year-old page through it rewrites the page's own "available until" line. `POST /chapters/unavailable/recard` takes the date from the archive row.
- **Termination.** It caps at 200 with no continuation, ordered on `unavailable_at DESC` — the column the uploader rewrites as it archives. A sweep through it re-cards the newest 200 for ever and never reaches the rest. This pages on the primary key and answers `nextAfterId`; the panel follows it until the archive is exhausted, reporting the running count as it goes.

A chapter with no card refuses as `not_unavailable`: this re-posts, it never cards a chapter for the first time. Everything else matches the bulk contract — `ids` XOR `filter`, dry run by default, live needs `dryRun: false` **and** `confirm: true`, `chapters:write` + ADMIN, one audit row per chapter plus a sweep summary.

### Tests

- `test/unit/dashboardChapters.test.ts` — the panel under jsdom: the three targets, and that the sweep **keeps calling** while a continuation comes back (a panel that fired once would silently leave most of the archive alone).
- `test/integration/chapters.test.ts` — preview writes nothing; the queued payload carries `force: true` and the archive's own date; a paged sweep covers every row exactly once **with the dates rewritten between pages**, which is the property the ordering exists for; per-chapter refusals; the role gate.

749 unit tests pass; lint and typecheck clean. The integration tests are written but were not run here — this machine has neither Docker nor a local Postgres, so `describe.skipIf(!dbReady())` skipped them. They need a run against a real database before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)