### PR TITLE
Single-series triggers: re-card its cards, and re-check it at the publisher

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -608,6 +608,7 @@ not a fourth flag on the bulk ones:
 | Method | Path | Scope | Notes |
 | --- | --- | --- | --- |
 | `POST` | `/chapters/unavailable/recard` | `chapters:write` + ADMIN | `{ids?, filter?, footerNote?, dryRun?, confirm?, afterId?, batch?}`. Always the `unavailable` archive and always forced. A chapter with no card refuses as `not_unavailable` rather than being carded for the first time |
+| `GET` | `/chapters/series` | `chapters:read` | `?archive=&extension=&language=&search=&limit=`. The titles present in one archive, most-affected first: `{mdMangaId, mangaName, extensions[], count, at}` plus `capped`. Aims the `mdMangaId` filter above; read-only, so unlike the re-card itself it is reachable on a `pa_…` token |
 
 It exists because the bulk route gets two things wrong for a re-render:
 
@@ -620,6 +621,12 @@ It exists because the bulk route gets two things wrong for a re-render:
   everything" through it re-cards the newest 200 for ever. This pages on the
   primary key and answers `nextAfterId`; the caller repeats with it until it is
   null, which is exactly what the dashboard panel does.
+
+`filter: {mdMangaId}` is the single-series trigger: every card one title has up,
+swept to the end by the same continuation as a whole-archive pass. `GET
+/chapters/series` is how a title is found — `count` is the size of the job, and
+extension and language narrow both it and the sweep identically, so the list an
+operator picks from and the rows the sweep touches are the same set.
 
 `filter: {}` means every unavailable chapter; the filter is required-but-emptiable
 so that "re-card everything" has to be typed rather than fallen into. Everything

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -275,6 +275,7 @@ as the legacy `force_login` without a chat command that handles a password.
 | `/tracked set <extension> <manga-id> <md-manga-id>` | mutate | `extensions:write` | Add or repoint a mapping. |
 | `/tracked remove <extension> <manga-id>` | mutate | `extensions:write` | Stop tracking. Does not touch MangaDex. |
 | `/reconcile [extension]` | read | `chapters:read` | How many chapters are already marked unavailable on MangaDex, or deleted, that the archives do not know about. **Reports only**; applying is closed to api tokens, so recording them is `padmin chapters reconcile --apply` or the dashboard. |
+| `/recard [series] [extension]` | read | `chapters:read` | Which titles have unavailable card images up and how many each has, autocompleted from the archive. Naming one title answers with the line that re-posts its cards. **Reports only**, for the same reason: posting card images is closed to api tokens, so the work happens on the dashboard or through `padmin chapters recard --series … --apply`. |
 
 `/extensions list` shows **published bundles**, not files on disk. An extension
 in the repo that was never published does not appear; that is intended.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -226,7 +226,7 @@ leak an id into an access log.
 | **Users** | OWNER | *Accounts*: invite, approve, change role, set a password, delete. *Sessions*: who is signed in, with revoke. *Signups*: the self-signup gate. |
 | **Tokens** | OWNER | *Issued*: every `pa_…` client credential with its scopes, creator, last use and expiry, with revoke. *Mint*: scopes grouped by area, with the shipped presets. |
 | **Audit** | `audit:read` | Who did what, searchable by actor, action, subject, free text and date range; and one event at a time by id. |
-| **System** | `settings:read` (acting needs `chapters:write` + ADMIN) | *Schema*: is this database the schema this build expects. *MangaDex*: the saved session. *Unavailable cards*: re-render and re-post the card image on chapters already marked unavailable — every one of them, a set ticked out of the archive, or a single chapter id, previewed first. *Backup*: a `pg_dump` download (OWNER only). |
+| **System** | `settings:read` (acting needs `chapters:write` + ADMIN) | *Schema*: is this database the schema this build expects. *MangaDex*: the saved session. *Unavailable cards*: re-render and re-post the card image on chapters already marked unavailable — every one of them, one series picked out of a list of the titles with cards up, a set ticked out of the archive, or a single chapter id, previewed first. *Backup*: a `pg_dump` download (OWNER only). |
 | **Maintenance** | `bundles:read` | Compare each live bundle against its GitHub branch, install a bundle, restart a service. Lives in `dashboard/sysops.js`. |
 | **Docs** | `stats:read` | The operator handbook that ships with this build, rendered in the page. Lives in `dashboard/docs.js`. |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1230,14 +1230,37 @@ a fossil of the build that put it there. When the renderer changes — a font th
 was missing, wording that was wrong, a layout that clipped long titles — the only
 fix for the pages already up is to render them again and post them over the top.
 
-**Dashboard → System → Unavailable cards.** Three targets, because the three
-occasions differ: one chapter somebody complained about, a set ticked out of the
-archive, or every card on the site after a renderer fix. Preview first; the
-preview resolves the same rows and checks the same refusals as the live run.
+**Dashboard → System → Unavailable cards.** Four targets, because the occasions
+differ: one chapter somebody complained about, **one series**, a set ticked out
+of the archive, or every card on the site after a renderer fix. Preview first;
+the preview resolves the same rows and checks the same refusals as the live run.
+
+The series target is the one most complaints arrive as — a reader reports that a
+title's pages are wrong, not that chapter `1c2d…`'s are. Picking it out of the
+list shows how many cards that title has up before anything is queued; from the
+CLI it is one command that follows its own continuation to the end:
+
+```bash
+# which titles have cards up, largest first
+padmin chapters series --archive unavailable --search sakamoto
+
+# what re-carding one of them would do, then doing it
+padmin chapters recard --series "$MD_MANGA_ID"
+padmin chapters recard --series "$MD_MANGA_ID" --apply
+```
+
+`/recard` in Discord answers the same question and hands back that command line;
+it cannot queue the work itself, because card images are closed to api tokens at
+the endpoint.
 
 By hand it is one route, always forced, always the `unavailable` archive:
 
 ```bash
+# one series, previewed
+curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d "{\"filter\":{\"mdMangaId\":\"$MD_MANGA_ID\"}}" \
+  "$API/api/v1/admin/chapters/unavailable/recard"
+
 # every unavailable chapter, previewed
 curl -s -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
   -d '{"filter":{}}' "$API/api/v1/admin/chapters/unavailable/recard"

--- a/src/bot/apiClient.ts
+++ b/src/bot/apiClient.ts
@@ -296,6 +296,22 @@ export type UploadTaskState = "PENDING" | "LEASED" | "DONE" | "FAILED" | "DEAD_L
  * What a reconcile pass found. Mirrors ReconcileReport in
  * core/md/chapterReconcile.ts, narrowed to the fields the bot renders.
  */
+/** One title's footprint in an archive, as `/chapters/series` reports it. */
+export interface ArchiveSeries {
+  mdMangaId: string;
+  mangaName: string | null;
+  extensions: string[];
+  count: number;
+  at: string;
+}
+
+export interface ArchiveSeriesReport {
+  archive: string;
+  series: ArchiveSeries[];
+  limit: number;
+  capped: boolean;
+}
+
 export interface ChapterReconcileReport {
   dryRun: boolean;
   groups: {
@@ -538,6 +554,36 @@ export class AdminApiClient {
       scope: "chapters:read",
       actor,
       json: { dryRun: true, extensions },
+    });
+  }
+
+  /**
+   * The titles present in an archive, most-affected first.
+   *
+   * Read-only and therefore reachable on a `pa_…` token, unlike the re-card it
+   * exists to aim: queuing card images is closed to api tokens at the endpoint,
+   * so what the bot can usefully do is answer "which title, and how many pages
+   * would move?" — the question somebody asks in a channel before going to the
+   * dashboard or the CLI to do it.
+   */
+  archiveSeries(
+    actor: string,
+    opts: { archive: string; search?: string | undefined; extension?: string | undefined; limit?: number },
+  ): Promise<ArchiveSeriesReport> {
+    return this.request({
+      method: "GET",
+      path: "/api/v1/admin/chapters/series",
+      scope: "chapters:read",
+      actor,
+      query: {
+        archive: opts.archive,
+        search: opts.search,
+        extension: opts.extension,
+        limit: opts.limit ?? 25,
+      },
+      // Autocomplete calls this on the keystroke and Discord closes the window
+      // at three seconds; a slow answer is worth abandoning, not waiting for.
+      timeoutMs: 2500,
     });
   }
 

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -285,9 +285,13 @@ export class PubloaderBot {
   }
 
   /**
-   * Extension-name autocomplete. Backed by the published-bundle list, which is
-   * the authority now; the legacy bot listed directories on the scheduler's
-   * disk, which could offer a name that had never been published.
+   * Option autocomplete.
+   *
+   * Extension names come from the published-bundle list, which is the authority
+   * now; the legacy bot listed directories on the scheduler's disk, which could
+   * offer a name that had never been published. Series come from the archive
+   * itself, uncached: the set changes every time the uploader archives a
+   * chapter, and a stale title list is a re-card aimed at the wrong id.
    */
   private async onAutocomplete(interaction: AutocompleteInteraction): Promise<void> {
     const invoker = invokerOf(interaction);
@@ -298,6 +302,10 @@ export class PubloaderBot {
       return;
     }
     const focused = interaction.options.getFocused(true);
+    if (focused.name === "series") {
+      await this.respondWithSeries(interaction, String(focused.value ?? ""));
+      return;
+    }
     if (focused.name !== "extension") {
       await interaction.respond([]).catch(() => undefined);
       return;
@@ -313,6 +321,37 @@ export class PubloaderBot {
       .filter((n) => !needle || n.toLowerCase().includes(needle))
       .slice(0, 25)
       .map((n) => ({ name: n, value: n }));
+    await interaction.respond(choices).catch(() => undefined);
+  }
+
+  /**
+   * Titles in the unavailable archive, largest first, as autocomplete choices.
+   *
+   * The value is the MangaDex id and the label carries the count, because the
+   * two things an operator needs to see before choosing are which title it is
+   * and how many pages a re-card would move. Failure answers an empty list: a
+   * missing suggestion is a worse UX, a thrown autocomplete is a broken one.
+   */
+  private async respondWithSeries(
+    interaction: AutocompleteInteraction,
+    needle: string,
+  ): Promise<void> {
+    let choices: { name: string; value: string }[] = [];
+    try {
+      const { series } = await this.api.archiveSeries("discord:autocomplete", {
+        archive: "unavailable",
+        search: needle.trim() || undefined,
+        limit: 25,
+      });
+      choices = series.map((entry) => ({
+        // Discord rejects a choice name over 100 characters outright, taking
+        // the whole response with it.
+        name: `${entry.mangaName ?? entry.mdMangaId} · ${entry.count} card(s)`.slice(0, 100),
+        value: entry.mdMangaId,
+      }));
+    } catch (err) {
+      this.log.debug({ err }, "autocomplete could not list series");
+    }
     await interaction.respond(choices).catch(() => undefined);
   }
 

--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -1381,6 +1381,86 @@ const commands: BotCommand[] = [
     },
   },
   {
+    name: "recard",
+    description: "Which titles have unavailable card images up, and how to re-post them.",
+    // Read, and not by choice: queuing card images is closed to api tokens at
+    // the endpoint, so a `pa_…` token could not re-post a card even if this
+    // asked it to. What the bot can do is the half that happens in a channel
+    // anyway — somebody reports a bad card, and the answer is which title it
+    // is, how many pages would move, and the one line that moves them.
+    sensitivity: "read",
+    ephemeral: true,
+    builder: new SlashCommandBuilder()
+      .setName("recard")
+      .setDescription("Which titles have unavailable card images up, and how to re-post them.")
+      .addStringOption((o) =>
+        o
+          .setName("series")
+          .setDescription("A title, by name or MangaDex id. Omit for the titles with the most cards up.")
+          .setAutocomplete(true),
+      )
+      .addStringOption((o) =>
+        o.setName("extension").setDescription("Only chapters this extension uploaded.").setAutocomplete(true),
+      ),
+    async run(ctx) {
+      const series = ctx.options.string("series");
+      const extension = ctx.options.string("extension");
+      const report = await ctx.api.archiveSeries(ctx.actor, {
+        archive: "unavailable",
+        search: series ?? undefined,
+        extension: extension ?? undefined,
+        limit: series ? 5 : 10,
+      });
+
+      const where = extension ? ` uploaded by **${extension}**` : "";
+      if (report.series.length === 0) {
+        return {
+          text: series
+            ? `:mag: No title${where} matching \`${series}\` has a card image up.`
+            : `:white_check_mark: No chapter${where} is marked unavailable, so there is no card to re-post.`,
+        };
+      }
+
+      // An exact id, or a name that matched one title and only one, is a
+      // target; anything else is a shortlist, and offering a command line for a
+      // title the operator has not actually chosen is how the wrong series gets
+      // re-carded.
+      const exact =
+        report.series.length === 1
+          ? report.series[0]
+          : report.series.find((entry) => entry.mdMangaId === series?.trim());
+
+      const lines = report.series.map(
+        (entry) =>
+          `• **${entry.mangaName ?? "(unnamed)"}** — ${entry.count} card(s) up, ` +
+          `${entry.extensions.map((name) => name || "(unattributed)").join(", ")}\n` +
+          `  \`${entry.mdMangaId}\``,
+      );
+
+      if (!exact) {
+        return {
+          text:
+            `:mag: ${report.series.length} title(s)${where} with card images up` +
+            (report.capped ? ", the largest shown" : "") +
+            `:\n${lines.join("\n")}\n` +
+            "Name one of them to get the command that re-posts its cards.",
+        };
+      }
+
+      const narrow = extension ? ` --extension ${extension}` : "";
+      return {
+        text:
+          `:card_index: **${exact.mangaName ?? exact.mdMangaId}** has **${exact.count}** ` +
+          `unavailable card image(s) up${where}, most recently ${exact.at}.\n` +
+          "Re-rendering them replaces each page with a fresh card and keeps the chapter's own " +
+          "unavailable-since date; it never cards a chapter for the first time.\n" +
+          "Nothing has been queued: the bot's token cannot post card images. Do it from " +
+          "**System → Unavailable cards** on the dashboard, or run\n" +
+          `\`\`\`\npadmin chapters recard --series ${exact.mdMangaId}${narrow} --apply\n\`\`\``,
+      };
+    },
+  },
+  {
     name: "tracked",
     description: "The external-id to MangaDex-id mapping for an extension.",
     sensitivity: { list: "read", set: "mutate", remove: "mutate" },

--- a/src/cli/admin.ts
+++ b/src/cli/admin.ts
@@ -650,6 +650,201 @@ chapters
     );
   });
 
+chapters
+  .command("series")
+  .description("the titles present in an archive, most-affected first")
+  .option("--archive <name>", "uploaded | unavailable | deleted | edited", "unavailable")
+  .option("--extension <name>", "only chapters this extension uploaded")
+  .option("--language <code>", "only chapters in this language")
+  .option("--search <text>", "substring of the title name, or any id")
+  .option("--limit <n>", "how many titles to list", "50")
+  .action(
+    async (opts: {
+      archive: string;
+      extension?: string;
+      language?: string;
+      search?: string;
+      limit: string;
+    }) => {
+      const res = await api<{
+        archive: string;
+        series: {
+          mdMangaId: string;
+          mangaName: string | null;
+          extensions: string[];
+          count: number;
+          at: string;
+        }[];
+        capped: boolean;
+      }>("/api/v1/admin/chapters/series", {
+        query: {
+          archive: opts.archive,
+          extension: opts.extension,
+          language: opts.language,
+          search: opts.search,
+          limit: opts.limit,
+        },
+      });
+
+      table(
+        res.series,
+        [
+          { header: "TITLE", get: (row) => (row.mangaName ?? "-").slice(0, 44) },
+          { header: "MD MANGA ID", get: (row) => row.mdMangaId },
+          { header: "CHAPTERS", get: (row) => row.count },
+          { header: "EXTENSION", get: (row) => row.extensions.map((e) => e || "(none)").join(",") },
+          { header: "MOST RECENT", get: (row) => ago(row.at) },
+        ],
+        `no title has a chapter in the ${res.archive} archive matching that filter`,
+      );
+      if (res.capped) {
+        console.error("  the list is capped; narrow it with --search or raise --limit");
+      }
+    },
+  );
+
+/**
+ * Re-render and re-post the card images of chapters already marked unavailable.
+ *
+ * The one target that is worth having a command for rather than a dashboard
+ * panel is `--series`: a stale card is nearly always reported one title at a
+ * time, and a title is the unit somebody complains in. The sweep pages on the
+ * primary key and follows its own continuation, so a title with four hundred
+ * chapters is one command rather than three requests an operator has to chain.
+ */
+chapters
+  .command("recard")
+  .description("re-render and re-post the card image of chapters already marked unavailable")
+  .option("--series <mdMangaId>", "every unavailable chapter of one MangaDex title")
+  .option("--chapter <mdChapterId...>", "these MangaDex chapter ids and no others")
+  .option("--all", "every unavailable chapter, narrowed by the filters below")
+  .option("--extension <name>", "narrow to one extension")
+  .option("--language <code>", "narrow to one language")
+  .option("--search <text>", "narrow by substring of the title name, or any id")
+  .option("--note <text>", "replace the card's standard explanatory paragraph")
+  .option("--batch <n>", "chapters per request while sweeping", "200")
+  .option("--apply", "queue the re-cards (default is a dry run that queues nothing)")
+  .action(
+    async (opts: {
+      series?: string;
+      chapter?: string[];
+      all?: boolean;
+      extension?: string;
+      language?: string;
+      search?: string;
+      note?: string;
+      batch: string;
+      apply?: boolean;
+    }) => {
+      const targets = [opts.series, opts.chapter?.length ? opts.chapter : undefined, opts.all].filter(
+        (value) => value !== undefined && value !== false,
+      );
+      if (targets.length !== 1) {
+        fail("give exactly one of --series, --chapter or --all");
+      }
+      const narrowing = opts.extension || opts.language || opts.search;
+      if (opts.chapter?.length && narrowing) {
+        fail("--extension, --language and --search narrow a sweep; an explicit --chapter list is already exact");
+      }
+
+      const filter = {
+        ...(opts.series ? { mdMangaId: opts.series } : {}),
+        ...(opts.extension ? { extension: opts.extension } : {}),
+        ...(opts.language ? { language: opts.language } : {}),
+        ...(opts.search ? { search: opts.search } : {}),
+      };
+      const target = opts.chapter?.length ? { ids: opts.chapter } : { filter };
+      const request = {
+        ...target,
+        ...(opts.note ? { footerNote: opts.note } : {}),
+        batch: Number(opts.batch),
+      };
+
+      interface RecardItem {
+        mdChapterId: string;
+        ok: boolean;
+        outcome: string;
+        reason?: string;
+        mangaName?: string | null;
+        chapterNumber?: string | null;
+        unavailableAt?: string;
+      }
+      interface RecardPage {
+        matched: number;
+        resolved?: number;
+        requested?: number;
+        wouldQueue?: number;
+        queued?: number;
+        blocked?: number;
+        refused?: number;
+        nextAfterId: string | null;
+        results: RecardItem[];
+      }
+
+      const call = (afterId: string | null) =>
+        api<RecardPage>("/api/v1/admin/chapters/unavailable/recard", {
+          method: "POST",
+          json: {
+            ...request,
+            dryRun: opts.apply !== true,
+            confirm: opts.apply === true,
+            ...(afterId ? { afterId } : {}),
+          },
+        });
+
+      // A dry run reports the first page only: it is a description of what the
+      // sweep would do, and paging the whole archive to describe it costs the
+      // same as doing it. The live run follows the continuation to the end,
+      // because a half-swept title is the outcome nobody asked for.
+      let afterId: string | null = null;
+      let acted = 0;
+      let skipped = 0;
+      let matched = 0;
+      let pages = 0;
+      const shown: RecardItem[] = [];
+      for (;;) {
+        const page: RecardPage = await call(afterId);
+        pages += 1;
+        matched = page.matched;
+        acted += page.wouldQueue ?? page.queued ?? 0;
+        skipped += page.blocked ?? page.refused ?? 0;
+        for (const item of page.results) if (shown.length < 50) shown.push(item);
+        afterId = page.nextAfterId;
+        if (!afterId || opts.apply !== true) break;
+        console.error(`  … ${acted} queued so far of ${matched} matching`);
+      }
+
+      table(
+        shown,
+        [
+          { header: "TITLE", get: (row) => (row.mangaName ?? "-").slice(0, 30) },
+          { header: "CHAPTER", get: (row) => (row.chapterNumber ? `Ch. ${row.chapterNumber}` : "-") },
+          { header: "MD CHAPTER ID", get: (row) => row.mdChapterId },
+          { header: "UNAVAILABLE", get: (row) => ago(row.unavailableAt) },
+          { header: "OUTCOME", get: (row) => row.outcome },
+          { header: "WHY", get: (row) => (row.reason ?? "").slice(0, 44) || "-" },
+        ],
+        "nothing matched",
+      );
+
+      kv({
+        matched,
+        pages,
+        [opts.apply === true ? "queued" : "wouldQueue"]: acted,
+        skipped,
+        ...(afterId ? { nextAfterId: afterId } : {}),
+      });
+      ok(
+        opts.apply === true
+          ? `queued ${acted} re-card(s)${skipped > 0 ? `, skipped ${skipped}` : ""}; ` +
+              "core-uploader drains the UNAVAILABLE queue at MangaDex's pace"
+          : `would queue ${acted} re-card(s) of ${matched} matching` +
+              (afterId ? " in the first page alone" : "") +
+              `${skipped > 0 ? `, skipping ${skipped}` : ""}; re-run with --apply to queue`,
+      );
+    },
+  );
+
 // ---- extension config (the database replacement for override_options.json) ----
 const extConfig = program
   .command("ext-config")

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -8641,14 +8641,29 @@ VIEWS.system = (route) => {
  * goes rather than timing out behind a spinner.
  */
 function unavailableCardsPanel() {
-  const target = { mode: "all", id: "", running: false, cancel: false };
+  const target = { mode: "all", id: "", series: "", seriesName: "", running: false, cancel: false };
   const selected = new Set();
   const filters = { extension: "", language: "", search: "" };
   const cursors = [];
 
+  /** The filter, as the query string both listings and the sweep body share. */
+  const activeFilter = () => {
+    const filter = {};
+    if (filters.extension) filter.extension = filters.extension;
+    if (filters.language) filter.language = filters.language;
+    return filter;
+  };
+
   const extensions = new Resource("recard-extensions", () =>
     api("/chapters/extensions?archive=unavailable"),
   );
+  const seriesList = new Resource("recard-series", () => {
+    const q = new URLSearchParams({ archive: "unavailable", limit: "100" });
+    if (filters.extension) q.set("extension", filters.extension);
+    if (filters.language) q.set("language", filters.language);
+    if (filters.search) q.set("search", filters.search);
+    return api(`/chapters/series?${q}`);
+  });
   const listing = new Resource("recard-listing", () => {
     const q = new URLSearchParams({ archive: "unavailable", limit: "50" });
     if (filters.extension) q.set("extension", filters.extension);
@@ -8678,9 +8693,14 @@ function unavailableCardsPanel() {
     if (target.mode === "selected") {
       return selected.size ? { ids: [...selected] } : null;
     }
-    const filter = {};
-    if (filters.extension) filter.extension = filters.extension;
-    if (filters.language) filter.language = filters.language;
+    if (target.mode === "series") {
+      const id = target.series.trim();
+      // Extension and language ride along when they are set, because the list
+      // this title was picked out of was narrowed by them: a sweep wider than
+      // the list it was chosen from would act on chapters never shown.
+      return id ? { filter: { ...activeFilter(), mdMangaId: id } } : null;
+    }
+    const filter = activeFilter();
     if (filters.search) filter.search = filters.search;
     return { filter };
   };
@@ -8701,6 +8721,19 @@ function unavailableCardsPanel() {
     progress.textContent = text;
   };
 
+  /**
+   * The filter changed, so every listing that was narrowed by it is stale and
+   * every selection made under it may no longer be shown. Reloading only the
+   * mounted list keeps a mode switch from paying for the other one's fetch.
+   */
+  const refilter = () => {
+    cursors.length = 0;
+    selected.clear();
+    if (target.mode === "selected") void listing.load({ force: true });
+    if (target.mode === "series") void seriesList.load({ force: true });
+    redraw();
+  };
+
   const runPreview = async (button) => {
     if (!bodyFor()) {
       say("Nothing is targeted yet.", true);
@@ -8710,10 +8743,10 @@ function unavailableCardsPanel() {
     if (!result) return;
     setChildren(preview, recardPreview(result, target.mode));
     say(
-      target.mode === "all"
+      target.mode === "all" || target.mode === "series"
         ? `${result.matched} unavailable chapter(s) match; this sweep would queue ${result.wouldQueue} ` +
             `in the first pass of ${result.resolved}` +
-            (result.nextAfterId ? ", and keep going until the archive is exhausted." : ".")
+            (result.nextAfterId ? ", and keep going until every one has been reached." : ".")
         : `${result.wouldQueue} of ${result.resolved} chapter(s) would be queued.`,
     );
   };
@@ -8738,7 +8771,9 @@ function unavailableCardsPanel() {
     const scope =
       mode === "all"
         ? "every unavailable chapter matching the filter"
-        : `${body.ids.length} chapter(s)`;
+        : mode === "series"
+          ? `every unavailable chapter of ${target.seriesName || target.series}`
+          : `${body.ids.length} chapter(s)`;
     if (
       !(await confirmDialog({
         title: "Re-post these card images",
@@ -8795,11 +8830,14 @@ function unavailableCardsPanel() {
       redraw();
     }
     if (mode === "selected") void listing.load({ force: true });
+    if (mode === "series") void seriesList.load({ force: true });
   };
 
-  /** The picker, only mounted for the two targets that name chapters. */
+  /** The picker, only mounted for the targets that name something. */
   const picker = () =>
-    target.mode === "selected"
+    target.mode === "series"
+      ? seriesPicker()
+      : target.mode === "selected"
       ? live(
           [listing],
           (data) => {
@@ -8874,10 +8912,7 @@ function unavailableCardsPanel() {
                 id: "recard-extension",
                 onchange: (event) => {
                   filters.extension = event.target.value;
-                  cursors.length = 0;
-                  selected.clear();
-                  void listing.load({ force: true });
-                  redraw();
+                  refilter();
                 },
               },
               el("option", { value: "", text: "all", selected: filters.extension === "" }),
@@ -8901,10 +8936,7 @@ function unavailableCardsPanel() {
           placeholder: "title, name, or any id",
           onchange: (event) => {
             filters.search = event.target.value;
-            cursors.length = 0;
-            selected.clear();
-            void listing.load({ force: true });
-            redraw();
+            refilter();
           },
         }),
       ]),
@@ -8917,10 +8949,7 @@ function unavailableCardsPanel() {
           placeholder: "e.g. en",
           onchange: (event) => {
             filters.language = event.target.value;
-            cursors.length = 0;
-            selected.clear();
-            void listing.load({ force: true });
-            redraw();
+            refilter();
           },
         }),
       ]),
@@ -8944,6 +8973,7 @@ function unavailableCardsPanel() {
           say("");
           redraw();
           if (mode === "selected") void listing.load();
+          if (mode === "series") void seriesList.load();
         },
       }),
       ` ${label}`,
@@ -8968,6 +8998,85 @@ function unavailableCardsPanel() {
     cardImage.hidden = !id;
     if (id) cardImage.src = previewSrc(id, note.value.trim());
   };
+
+  /**
+   * The series target: a title picked out of the archive, or an id pasted in.
+   *
+   * Both, because the two ways an operator arrives here are different. Somebody
+   * reports that one title's cards are wrong and the id is in the URL they were
+   * sent; or a renderer fix landed and the question is which titles carry the
+   * most stale cards, which is what the list answers and no id in hand can.
+   */
+  const seriesField = () =>
+    target.mode === "series"
+      ? el(
+          "div",
+          {},
+          el("label", { for: "recard-series-id", text: "MangaDex title id" }),
+          el("input", {
+            id: "recard-series-id",
+            type: "text",
+            value: target.series,
+            placeholder: "paste it from the title URL, or pick one below",
+            oninput: (event) => {
+              target.series = event.target.value;
+              target.seriesName = "";
+              redrawButtons();
+            },
+          }),
+          el("p", {
+            class: "dim small",
+            text:
+              "Every chapter of this title in the unavailable archive gets a fresh card, " +
+              "narrowed by the filter below where one is set.",
+          }),
+        )
+      : el("span", {});
+
+  const seriesPicker = () =>
+    live(
+      [seriesList],
+      (data) => {
+        const rows = data.series ?? [];
+        return el(
+          "div",
+          {},
+          el("div", { class: "row" }, [
+            el("span", {
+              class: "dim small",
+              text: target.series
+                ? `Targeting ${target.seriesName || target.series}`
+                : `${rows.length} title(s) with cards up${data.capped ? ", the largest shown" : ""}`,
+            }),
+          ]),
+          table(
+            ["", "Series", "Cards up", "Extension", "Most recent"],
+            rows.map((entry) => [
+              el("input", {
+                type: "radio",
+                name: "recard-series-pick",
+                checked: target.series.trim() === entry.mdMangaId,
+                "aria-label": `Target ${entry.mangaName ?? entry.mdMangaId}`,
+                onchange: (event) => {
+                  if (!event.target.checked) return;
+                  target.series = entry.mdMangaId;
+                  target.seriesName = entry.mangaName ?? "";
+                  setChildren(preview);
+                  say("");
+                  redraw();
+                },
+              }),
+              truncate(entry.mangaName || entry.mdMangaId, 40),
+              String(entry.count),
+              (entry.extensions ?? []).map((name) => name || "(unattributed)").join(", ") || "-",
+              fmtTime(entry.at),
+            ]),
+            { empty: "No title in the unavailable archive matches this filter." },
+          ),
+        );
+      },
+      { reserve: 300, skeleton: () => skeletonTable(5, 6) },
+    );
 
   const oneChapterField = () =>
     target.mode === "one"
@@ -9012,7 +9121,12 @@ function unavailableCardsPanel() {
       }),
       gatedButton("chapters:write", {
         class: "primary",
-        text: target.mode === "all" ? "Re-post every card…" : "Re-post these cards…",
+        text:
+          target.mode === "all"
+            ? "Re-post every card…"
+            : target.mode === "series"
+              ? "Re-post this series' cards…"
+              : "Re-post these cards…",
         disabled: !ready,
         onclick: () => runApply(),
       }),
@@ -9033,6 +9147,7 @@ function unavailableCardsPanel() {
     setChildren(
       modes,
       oneChapterField(),
+      seriesField(),
       target.mode === "one" ? el("span", {}) : filterRow(),
       picker(),
     );
@@ -9064,6 +9179,7 @@ function unavailableCardsPanel() {
         "div",
         { class: "row" },
         modeRadio("all", "Every unavailable chapter", "optionally narrowed by the filter below"),
+        modeRadio("series", "One series", "every card this title has up"),
         modeRadio("selected", "Pick from the archive", "tick the ones to re-post"),
         modeRadio("one", "One chapter", "by MangaDex chapter id"),
       ),
@@ -9098,7 +9214,7 @@ function recardPreview(result, mode) {
       ? el("p", {
           class: "dim small",
           text:
-            mode === "all"
+            mode === "all" || mode === "series"
               ? "More chapters remain after this page; the sweep continues automatically until none do."
               : "More chapters remain after this page.",
         })

--- a/src/core/api/routes/chapters.ts
+++ b/src/core/api/routes/chapters.ts
@@ -69,6 +69,9 @@ const MAX_PROJECTION_PAGE = 500;
 /** Titles shown in a run's per-series breakdown. */
 const MANGA_BREAKDOWN_LIMIT = 200;
 
+/** Titles one `/chapters/series` answer carries. */
+const SERIES_LIMIT = 500;
+
 /**
  * Hard ceiling on one bulk action. Lower than the 1000 routes/queues.ts allows,
  * because that cap bounds a change to queue rows and this one bounds a change to
@@ -634,6 +637,53 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
           req.query ?? {},
         );
         return { archive, extensions: await ctx.chapters.byExtension(archive) };
+      },
+    );
+
+    /**
+     * The series present in one archive, most-affected first.
+     *
+     * The counterpart to `/chapters/extensions`, for the axis an operator
+     * actually arrives on when one title is wrong: "this series' cards are
+     * stale" is the shape of the complaint, and a series-scoped re-card is the
+     * answer to it. Answering here rather than by paging `/chapters` is the
+     * difference between reading one row and reading every chapter of a title
+     * to count them.
+     */
+    scope.get(
+      "/api/v1/admin/chapters/series",
+      { preHandler: requireScope("chapters:read") },
+      async (req) => {
+        const query = parseOrThrow(
+          z
+            .object({
+              archive: z.enum(CHAPTER_ARCHIVES).default("uploaded"),
+              extension: z.string().max(64).optional(),
+              language: z.string().max(16).optional(),
+              search: z.string().min(1).max(256).optional(),
+              limit: z.coerce.number().int().min(1).max(SERIES_LIMIT).default(100),
+            })
+            .strict(),
+          req.query ?? {},
+        );
+        const series = await ctx.chapters.bySeries(
+          query.archive,
+          {
+            extension: query.extension,
+            chapterLanguage: query.language,
+            search: query.search,
+          },
+          query.limit,
+        );
+        return {
+          archive: query.archive,
+          series,
+          limit: query.limit,
+          // A `LIMIT`, not a page: the ordering is by count, so the caller's
+          // next move when this is true is to narrow the search rather than to
+          // walk a tail that is by construction the least interesting end.
+          capped: series.length === query.limit,
+        };
       },
     );
 

--- a/src/core/store/chapters.ts
+++ b/src/core/store/chapters.ts
@@ -98,6 +98,19 @@ export function decodeChapterCursor(raw: string): ChapterCursor | null {
   return { at: when, id };
 }
 
+/**
+ * One title's footprint in an archive: what a series-scoped action would cover.
+ */
+export interface SeriesGroup {
+  mdMangaId: string;
+  mangaName: string | null;
+  /** Every extension that put a chapter of this title into the archive. */
+  extensions: string[];
+  count: number;
+  /** The most recent instant of the archive, for this title. */
+  at: Date;
+}
+
 /** Where a MangaDex chapter id appears across the four tables. */
 export interface ChapterHistory {
   uploaded: ChapterRow | null;
@@ -300,6 +313,53 @@ export class ChapterStore {
     // (the column is NOT NULL there); the other three tables allow NULL. Both
     // mean the same thing to a reader, so both surface as "".
     return rows.map((row) => ({ extension: row.extension ?? "", count: Number(row.count) }));
+  }
+
+  /**
+   * The series present in one archive, most-affected first.
+   *
+   * The per-extension breakdown answers "who uploaded this?"; this answers "what
+   * is this about?", which is the question an operator arrives with when one
+   * title is wrong and the rest of the archive is fine. Grouping happens here
+   * rather than in the caller because the set is a page of a table with tens of
+   * thousands of rows in it, and paging a listing until every chapter of one
+   * title has been seen is not a way to learn how many there are.
+   *
+   * A row whose `md_manga_id` is NULL cannot be targeted by a series filter, so
+   * it is left out entirely rather than offered as a group nothing can act on.
+   */
+  async bySeries(
+    archive: ChapterArchive,
+    filter: ChapterFilter = {},
+    limit = 100,
+  ): Promise<SeriesGroup[]> {
+    const spec = ARCHIVES[archive];
+    const parts = chapterWhere(filter, spec);
+    parts.push(Prisma.sql`c.md_manga_id IS NOT NULL AND c.md_manga_id <> ''`);
+    // The name is taken from the newest row rather than an arbitrary one: a
+    // title can have been recorded under several spellings over the years, and
+    // the one an operator will recognise is the one most recently written.
+    const rows = await this.prisma.$queryRaw<
+      { mdMangaId: string; mangaName: string | null; extensions: string[]; count: bigint; at: Date }[]
+    >(Prisma.sql`
+      SELECT c.md_manga_id AS "mdMangaId",
+             (array_agg(c.manga_name ORDER BY ${Prisma.raw(`c.${spec.instant}`)} DESC))[1] AS "mangaName",
+             array_agg(DISTINCT coalesce(c.extension, '')) AS "extensions",
+             count(*) AS count,
+             max(${Prisma.raw(`c.${spec.instant}`)}) AS at
+      FROM ${Prisma.raw(spec.table)} c
+      ${combine(parts)}
+      GROUP BY c.md_manga_id
+      ORDER BY count(*) DESC, max(${Prisma.raw(`c.${spec.instant}`)}) DESC, c.md_manga_id ASC
+      LIMIT ${limit}
+    `);
+    return rows.map((row) => ({
+      mdMangaId: row.mdMangaId,
+      mangaName: row.mangaName ?? null,
+      extensions: [...row.extensions].sort(),
+      count: Number(row.count),
+      at: row.at,
+    }));
   }
 
   /** Row counts for all four archives; the header of the Chapters view. */

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -700,6 +700,118 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
   });
 
 
+  /**
+   * The per-title breakdown of an archive.
+   *
+   * The axis a complaint actually arrives on: a reader reports that one title's
+   * pages are wrong, and the operator needs that title's id and the size of the
+   * job before deciding to do anything. Counting by paging the chapter listing
+   * would mean reading every chapter of the title to learn how many there are.
+   */
+  it("groups an archive by title, most-affected first", async () => {
+    const otherManga = uuid(901);
+    await prisma.unavailableChapter.createMany({
+      data: [
+        {
+          mdChapterId: uuid(601),
+          extension: "exampleext",
+          chapterNumber: "1",
+          chapterLanguage: "en",
+          mangaName: "Old spelling",
+          mdMangaId: uuid(900),
+          unavailableAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        {
+          mdChapterId: uuid(602),
+          extension: "otherext",
+          chapterNumber: "2",
+          chapterLanguage: "en",
+          mangaName: "Test Series",
+          mdMangaId: uuid(900),
+          unavailableAt: new Date("2026-05-05T00:00:00.000Z"),
+        },
+        {
+          mdChapterId: uuid(603),
+          extension: "exampleext",
+          chapterNumber: "3",
+          chapterLanguage: "ja",
+          mangaName: "Second Series",
+          mdMangaId: otherManga,
+          unavailableAt: new Date("2026-02-02T00:00:00.000Z"),
+        },
+        // No MangaDex title id: a series filter cannot address it, so it is not
+        // offered as a group nothing can act on.
+        {
+          mdChapterId: uuid(604),
+          extension: "exampleext",
+          chapterNumber: "4",
+          unavailableAt: new Date("2026-02-02T00:00:00.000Z"),
+        },
+      ],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters/series?archive=unavailable",
+      headers: root,
+    });
+    expect(res.statusCode).toBe(200);
+    const series = res.json().series;
+    expect(series).toHaveLength(2);
+    expect(res.json().capped).toBe(false);
+
+    // Two chapters beats one, and the name comes from the newest row: one title
+    // recorded under two spellings should read as the one an operator has seen.
+    expect(series[0]).toMatchObject({
+      mdMangaId: uuid(900),
+      mangaName: "Test Series",
+      count: 2,
+      extensions: ["exampleext", "otherext"],
+    });
+    expect(series[0].at).toBe("2026-05-05T00:00:00.000Z");
+    expect(series[1]).toMatchObject({ mdMangaId: otherManga, count: 1 });
+
+    // The same narrowing the listing takes, so the list an operator picks from
+    // and the sweep they then run cover the same rows.
+    const narrowed = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters/series?archive=unavailable&extension=otherext",
+      headers: root,
+    });
+    expect(narrowed.json().series).toEqual([
+      expect.objectContaining({ mdMangaId: uuid(900), count: 1 }),
+    ]);
+
+    const searched = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters/series?archive=unavailable&search=Second",
+      headers: root,
+    });
+    expect(searched.json().series).toEqual([
+      expect.objectContaining({ mdMangaId: otherManga, count: 1 }),
+    ]);
+
+    // A limit reached is said so, because the ordering is by count and the
+    // caller's next move is to narrow rather than to walk a tail.
+    const capped = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters/series?archive=unavailable&limit=1",
+      headers: root,
+    });
+    expect(capped.json().series).toHaveLength(1);
+    expect(capped.json().capped).toBe(true);
+  });
+
+  it("keeps the series breakdown behind the read scope", async () => {
+    const reader = await mint(["runs:read"]);
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/chapters/series?archive=unavailable",
+      headers: reader,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
   // ---- re-carding what is already unavailable ----
 
   /**
@@ -845,6 +957,63 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
       expect(res.json().queued).toBe(1);
       const tasks = await prisma.uploadTask.findMany({ where: { kind: "UNAVAILABLE" } });
       expect(tasks.map((t) => t.dedupeKey)).toEqual([mine.mdChapterId]);
+    });
+
+    /**
+     * The whole point of the series target: one title's cards, all of them,
+     * and nothing belonging to another title.
+     */
+    it("re-cards one title and leaves every other title alone", async () => {
+      const otherManga = uuid(902);
+      const mine = [
+        await carded({ chapterNumber: "1" }),
+        await carded({ chapterNumber: "2" }),
+      ];
+      const theirs = await carded({ mdMangaId: otherManga, mangaName: "Somebody Else" });
+
+      const preview = await recard({ filter: { mdMangaId: uuid(900) } });
+      expect(preview.json().matched).toBe(2);
+      expect(preview.json().wouldQueue).toBe(2);
+      expect(await prisma.uploadTask.count()).toBe(0);
+
+      const res = await recard({
+        filter: { mdMangaId: uuid(900) },
+        dryRun: false,
+        confirm: true,
+      });
+      expect(res.json().queued).toBe(2);
+      const tasks = await prisma.uploadTask.findMany({ where: { kind: "UNAVAILABLE" } });
+      expect(tasks.map((t) => t.dedupeKey).sort()).toEqual(mine.map((c) => c.mdChapterId).sort());
+      expect(tasks.map((t) => t.dedupeKey)).not.toContain(theirs.mdChapterId);
+    });
+
+    it("sweeps a title bigger than one page to the end", async () => {
+      const chapters = [];
+      for (let i = 0; i < 4; i += 1) chapters.push(await carded({ chapterNumber: String(i) }));
+      await carded({ mdMangaId: uuid(903) });
+
+      const seen: string[] = [];
+      let afterId: string | null = null;
+      for (let page = 0; page < 10; page += 1) {
+        const res = await recard({
+          filter: { mdMangaId: uuid(900) },
+          dryRun: false,
+          confirm: true,
+          batch: 2,
+          ...(afterId ? { afterId } : {}),
+        });
+        expect(res.statusCode).toBe(200);
+        // The count is the title's, not the archive's: the number an operator
+        // watches to know the title is done.
+        expect(res.json().matched).toBe(4);
+        for (const item of res.json().results) seen.push(item.mdChapterId);
+        afterId = res.json().nextAfterId;
+        if (!afterId) break;
+      }
+      expect(afterId).toBeNull();
+      expect(seen.sort()).toEqual(chapters.map((c) => c.mdChapterId).sort());
+      // The other title's chapter was never in the sweep.
+      expect(await prisma.uploadTask.count({ where: { kind: "UNAVAILABLE" } })).toBe(4);
     });
 
     it("refuses chapters that have no card to replace, one by one", async () => {

--- a/test/unit/botCommands.test.ts
+++ b/test/unit/botCommands.test.ts
@@ -1054,3 +1054,92 @@ describe("retired pointers stay accurate as endpoints land", () => {
     expect(reply.text).toContain("/queue cancel");
   });
 });
+
+
+/**
+ * `/recard`: the half of a re-card the bot can actually do.
+ *
+ * Queuing card images is closed to api tokens at the endpoint, so the command
+ * reports and hands over a command line rather than pretending it can act. The
+ * property worth holding is that it never hands over a command line aimed at a
+ * title nobody chose.
+ */
+describe("recard", () => {
+  const series = (over: Record<string, unknown> = {}) => ({
+    mdMangaId: "9a1b1c1d-0000-4000-8000-000000000000",
+    mangaName: "Sakamoto Days",
+    extensions: ["mangaplus"],
+    count: 12,
+    at: "2026-03-04T05:06:07.000Z",
+    ...over,
+  });
+
+  it("names the title, the size of the job, and how to run it", async () => {
+    const archiveSeries = vi.fn().mockResolvedValue({
+      archive: "unavailable",
+      series: [series()],
+      limit: 5,
+      capped: false,
+    });
+    const reply = await invoke("recard", fakeApi({ archiveSeries }), { series: "sakamoto" });
+
+    expect(archiveSeries).toHaveBeenCalledWith("discord:ardax", {
+      archive: "unavailable",
+      search: "sakamoto",
+      extension: undefined,
+      limit: 5,
+    });
+    expect(reply.text).toContain("Sakamoto Days");
+    expect(reply.text).toContain("12");
+    expect(reply.text).toContain(
+      "padmin chapters recard --series 9a1b1c1d-0000-4000-8000-000000000000 --apply",
+    );
+    // Said plainly rather than discovered as a 403 after the fact.
+    expect(reply.text).toContain("cannot post card images");
+  });
+
+  it("shortlists rather than guessing when a name matches several titles", async () => {
+    const archiveSeries = vi.fn().mockResolvedValue({
+      archive: "unavailable",
+      series: [series(), series({ mdMangaId: "other-id", mangaName: "Sakamoto Days Gaiden", count: 3 })],
+      limit: 5,
+      capped: false,
+    });
+    const reply = await invoke("recard", fakeApi({ archiveSeries }), { series: "sakamoto" });
+
+    expect(reply.text).toContain("Sakamoto Days Gaiden");
+    // No command line: running one against the wrong title is the failure this
+    // shortlist exists to prevent.
+    expect(reply.text).not.toContain("--apply");
+    expect(reply.text).toContain("Name one of them");
+  });
+
+  it("carries the extension into the command line it hands over", async () => {
+    const archiveSeries = vi.fn().mockResolvedValue({
+      archive: "unavailable",
+      series: [series()],
+      limit: 5,
+      capped: false,
+    });
+    const reply = await invoke("recard", fakeApi({ archiveSeries }), {
+      series: "sakamoto",
+      extension: "mangaplus",
+    });
+    expect(reply.text).toContain("--extension mangaplus --apply");
+  });
+
+  it("says so when nothing is carded at all", async () => {
+    const archiveSeries = vi.fn().mockResolvedValue({
+      archive: "unavailable",
+      series: [],
+      limit: 10,
+      capped: false,
+    });
+    const reply = await invoke("recard", fakeApi({ archiveSeries }), {});
+    expect(reply.text).toContain("no card to re-post");
+  });
+
+  it("stays a read command; it has no write to gate", () => {
+    expect(resolveSensitivity(COMMANDS_BY_NAME.get("recard")!, null)).toBe("read");
+  });
+});

--- a/test/unit/dashboardChapters.test.ts
+++ b/test/unit/dashboardChapters.test.ts
@@ -181,6 +181,23 @@ function apiRoutes(): { match: RegExp; body: unknown | ((init?: { body?: string 
     },
     { match: /\/chapters\/extensions/, body: { table: "uploaded", extensions: [{ extension: "mangaplus", count: 902 }] } },
     {
+      match: /\/chapters\/series/,
+      body: {
+        archive: "unavailable",
+        limit: 100,
+        capped: false,
+        series: [
+          {
+            mdMangaId: MD_MANGA,
+            mangaName: "Sakamoto Days",
+            extensions: ["mangaplus"],
+            count: 12,
+            at: "2026-03-04T05:06:07Z",
+          },
+        ],
+      },
+    },
+    {
       // Answers from the request, because the property under test is that the
       // panel keeps calling while a continuation comes back.
       match: /\/chapters\/unavailable\/recard/,
@@ -502,11 +519,12 @@ describe("dashboard chapter views", () => {
     const recardCalls = () =>
       win.fetch.mock.calls.filter(([url]: [string]) => String(url).includes("/unavailable/recard"));
 
-    it("offers the three targets and previews the whole archive by default", async () => {
+    it("offers the four targets and previews the whole archive by default", async () => {
       await goto("#/system/cards");
       const view = text();
       expect(view).toContain("Re-post unavailable card images");
       expect(view).toContain("Every unavailable chapter");
+      expect(view).toContain("One series");
       expect(view).toContain("Pick from the archive");
       expect(view).toContain("One chapter");
 
@@ -578,6 +596,98 @@ describe("dashboard chapter views", () => {
       await settle();
       expect(JSON.parse(recardCalls()[0][1].body)).toEqual({
         ids: [MD_CHAPTER],
+        dryRun: true,
+      });
+    });
+
+    /**
+     * The series target, which is the one somebody reaches for after a reader
+     * reports that a title's pages are wrong.
+     *
+     * It is a filter sweep, not an id list: a title with four hundred chapters
+     * is more than one page, so it has to page like the whole-archive target
+     * and not like the picker.
+     */
+    const pickSeriesMode = async (): Promise<void> => {
+      doc.getElementById("recard-mode-series").checked = true;
+      doc.getElementById("recard-mode-series").dispatchEvent(new win.Event("change"));
+      await settle();
+    };
+
+    it("lists the titles with cards up, largest first", async () => {
+      await goto("#/system/cards");
+      await pickSeriesMode();
+      expect(requested.some((path) => path.includes("/chapters/series?"))).toBe(true);
+      expect(requested.some((path) => path.includes("archive=unavailable"))).toBe(true);
+      const view = text();
+      expect(view).toContain("Sakamoto Days");
+      // The count is the reason to pick this title over another one.
+      expect(view).toContain("12");
+    });
+
+    it("re-cards one title picked out of that list", async () => {
+      await goto("#/system/cards");
+      await pickSeriesMode();
+
+      const pick = doc.querySelector('#view input[type="radio"][name="recard-series-pick"]');
+      pick.checked = true;
+      pick.dispatchEvent(new win.Event("change"));
+      await settle();
+
+      click("Preview");
+      await settle();
+      expect(JSON.parse(recardCalls()[0][1].body)).toEqual({
+        filter: { mdMangaId: MD_MANGA },
+        dryRun: true,
+      });
+    });
+
+    it("takes a title id pasted in, and sweeps it to the end", async () => {
+      await goto("#/system/cards");
+      await pickSeriesMode();
+
+      const field = doc.getElementById("recard-series-id");
+      field.value = MD_MANGA;
+      field.dispatchEvent(new win.Event("input"));
+      await settle();
+
+      click("Re-post this series' cards…");
+      await settle();
+      click("Queue the re-cards");
+      await settle(20);
+
+      const live = recardCalls().filter(
+        ([, init]: [string, { body: string }]) => JSON.parse(init.body).dryRun === false,
+      );
+      // Same two-page continuation as the whole-archive sweep: a series is a
+      // filter, so stopping at the first page would leave the title half done.
+      expect(live).toHaveLength(2);
+      expect(JSON.parse(live[0][1].body)).toEqual({
+        filter: { mdMangaId: MD_MANGA },
+        dryRun: false,
+        confirm: true,
+      });
+      expect(JSON.parse(live[1][1].body).afterId).toBe("row-4");
+    });
+
+    it("carries the extension filter into the series sweep it was chosen under", async () => {
+      await goto("#/system/cards");
+      await pickSeriesMode();
+
+      const picker = doc.getElementById("recard-extension");
+      picker.value = "mangaplus";
+      picker.dispatchEvent(new win.Event("change"));
+      await settle();
+
+      const field = doc.getElementById("recard-series-id");
+      field.value = MD_MANGA;
+      field.dispatchEvent(new win.Event("input"));
+      await settle();
+
+      click("Preview");
+      await settle();
+      expect(JSON.parse(recardCalls()[0][1].body)).toEqual({
+        filter: { extension: "mangaplus", mdMangaId: MD_MANGA },
         dryRun: true,
       });
     });


### PR DESCRIPTION
Two commits, both about doing something to one series instead of the whole catalogue.

### 1. Re-card the unavailable cards of one series

The re-card route's filter already took `mdMangaId`; nothing asked for it. Adds `GET /chapters/series` (the titles in an archive, most-affected first), a **One series** target in the dashboard panel, `padmin chapters series` / `padmin chapters recard --series`, and `/recard` in Discord.

### 2. Ask the publisher whether one series is still there

Re-carding re-renders the page of a chapter *already known* to be gone. Nothing asked whether it is gone: removals are noticed by runs, and a run only visits series that reported an update, so a series quiet for a year can lose its back catalogue silently. The only lever was a full CLEAN re-scrape of the whole extension.

`POST /chapters/series/:mdMangaId/recheck` starts a **run** rather than building a second path to the publisher — dedupe, override options, language rules and the removal pass are the most delicate logic here and a second copy would be a worse one. The run is CLEAN (how the contract asks for `allChapters`, the only thing removal detection can be computed from) and is one job whose `segmentMangaIds` is the series' external id.

**The load-bearing part is `runs.scope_manga_ids`.** `removeMangaWithoutExternalChapters` walks every tracked title absent from the snapshot and queues its chapters for removal — correct for a run that claimed to cover everything, and for a one-series run it unpublishes the entire rest of the catalogue. Empty scope keeps the old claim ("this is everything the publisher has"); non-empty means "everything for these titles, and nothing about the rest". The processor then:

- skips both catalogue-wide removal passes and keeps duplicate detection inside the scope;
- **visits the scope even where it reported no updates** — not an edge case but the common one, since a dormant series is exactly what you re-check;
- does not announce a run summary ("no updates from mangaplus" is a claim about the extension's sweep, which an operator probing one series has not made).

Refusals: a title two extensions publish, with neither named (409, listing them); a title whose external id lives in a named catalogue (409 — a manga subset travels as a bare id, the same limit the scheduler already declines to partition around). Gated as a run, not a chapter write, so the bot can do this one.

The dry run names the extension, the MangaDex holdings, how many already carry a card (never candidates), and **whether the extension has sent a full listing recently at all** — one that reports only its updates can never say something is missing, and a re-check against it will honestly find nothing.

### Testing

- `pnpm test` — **793** unit tests pass (17 new). `lint`, `typecheck`, `build` clean. CLI verified against the built binary.
- **Integration tests are written but were not run**: no postgres and no docker daemon on the build machine, so `test/integration` skipped. Please run before merge.
- `test/integration/scopedRun.test.ts` is new and is the one that matters: it drives the real `RunProcessor` and pins the scope guard **with its control** — the same envelope, unscoped, still unpublishes the absent title, so the guard test cannot quietly stop proving anything.
- `test/integration/chapters.test.ts` covers the endpoint's refusals, the dry run, and the exact shape of the run it creates.

### Migration

`20260825000000_run_scope_manga_ids` adds one column, defaulted, backfill-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETLnonwjNbmrQ44hCSEeKm
