### PR TITLE
Check ownership where the write happens, and fix the environment-dependent font test

### DIFF
--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -8,7 +8,7 @@ import { chapterFromJson, chapterToColumns, uploadedChapterColumns } from "./cha
 import type { MdChapterDetail, MdExtendedApi } from "./client.js";
 import type { DiscordEmbedInput, DiscordNotifier } from "./webhook.js";
 import { queueEmbed, queueFinishedEmbed, queueSummaryEmbed } from "./webhookEmbeds.js";
-import { isCarded, type Chapter } from "./types.js";
+import { botUserIdFromClientId, isCarded, type Chapter } from "./types.js";
 import type { UnavailableReason } from "./card.js";
 import type { SettingsStore } from "../store/settings.js";
 
@@ -59,6 +59,54 @@ export class UploadTaskWorkers {
   private sendSuccesses = false;
 
   constructor(private readonly deps: TaskWorkerDeps) {}
+
+  /** The MangaDex account publoader uploads as; see `uploadedByBot`. */
+  private get botUserId(): string | null {
+    return this.deps.config.mdBotUserId ?? botUserIdFromClientId(this.deps.config.mdClientId);
+  }
+
+  /**
+   * May this task write to this chapter?
+   *
+   * The ownership gate in `dedupe.ts` decides what gets QUEUED. It does not run
+   * here, so anything already in the queue -- or put back by a retry -- reaches
+   * the write with no check at all. That is not hypothetical: four chapters
+   * uploaded by another account dead-lettered on DELETE with 403, and retrying
+   * the dead letters re-queued them as UNAVAILABLE, which would have uploaded a
+   * card over somebody else's chapter and repointed their externalUrl.
+   *
+   * So the check runs again at the point of the write. Chapters are not
+   * transferred between accounts, so "not ours" is permanent: the task is
+   * finished rather than failed, because retrying it forever only produces
+   * noise and 403s.
+   */
+  private async ownership(
+    mdChapterId: string,
+  ): Promise<
+    | { ok: true; detail: MdChapterDetail }
+    | { ok: false; gone: true }
+    | { ok: false; gone: false; reason: string }
+  > {
+    const detail = await this.deps.md.chapterById(mdChapterId, [
+      "scanlation_group",
+      "manga",
+      "user",
+    ]);
+    if (detail === null) return { ok: false, gone: true };
+
+    const uploader = detail.relationships.find((rel) => rel.type === "user")?.id ?? null;
+    const bot = this.botUserId;
+    if (!bot) {
+      return { ok: false, gone: false, reason: "no MangaDex bot user id is configured" };
+    }
+    if (uploader === null) {
+      return { ok: false, gone: false, reason: "MangaDex did not say who uploaded this chapter" };
+    }
+    if (uploader.toLowerCase() !== bot.toLowerCase()) {
+      return { ok: false, gone: false, reason: `uploaded by ${uploader}, not by this account` };
+    }
+    return { ok: true, detail };
+  }
 
   /** Re-read the reporting settings. Call once at the start of each drain. */
   async refreshReporting(): Promise<void> {
@@ -414,6 +462,28 @@ export class UploadTaskWorkers {
     const mdChapterId = chapter.mdChapterId;
     if (!mdChapterId) throw new TaskError("delete task has no mdChapterId");
 
+    // Costs one read before an irreversible write. `runDelete` previously
+    // called deleteChapter without ever looking at the chapter, so a queued row
+    // was enough to attempt a deletion on any chapter id it happened to carry.
+    const owned = await this.ownership(mdChapterId);
+    if (!owned.ok) {
+      if (owned.gone) {
+        log.info({ mdChapterId }, "chapter already gone from MangaDex, nothing to delete");
+        metrics.uploadsTotal.inc({ outcome: "delete_already_gone" });
+        this.queue("Delete", chapter, mdChapterId, true, "Chapter no longer on MangaDex.");
+        return;
+      }
+      // Finished, not failed: ownership does not change, so a retry can only
+      // produce the same 403.
+      log.error(
+        { mdChapterId, reason: owned.reason },
+        "refusing to delete a chapter this account did not upload",
+      );
+      metrics.uploadsTotal.inc({ outcome: "delete_refused_not_ours" });
+      this.queue("Delete", chapter, mdChapterId, false, `Refused: ${owned.reason}`);
+      return;
+    }
+
     let deleted: boolean;
     try {
       deleted = await this.deps.md.deleteChapter(mdChapterId);
@@ -475,14 +545,30 @@ export class UploadTaskWorkers {
     const force = raw["force"] === true;
     const footerNote = readString(raw, "footerNote");
 
-    let detail: MdChapterDetail | null;
+    let owned: Awaited<ReturnType<UploadTaskWorkers["ownership"]>>;
     try {
-      detail = await md.chapterById(mdChapterId, ["scanlation_group", "manga"]);
+      owned = await this.ownership(mdChapterId);
     } catch (err) {
       metrics.uploadsTotal.inc({ outcome: "unavailable_failed" });
       this.queue("Unavailable", chapter, mdChapterId, false, errorMessage(err));
       throw err;
     }
+
+    // Carding is a write to somebody's chapter: it uploads a page over it and
+    // repoints its externalUrl. A retried task reaches here without having gone
+    // through the queueing gate, which is how four chapters belonging to
+    // another account came to be queued for exactly this.
+    if (!owned.ok && !owned.gone) {
+      log.error(
+        { mdChapterId, reason: owned.reason },
+        "refusing to card a chapter this account did not upload",
+      );
+      metrics.uploadsTotal.inc({ outcome: "unavailable_refused_not_ours" });
+      this.queue("Unavailable", chapter, mdChapterId, false, `Refused: ${owned.reason}`);
+      return;
+    }
+
+    const detail: MdChapterDetail | null = owned.ok ? owned.detail : null;
 
     if (detail === null) {
       // Gone from MangaDex already; archiving is the correct end state.

--- a/test/unit/card.test.ts
+++ b/test/unit/card.test.ts
@@ -98,9 +98,29 @@ describe("chapter card", () => {
 });
 
 describe("font coverage", () => {
-  it("covers the scripts the catalogue actually publishes in", () => {
-    for (const sample of ["Black Clover", "Последняя страница", "黒の召喚士"]) {
-      expect(missingGlyphs(sample)).toEqual([]);
+  it("covers what the vendored fonts ship, on any host", () => {
+    // Latin and its punctuation come from the faces vendored in assets/fonts,
+    // so this holds regardless of what the machine has installed.
+    expect(missingGlyphs("Black Clover — Vol. 1 (2024)")).toEqual([]);
+  });
+
+  it("either renders a script or refuses to, but never draws boxes", () => {
+    // Coverage for CJK, Cyrillic and Thai comes from system fonts, so it is a
+    // property of the host: the runtime image installs the Noto families, a CI
+    // runner generally has no CJK font at all. Both are fine. What must never
+    // happen is the third outcome -- reporting full coverage and then drawing
+    // tofu -- so assert the contract rather than the machine.
+    //
+    // The first version of this test asserted coverage directly and passed on a
+    // developer Mac (which ships Arial Unicode MS) while failing CI, which is
+    // exactly the environment-dependent assertion it was meant to catch in the
+    // renderer.
+    for (const sample of ["黒の召喚士", "Последняя страница", "ไทย"]) {
+      if (missingGlyphs(sample).length === 0) {
+        expect(() => assertRenderable([sample])).not.toThrow();
+      } else {
+        expect(() => assertRenderable([sample])).toThrow(/unrenderable/i);
+      }
     }
   });
 


### PR DESCRIPTION
Two fixes. The first closes a real gap in #58's ownership gate that was about to be exercised in production; the second unbreaks `master`'s CI.

## Ownership was only checked at decision time (`fd5d14f`)

The gate added in #58 lives in `findExtraChapters`/`findDuplicateChapters` — the passes that decide what gets **queued**. Nothing re-checked at the point of the write, so a task already in the queue, or put back by a **retry**, reached MangaDex unchecked.

Observed in production today:

1. Four Youchien Wars ch 100.5 chapters uploaded by `f56aa6ad-…` (not the bot), inside our own MangaPlus group, dead-lettered on DELETE with `403 access_denied_http_exception`.
2. Retrying the dead letters reset their attempts and re-queued them as **UNAVAILABLE**.
3. That path uploads a card as the chapter's page and repoints its `externalUrl` — i.e. writing over somebody else's chapter.

They were removed from the queue by hand. Nothing in the code would have stopped them.

Both destructive workers now verify the uploader before writing:

- `runDelete` previously called `deleteChapter` **without ever reading the chapter**, so a queued row was enough to attempt an irreversible delete on whatever id it carried. It now pays one read first.
- `runUnavailable` already fetched the chapter and simply never looked at who uploaded it.

A chapter that is not ours is **finished, not failed** — chapters are not transferred between accounts, so the answer cannot change and retrying would only produce the same 403 five more times. Fails closed on both unknowns (no configured bot id; MangaDex not reporting an uploader), matching `uploadedByBot`.

## The font coverage test asserted the machine, not the code (`6bc4ce5`)

`master` CI is currently red because of a test I added in #58. It asserted `missingGlyphs("黒の召喚士")` finds nothing missing — which is a property of the **host**. It passed on a developer Mac (ships Arial Unicode MS) and failed the CI runner, which has no CJK font. Precisely the environment-dependence the renderer was changed to stop relying on.

CJK/Cyrillic/Thai coverage comes from system fonts: the runtime image installs the Noto families, a CI runner generally has none. Both are acceptable. The outcome that must never happen is the third one — reporting coverage and then drawing boxes — so the test now asserts *that* contract: either the script is covered and rendering is allowed, or it is not and `assertRenderable` refuses. Latin is still asserted directly, since it comes from the vendored faces and holds anywhere.

Worth noting the CI failure was the guard working: on a host with no CJK font, coverage detection reported the gap instead of letting tofu through.

## Not included

The dashboard already exposes the full queue surface (`retry`, `remove`, `purge`, `reorder`, `tasks`, `tasks/:id`, `chapters`) with Remove/Retry/Reorder/"Purge them" controls, so no dashboard work was needed.

884 unit tests pass.