### PR TITLE
Ship the card's fonts in the runtime image, and audit automated removals

### DIFF
--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -213,6 +213,23 @@ COPY --chown=root:root docs ./docs
 # Fail here rather than serving an empty docs list in production.
 RUN test -n "$(ls -A ./docs 2>/dev/null)" || (echo "no docs/ in the runtime image" >&2; exit 1)
 
+# The fonts the unavailable-chapter card is drawn with (core/md/fonts.ts).
+#
+# They are vendored precisely so a card looks the same whatever the host has
+# installed, and that guarantee is only worth anything if they reach the runtime
+# image. Without this the renderer finds no vendored directory, silently falls
+# back to whatever fontconfig offers, and draws the card in a different typeface
+# than the one its layout was measured against.
+#
+# fonts.ts locates this by walking up from its own module, so /app/assets/fonts
+# is what it finds from /app/dist/src/core/md (PUBLOADER_FONT_DIR overrides it).
+COPY --chown=root:root assets ./assets
+# Fail here rather than drawing every card in a substitute face. Unlike docs,
+# this one is not cosmetic: the card replaces the chapter itself on a public
+# catalogue.
+RUN test -n "$(ls -A ./assets/fonts 2>/dev/null)" \
+    || (echo "no assets/fonts in the runtime image" >&2; exit 1)
+
 # Everything is owned by root and only readable by the service account: the
 # process can execute its own code but cannot rewrite it, which is what makes
 # `read_only: true` in compose meaningful rather than decorative.

--- a/src/core/api/routes/admin.ts
+++ b/src/core/api/routes/admin.ts
@@ -954,6 +954,105 @@ export function registerAdminRoutes(app: FastifyInstance, ctx: AppContext): void
     });
 
     /**
+     * Put skipped series back in the queue.
+     *
+     * Skipping was a one-way door: `approve` refuses anything that is not NEW
+     * or FAILED, the CLI's `--state` only filters a listing, and nothing else
+     * writes the column. A series parked by mistake — or one skipped while its
+     * publisher was misbehaving, which is the common case — could only be
+     * recovered by editing the database by hand.
+     *
+     * Rows whose series is ALREADY TRACKED are reported rather than reset. A
+     * skipped row goes stale the moment someone maps that series manually, and
+     * moving it back to NEW would have the title service create a second
+     * MangaDex entry for a series that already has one. That has already
+     * happened once here by a different route, and cleaning it up meant
+     * deleting chapters off a live title.
+     */
+    scope.post("/api/v1/admin/untracked/unskip", { preHandler: requireScope("untracked:write") }, async (req) => {
+      const body = z
+        .object({
+          ids: z.array(z.string().uuid()).max(500).optional(),
+          extension: z.string().max(64).optional(),
+          dryRun: z.boolean().default(true),
+        })
+        .strict()
+        .parse(req.body ?? {});
+
+      const candidates = await ctx.prisma.untrackedManga.findMany({
+        where: {
+          state: "SKIPPED",
+          ...(body.ids ? { id: { in: body.ids } } : {}),
+          ...(body.extension ? { extension: body.extension } : {}),
+        },
+      });
+
+      // One query rather than per row: the tracked map is the authority on
+      // whether a series already has a MangaDex title, and it is what makes
+      // "already tracked" answerable without asking MangaDex.
+      const tracked = await ctx.prisma.trackedManga.findMany({
+        where: { mangaId: { in: candidates.map((row) => row.mangaId) } },
+        select: { extension: true, mangaId: true, mdMangaId: true },
+      });
+      const trackedBy = new Map(tracked.map((row) => [`${row.extension}:${row.mangaId}`, row.mdMangaId]));
+
+      const requeue: typeof candidates = [];
+      const alreadyTracked: { id: string; mangaId: string; mangaName: string; mdMangaId: string }[] = [];
+      for (const row of candidates) {
+        const mdMangaId = trackedBy.get(`${row.extension}:${row.mangaId}`);
+        if (mdMangaId) {
+          alreadyTracked.push({
+            id: row.id,
+            mangaId: row.mangaId,
+            mangaName: row.mangaName,
+            mdMangaId,
+          });
+        } else {
+          requeue.push(row);
+        }
+      }
+
+      const summary = {
+        matched: candidates.length,
+        requeued: requeue.length,
+        alreadyTracked,
+        series: requeue.map((row) => ({
+          id: row.id,
+          extension: row.extension,
+          mangaId: row.mangaId,
+          mangaName: row.mangaName,
+          mangaLanguage: row.mangaLanguage,
+        })),
+      };
+
+      if (body.dryRun) {
+        return {
+          ok: true,
+          dryRun: true,
+          ...summary,
+          note: "nothing was changed. Repeat with {dryRun: false} to move these back to NEW",
+        };
+      }
+
+      // Back to NEW with a fresh budget: a row skipped after a failure kept its
+      // attempt count, and re-queueing it with the budget already spent would
+      // fail it again on the first try.
+      const updated = await ctx.prisma.untrackedManga.updateMany({
+        where: { id: { in: requeue.map((row) => row.id) }, state: "SKIPPED" },
+        data: { state: "NEW", attempts: 0, lastError: null },
+      });
+      await ctx.audit.recordMany(
+        requeue.map((row) => ({
+          actor: actor(req),
+          action: "untracked.unskip",
+          subject: row.id,
+          detail: { extension: row.extension, mangaId: row.mangaId, mangaName: row.mangaName },
+        })),
+      );
+      return { ok: true, dryRun: false, ...summary, updated: updated.count };
+    });
+
+    /**
      * Yank a bundle version. `latest()` then resolves to the previous non-yanked
      * version, so this rolls back a bad extension release without touching the
      * core or deleting anything. Jobs already pinned to the yanked sha keep

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -13,10 +13,10 @@ import {
   updatesEmbeds,
   type UntrackedMangaLike,
 } from "../md/webhookEmbeds.js";
-import { chapterFromRecord, type Chapter, type MdApi, type MdChapter } from "../md/types.js";
+import { chapterFromRecord, uploaderId, type Chapter, type MdApi, type MdChapter } from "../md/types.js";
 import { ExtensionConfigStore } from "../store/extensionConfig.js";
 import { ResultStore } from "../store/results.js";
-import { SettingsStore, type RemovalMode } from "../store/settings.js";
+import { AuditLog, SettingsStore, type RemovalMode } from "../store/settings.js";
 import { UploadTaskStore, uploadDedupeKey } from "../store/uploadTasks.js";
 import {
   aggregateChapterIds,
@@ -58,6 +58,22 @@ interface ClaimedRun {
    */
   scopeMangaIds: string[];
 }
+
+/**
+ * Which pass decided a removal.
+ *
+ * Recorded on every audited removal because the passes fail in different ways
+ * and the distinction is invisible afterwards: `duplicates` hard-deletes
+ * whatever the removal mode, `no-longer-listed` acts on the publisher's
+ * catalogue, and the two untracked passes act on a series leaving the tracked
+ * map entirely. "132 chapters were deleted" is not an answerable complaint
+ * without it.
+ */
+export type RemovalPass =
+  | "no-longer-listed"
+  | "duplicates"
+  | "manga-untracked"
+  | "manga-without-external-chapters";
 
 export interface MergedResults {
   updatedChapters: Chapter[];
@@ -117,6 +133,7 @@ export class RunProcessor {
   private readonly maxRunsPerTick: number;
   private readonly notifier: { enabled: boolean; send(embeds: DiscordEmbedInput[]): Promise<void> } | null;
   private readonly botUserId: string | null;
+  private readonly audit: AuditLog;
 
   constructor(
     private readonly prisma: PrismaClient,
@@ -128,6 +145,7 @@ export class RunProcessor {
     this.tasks = new UploadTaskStore(prisma);
     this.settings = new SettingsStore(prisma);
     this.config = new ExtensionConfigStore(prisma);
+    this.audit = new AuditLog(prisma);
     this.maxRunsPerTick = options.maxRunsPerTick ?? 10;
     this.notifier = options.notifier ?? null;
     this.botUserId = options.botUserId ?? null;
@@ -436,7 +454,14 @@ export class RunProcessor {
           payload: edit.payload,
         });
       }
-      await this.enqueueRemovals(decision.toRemove, mangaId, run.extension, groupId, removalMode);
+      await this.enqueueRemovals(
+        decision.toRemove,
+        mangaId,
+        run.extension,
+        groupId,
+        removalMode,
+        "no-longer-listed",
+      );
       await this.recordUploaded(
         [...decision.toEdit.map((edit) => edit.chapter), ...decision.skipped],
         run.extension,
@@ -747,6 +772,7 @@ export class RunProcessor {
     extension: string,
     groupId: string,
     mode: RemovalMode,
+    pass: RemovalPass,
   ): Promise<void> {
     if (mdChapters.length === 0) return;
     const kind: UploadTaskKind = mode === "delete" ? "DELETE" : "UNAVAILABLE";
@@ -759,6 +785,47 @@ export class RunProcessor {
         chapterFromMdChapter(mdChapter, { mdMangaId, extension, groupId, mangaName, mode }),
       );
       await this.prisma.uploadedChapter.deleteMany({ where: { mdChapterId: mdChapter.id } });
+    }
+
+    // Audited here, where the decision is made, not where the task runs.
+    //
+    // Until now only operator-initiated bulk actions wrote audit rows, so the
+    // destructive path that runs unattended was the one with no trail: 132
+    // chapters were removed in a single session with nothing recording which
+    // pass chose them, on what evidence, or who had uploaded them. After the
+    // fact that is unanswerable -- a deleted chapter 404s on MangaDex, so even
+    // its uploader cannot be recovered. One row per chapter rather than a
+    // summary, because "why was THIS chapter removed?" is the question actually
+    // asked, and it is a lookup by subject.
+    //
+    // Never allowed to fail the run: losing an audit row is bad, failing a run
+    // that has already queued its work and deleted its bookkeeping rows is
+    // worse, and would replay the removals on the next attempt.
+    try {
+      await this.audit.recordMany(
+        mdChapters.map((mdChapter) => ({
+          actor: `processor:${extension}`,
+          action: mode === "delete" ? "chapter.delete.auto" : "chapter.unavailable.auto",
+          subject: mdChapter.id,
+          detail: {
+            pass,
+            mode,
+            kind,
+            extension,
+            mdMangaId,
+            mangaName,
+            chapter: mdChapter.attributes.chapter,
+            language: mdChapter.attributes.translatedLanguage,
+            externalUrl: mdChapter.attributes.externalUrl,
+            // The question that could not be answered retrospectively when
+            // publoader was found queueing other people's chapters.
+            uploaderId: uploaderId(mdChapter),
+            botUserId: this.botUserId,
+          },
+        })),
+      );
+    } catch (error) {
+      this.log.warn({ error, mdMangaId, pass }, "could not write removal audit rows");
     }
   }
 
@@ -794,7 +861,14 @@ export class RunProcessor {
     let removed = 0;
     for (const mangaId of untracked) {
       const mdChapters = chaptersOnMdByManga.get(mangaId) ?? [];
-      await this.enqueueRemovals(mdChapters, mangaId, extension, groupId, mode);
+      await this.enqueueRemovals(
+        mdChapters,
+        mangaId,
+        extension,
+        groupId,
+        mode,
+        "manga-untracked",
+      );
       removed += mdChapters.length;
     }
     return removed;
@@ -821,7 +895,14 @@ export class RunProcessor {
       const mdChapters = await this.md.chaptersForManga(mangaId, groupId);
       if (mdChapters.length === 0) continue;
       await this.resolveMangaNames([mangaId]);
-      await this.enqueueRemovals(mdChapters, mangaId, extension, groupId, mode);
+      await this.enqueueRemovals(
+        mdChapters,
+        mangaId,
+        extension,
+        groupId,
+        mode,
+        "manga-without-external-chapters",
+      );
       removed += mdChapters.length;
       removedFrom.push(mangaId);
     }
@@ -877,7 +958,7 @@ export class RunProcessor {
 
       log.info({ mangaId, dupes: dupes.map((c) => c.id) }, "found duplicate chapters to delete");
       await this.resolveMangaNames([mangaId]);
-      await this.enqueueRemovals(dupes, mangaId, run.extension, groupId, "delete");
+      await this.enqueueRemovals(dupes, mangaId, run.extension, groupId, "delete", "duplicates");
       deleted += dupes.length;
     }
     return deleted;


### PR DESCRIPTION
Two follow-ups to #58. The first is required for #58's card fix to actually work in production.

## The runtime image never shipped the fonts (`ea475aa`)

`docker/core/Dockerfile` copies `src`, `prisma`, `docs` and `node_modules` — but never `assets/`. So in production `findAssetsDir()` returns null, the renderer logs "vendored font directory not found; relying on system fonts only", and draws every card in whatever fontconfig offers.

Cards would not be tofu — `fonts-noto-cjk` and friends are installed, and `assertRenderable` still guards — but they would be drawn in a substitute face, **measured against metrics from fonts that were not present**. The whole point of vendoring was that a card looks the same regardless of host, and that guarantee held in tests and was absent where it mattered.

Now copied, and guarded with a `RUN test` the same way `docs` is. Stronger reason though: a missing docs directory degrades a dashboard view, a missing font directory changes what readers see on a page that has *replaced the chapter itself*.

## Automated removals now leave a trail (`f3065a1`)

132 chapters were removed during one session with no audit entry for any of them. The only `chapter.delete` rows were five queued by hand through the bulk API — `enqueueRemovals` queued the task and deleted the bookkeeping row without recording anything, so the destructive path that runs unattended was the one with no trail.

That is why, when publoader was found queueing chapters this account never uploaded, whether it had already succeeded in deleting somebody else's work could not be settled from the record: a deleted chapter 404s on MangaDex, so even its uploader is gone with it.

Every automated removal now writes one row per chapter carrying the deciding pass, removal mode, series, chapter, external URL, uploader id, and the bot id it was compared against. The pass matters because the four fail differently and the difference is invisible afterwards — `duplicates` hard-deletes whatever the mode is set to, `no-longer-listed` acts on the publisher's catalogue, and the two untracked passes act on a series leaving the tracked map. "132 chapters were deleted" is not an answerable complaint without knowing which.

The audit write can never fail the run: losing a row is bad, failing a run that has already queued its work and deleted its bookkeeping rows is worse and would replay the removals.

## Verified in production since #58 deployed

The duplicate scan now reports **0 duplicates across 773 series / 7,822 chapters**. Before the ownership gate it queued four Youchien Wars ch 100.5 chapters uploaded by `f56aa6ad-…` — not the bot — inside our own MangaPlus group; all four failed with MangaDex `403 access_denied_http_exception`, which is what actually prevented the damage. Finding zero now is the gate excluding exactly those.

883 unit tests pass.