### PR TITLE
Let the forced re-card test see the stale-session sweep

### DIFF
--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -1184,7 +1184,13 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
         mangaById: unexpected("mangaById"),
         searchManga: unexpected("searchManga"),
         mangaAggregate: unexpected("mangaAggregate"),
-        currentUploadSession: unexpected("currentUploadSession"),
+        // The uploader clears any stale session before opening an edit one;
+        // nothing is left over here, so this is the answer production gets on a
+        // clean account.
+        currentUploadSession: async () => {
+          calls.push("currentUploadSession");
+          return null;
+        },
         deleteUploadSession: async () => {
           calls.push("deleteUploadSession");
         },


### PR DESCRIPTION
`master` has been red since #44 landed the stale-upload-session guard, and every open PR inherits the failure:

```
FAIL test/integration/chapters.test.ts > chapter management endpoints
  > the uploader executing a regeneration
  > renders and posts a fresh card when the operator forces it
Error: the uploader should not call currentUploadSession in this test
 ❯ UploadTaskWorkers.runUnavailable src/core/md/taskWorkers.ts:478:36
```

`runUnavailable` sweeps away a leftover upload session before opening an edit one — MangaDex allows a single open session per account, and a task killed between opening and deleting leaves one that rejects every later begin, edit or upload. That guard is the behaviour we want.

The stub in `chapters.test.ts` was the stale half: it still listed `currentUploadSession` among the calls the uploader must never make, so the forced path threw the moment it reached the sweep. It now answers the way a clean account does — no open session — and records the call. The sibling test (`archives without touching MangaDex when the card is already posted`) returns early and never reaches the sweep, so its exact-call assertion is unchanged.

Verified locally: `pnpm run typecheck` and `eslint` clean. Integration tests need a real PostgreSQL, so CI on this PR is the check that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHK1eAcCwBMJA97e9rxwPo