### PR TITLE
Install a Thai font, and clear the remaining lint failure

### DIFF
--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -158,20 +158,29 @@ RUN apt-get update \
 # nothing errors, a PNG is produced, and it goes to MangaDex as a public page.
 #
 #   fontconfig       /etc/fonts, so the renderer can find anything at all
-#   fonts-dejavu-core   DejaVu Sans + Sans Mono, the two families card.ts pins
-#   fonts-liberation2   Liberation Sans, the pinned second choice
+#   fonts-dejavu-core   DejaVu Sans + Sans Mono, a broad Latin/Cyrillic/Greek
+#                       fallback behind the vendored display faces
+#   fonts-liberation2   Liberation Sans, the next fallback
 #   fonts-noto-cjk      Japanese/Korean/Chinese series titles, which DejaVu has
 #                       no glyphs for; the biggest package here and the reason
 #                       the card can name a Japanese series at all
+#   fonts-noto-core     everything else the catalogue publishes in. Thai is the
+#                       one that bit: MangaPlus publishes `th`, no package here
+#                       covered it, and a Thai One Piece card failed to render
+#                       with "no installed font covers them" -- which is the
+#                       renderer refusing to draw boxes, working as intended,
+#                       but a card that cannot be drawn is still a card nobody
+#                       gets. Also covers Vietnamese diacritics and Greek.
 #
-# The two `fc-list` greps fail the build rather than ship an image that renders
+# The `fc-list` greps fail the build rather than ship an image that renders
 # tofu; a missing font is otherwise invisible until a card reaches MangaDex.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      fontconfig fonts-dejavu-core fonts-liberation2 fonts-noto-cjk \
+      fontconfig fonts-dejavu-core fonts-liberation2 fonts-noto-cjk fonts-noto-core \
  && fc-cache -f \
  && fc-list | grep -q DejaVuSans \
  && fc-list | grep -qi NotoSansCJK \
+ && fc-list | grep -qi NotoSansThai \
  && rm -rf /var/lib/apt/lists/*
 
 # postgresql-client is here for ONE reason: the dashboard's backup button, which

--- a/src/core/md/card.ts
+++ b/src/core/md/card.ts
@@ -30,13 +30,11 @@ import {
 const LOGICAL = 1000;
 const SCALE = 2;
 
-// Noto Sans CJK sits after the Latin families and before the generic: a series
-// title is frequently Japanese, and DejaVu has no glyph for a single kana. The
-// core image installs all three (docker/core/Dockerfile); on a host missing
-// them the renderer silently draws tofu rather than failing, which is why the
-// image asserts they are present at build time.
-const SANS = "DejaVu Sans, Liberation Sans, Helvetica, Arial, Noto Sans CJK JP, sans-serif";
-const MONO = "DejaVu Sans Mono, Liberation Mono, Menlo, Consolas, monospace";
+// The font stack is no longer a constant here. It is built per string by
+// `familiesForText`, from the faces that were actually used to measure that
+// string, so drawing and measuring cannot disagree — a fixed list could name a
+// family librsvg then substitutes for something of a different width, which is
+// how text ended up outside boxes it had been measured to fit.
 
 const ORANGE = "#FF6740";
 const ORANGE_SOFT = "#FFF1EC";


### PR DESCRIPTION
Two fixes, one found by production and one by CI.

## A Thai card could not be drawn (`Dockerfile`)

A Thai One Piece chapter's card dead-lettered after five attempts with:

```
chapter card would contain unrenderable characters (สิ่งทีพวกเรา = U+0E2A U+0E34 …);
no installed font covers them.
```

That is the guard from #58 working exactly as designed — it refused to draw boxes — but a card nobody can draw is still a card nobody gets.

The image installs DejaVu, Liberation and Noto CJK. **None of them has Thai**, and MangaPlus publishes `th`. The gap was always there; it was invisible before because the old renderer would have drawn tofu and uploaded it to MangaDex without complaint.

`fonts-noto-core` covers Thai, plus Vietnamese diacritics and Greek — also in the catalogue's language list. The build now greps for `NotoSansThai` alongside the existing two checks, so a base image that drops it fails at build rather than at a reader.

## Lint (`card.ts`)

`SANS` and `MONO` have been dead since the font stack became per-string via `familiesForText`. They were the last trace of a fixed family list, which is precisely what let librsvg substitute a face of a different width than the layout was measured against. Removed.

## Note on CI

`test/integration/scopedRun.test.ts > uploads a chapter the publisher lists that MangaDex never got` is failing, but **not from this work** — it fails identically (`expected [ 'a1', 'a3', 'b1', 'b2' ] to deeply equal [ 'a3' ]`) on the #57 merge at 2026-08-26 23:11, before any of these branches existed. Platform CI has been red since 26 Aug 10:37; last green was #53. Worth its own investigation.

Typecheck, lint and 884 unit tests pass.