### PR TITLE
Raw log viewer, carded chapter URLs, and a page budget that fits the job

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -8,6 +8,11 @@ name: Publish images
 # built by hand on an arm64 laptop and pushed single-arch, so every x86_64 server
 # rejected them with `exec format error`: a message that names Prisma and has
 # nothing to do with it. A runner builds both architectures every time.
+#
+# The three images build as a matrix rather than as three steps of one job. They
+# do not depend on each other, and arm64 is emulated under QEMU and therefore
+# slow, so running them in sequence made the wall clock the sum of three
+# emulated builds when it only needs to be the longest one.
 
 on:
   push:
@@ -27,18 +32,14 @@ permissions:
   contents: read
 
 jobs:
-  publish:
+  # Resolved once and shared, so three parallel builds cannot disagree about
+  # which version they are publishing.
+  meta:
     runs-on: ubuntu-latest
+    outputs:
+      owner: ${{ steps.meta.outputs.owner }}
+      version: ${{ steps.meta.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       # A tag push or a manual run publishes that version as well as `latest`;
       # a plain push to master only moves `latest`, so merging never silently
       # overwrites a released version number.
@@ -71,55 +72,89 @@ jobs:
           esac
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      # The core image's context is the REPO ROOT, not platform/: it copies docs/
-      # into the runtime so the dashboard can serve the operator handbook, and
-      # docs/ is a sibling of platform/. The worker needs nothing outside
-      # platform/, so its context stays narrow.
-      - name: core
+  build:
+    needs: meta
+    runs-on: ubuntu-latest
+    strategy:
+      # One image failing should not cancel the other two: a partial publish is
+      # easier to reason about when the successes are actually published, and
+      # the arch assertion below refuses to pass on a half-finished set anyway.
+      fail-fast: false
+      matrix:
+        include:
+          # The core image's context is the REPO ROOT, not platform/: it copies
+          # docs/ and assets/ into the runtime so the dashboard can serve the
+          # handbook and the card renderer has its fonts, and both are siblings
+          # of platform/.
+          - name: core
+            image: publoader-core
+            file: docker/core/Dockerfile
+            target: ""
+            cache: core
+          - name: core-migrate
+            image: publoader-core-migrate
+            file: docker/core/Dockerfile
+            target: migrate
+            # Reads the core scope as well as its own: `migrate` is a stage of
+            # the same Dockerfile, so most of its layers are core's. In parallel
+            # that hits the previous run's core cache rather than this run's,
+            # which costs a little on the first build after a base change and
+            # nothing afterwards.
+            cache: core-migrate
+          # The worker needs nothing outside platform/, so its context could be
+          # narrower; it is kept at the root so all three share one build
+          # context and therefore one cache of it.
+          - name: worker
+            image: publoader-worker
+            file: docker/worker/Dockerfile
+            target: ""
+            cache: worker
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: ${{ matrix.name }}
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/core/Dockerfile
+          file: ${{ matrix.file }}
+          target: ${{ matrix.target }}
           platforms: linux/amd64,linux/arm64
           push: true
+          # Attestations are not consumed by anything that deploys these, and
+          # generating them adds a build and a push per architecture.
+          provenance: false
+          sbom: false
           tags: |
-            ${{ steps.meta.outputs.owner }}/publoader-core:latest
-            ${{ steps.meta.outputs.version && format('{0}/publoader-core:{1}', steps.meta.outputs.owner, steps.meta.outputs.version) || '' }}
-          cache-from: type=gha,scope=core
-          cache-to: type=gha,mode=max,scope=core
+            ${{ needs.meta.outputs.owner }}/${{ matrix.image }}:latest
+            ${{ needs.meta.outputs.version && format('{0}/{1}:{2}', needs.meta.outputs.owner, matrix.image, needs.meta.outputs.version) || '' }}
+          cache-from: |
+            type=gha,scope=${{ matrix.cache }}
+            type=gha,scope=core
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache }}
 
-      - name: core-migrate
-        uses: docker/build-push-action@v6
+  # Cheap, and it catches the exact failure this workflow exists to prevent.
+  # Its own job so it runs after all three have pushed rather than after each.
+  verify:
+    needs: [meta, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
         with:
-          context: .
-          file: docker/core/Dockerfile
-          target: migrate
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.owner }}/publoader-core-migrate:latest
-            ${{ steps.meta.outputs.version && format('{0}/publoader-core-migrate:{1}', steps.meta.outputs.owner, steps.meta.outputs.version) || '' }}
-          cache-from: type=gha,scope=core
-          cache-to: type=gha,mode=max,scope=core-migrate
-
-      - name: worker
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/worker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.owner }}/publoader-worker:latest
-            ${{ steps.meta.outputs.version && format('{0}/publoader-worker:{1}', steps.meta.outputs.owner, steps.meta.outputs.version) || '' }}
-          cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=max,scope=worker
-
-      # Cheap, and it catches the exact failure this workflow exists to prevent.
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Assert both architectures published
+        env:
+          OWNER: ${{ needs.meta.outputs.owner }}
         run: |
           for image in publoader-core publoader-core-migrate publoader-worker; do
-            ref="${{ steps.meta.outputs.owner }}/$image:latest"
+            ref="$OWNER/$image:latest"
             archs=$(docker manifest inspect "$ref" \
               | grep -o '"architecture"[^,]*' | grep -oE 'amd64|arm64' | sort -u | tr '\n' ' ')
             echo "$ref -> ${archs:-none}"

--- a/prisma/migrations/20260827100000_log_events/migration.sql
+++ b/prisma/migrations/20260827100000_log_events/migration.sql
@@ -1,0 +1,25 @@
+-- Structured log lines, so the dashboard can show what happened without shell
+-- access to the host. Diagnostic volume, pruned on a retention window; audit
+-- decisions live in audit_events and are kept indefinitely.
+CREATE TABLE "log_events" (
+    "id" TEXT NOT NULL,
+    "level" INTEGER NOT NULL,
+    "service" TEXT NOT NULL,
+    "component" TEXT,
+    "run_id" TEXT,
+    "job_id" TEXT,
+    "msg" TEXT NOT NULL,
+    "fields" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "log_events_pkey" PRIMARY KEY ("id")
+);
+
+-- Newest-first paging is the default read, and pruning deletes by age.
+CREATE INDEX "log_events_created_at_idx" ON "log_events"("created_at");
+-- "at least warn, newest first" as a range scan rather than set membership.
+CREATE INDEX "log_events_level_created_at_idx" ON "log_events"("level", "created_at");
+CREATE INDEX "log_events_service_created_at_idx" ON "log_events"("service", "created_at");
+-- "everything from this run" is the question an operator actually asks.
+CREATE INDEX "log_events_run_id_idx" ON "log_events"("run_id");
+CREATE INDEX "log_events_job_id_idx" ON "log_events"("job_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -779,6 +779,40 @@ model ApiToken {
   @@map("api_tokens")
 }
 
+/// One structured log line, kept so the dashboard can show what happened
+/// without shell access to the host.
+///
+/// Logs were previously written to stdout and nowhere else, which made
+/// `docker compose logs` the only way to read them — and made anything a run
+/// reported unreadable to an operator, and to the admin API, the moment the
+/// container restarted.
+///
+/// Deliberately NOT an audit trail. `audit_events` records decisions and who
+/// made them and is kept indefinitely; this is diagnostic volume and is pruned.
+model LogEvent {
+  id        String   @id @default(uuid())
+  /// pino's numeric level: 10 trace, 20 debug, 30 info, 40 warn, 50 error, 60 fatal.
+  /// Stored as the number so "at least warn" is a range scan rather than a set.
+  level     Int
+  service   String
+  component String?
+  /// Correlation ids, when the line carried them. Indexed together because the
+  /// question is almost always "show me everything from this run".
+  runId     String?  @map("run_id")
+  jobId     String?  @map("job_id")
+  msg       String
+  /// Everything else pino was given, verbatim, so the page can show raw lines.
+  fields    Json?
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([createdAt])
+  @@index([level, createdAt])
+  @@index([service, createdAt])
+  @@index([runId])
+  @@index([jobId])
+  @@map("log_events")
+}
+
 model AuditEvent {
   id        String   @id @default(uuid())
   actor     String

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,15 @@ const ConfigSchema = z.object({
     .default("false")
     .transform((v) => v === "true"),
   logLevel: z.enum(["trace", "debug", "info", "warn", "error"]).default("info"),
+  /**
+   * Days of log lines kept in the database for the dashboard's log page.
+   *
+   * Diagnostic volume, not an audit trail: `audit_events` records decisions and
+   * is kept indefinitely, while this table would grow without limit for no
+   * lasting benefit. stdout is unaffected, so the host's own log retention
+   * still applies to the authoritative copy.
+   */
+  logRetentionDays: z.coerce.number().int().min(1).max(365).default(14),
 
   // Lease/queue tuning
   leaseTtlSeconds: z.coerce.number().int().min(30).default(300),
@@ -215,6 +224,7 @@ export function loadConfig(overrides: Partial<Record<string, string>> = {}): Con
     sessionTtlMinutes: get("SESSION_TTL_MINUTES"),
     sessionCookieSecure: get("SESSION_COOKIE_SECURE"),
     logLevel: get("LOG_LEVEL"),
+    logRetentionDays: get("LOG_RETENTION_DAYS"),
     leaseTtlSeconds: get("LEASE_TTL_SECONDS"),
     sweepIntervalSeconds: get("SWEEP_INTERVAL_SECONDS"),
     schedulerIntervalSeconds: get("SCHEDULER_INTERVAL_SECONDS"),

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -62,6 +62,13 @@ const store = {
   navOpen: false,
   /** Per-view filter state, kept here so a redraw does not lose it. */
   filters: {
+    logService: "",
+    logMinLevel: "",
+    logQ: "",
+    /** Correlation id typed in, or arrived at from a run/job link. */
+    logCorrelation: "",
+    /** Timestamps already paged past, so "older" walks back without an offset. */
+    logBefore: [],
     queueKind: "",
     queueState: "",
     queueDedupeKey: "",
@@ -416,6 +423,7 @@ const ICONS = {
   tokens: "M14 4a6 6 0 1 1-4.6 9.9L4 19v2h3v-2h2v-2h2l1.5-1.5A6 6 0 0 1 14 4Zm2.5 3.5h.01",
   permissions: "M6 11V8a6 6 0 0 1 12 0v3m-13 0h14v9H5v-9Zm7 3.5v2",
   audit: "M7 3h7l5 5v13H7V3Zm7 0v5h5M10 13h7m-7 4h7",
+  logs: "M4 5h16M4 9h10M4 13h16M4 17h7",
   system: "M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Zm8 3.5-1.8.6-.7 1.7 1 1.6-1.6 1.6-1.6-1-1.7.7L13 19h-2l-.6-1.8-1.7-.7-1.6 1L5.5 16l1-1.6-.7-1.7L4 12v-2l1.8-.6.7-1.7-1-1.6L7.1 4.5l1.6 1 1.7-.7L11 3h2l.6 1.8 1.7.7 1.6-1 1.6 1.6-1 1.6.7 1.7L20 10v2Z",
   chevron: "M15 6l-6 6 6 6",
   menu: "M4 7h16M4 12h16M4 17h16",
@@ -970,6 +978,17 @@ const NAV = [
       ["quarantine", "Quarantine"],
     ],
     blurb: "Everything that failed, newest first.",
+  },
+  {
+    id: "logs",
+    label: "Logs",
+    group: "Work",
+    icon: "logs",
+    scope: "runs:read",
+    // Errors is the curated view of what broke. This is the uncurated one, and
+    // it exists because the line that explains an incident is usually not an
+    // error: what a check concluded, which titles were skipped and why.
+    blurb: "Raw log lines from the core services, newest first.",
   },
   {
     id: "extensions",
@@ -6166,6 +6185,189 @@ function activityActions(entry) {
  * acknowledgement is recorded against the failure's timestamp (see
  * core/observability/errorFeed.ts).
  */
+/** pino's numeric levels, and what to call them. */
+const LOG_LEVELS = [
+  [10, "trace"],
+  [20, "debug"],
+  [30, "info"],
+  [40, "warn"],
+  [50, "error"],
+  [60, "fatal"],
+];
+
+const logLevelName = (level) => {
+  let name = "info";
+  for (const [value, label] of LOG_LEVELS) if (level >= value) name = label;
+  return name;
+};
+
+VIEWS.logs = () => {
+  const query = () => {
+    const parts = ["limit=300"];
+    const f = store.filters;
+    if (f.logService) parts.push(`service=${encodeURIComponent(f.logService)}`);
+    if (f.logMinLevel) parts.push(`minLevel=${encodeURIComponent(f.logMinLevel)}`);
+    if (f.logQ) parts.push(`q=${encodeURIComponent(f.logQ)}`);
+    if (f.logCorrelation) {
+      // One box for both ids: an operator pastes an id, not a field name, and
+      // the server ignores whichever of the two does not match.
+      parts.push(`runId=${encodeURIComponent(f.logCorrelation)}`);
+    }
+    const before = f.logBefore[f.logBefore.length - 1];
+    if (before) parts.push(`before=${encodeURIComponent(before)}`);
+    return parts.join("&");
+  };
+
+  const logs = new Resource("logs", () => api(`/logs?${query()}`));
+  const sources = new Resource("logSources", () => api("/logs/sources"));
+
+  // Outside the reactive region so a redraw cannot steal the caret mid-word.
+  const search = el("input", {
+    id: "logs-q",
+    type: "search",
+    maxlength: 200,
+    placeholder: "message contains…",
+    value: store.filters.logQ,
+    "aria-label": "Filter log lines by message",
+  });
+  const correlation = el("input", {
+    id: "logs-run",
+    type: "search",
+    maxlength: 64,
+    placeholder: "run id",
+    value: store.filters.logCorrelation,
+    "aria-label": "Filter log lines by run id",
+  });
+
+  const reload = () => {
+    setFilter({ logQ: search.value.trim(), logCorrelation: correlation.value.trim(), logBefore: [] });
+    void logs.load({ force: true });
+  };
+  search.addEventListener("change", reload);
+  correlation.addEventListener("change", reload);
+
+  const older = () => {
+    const next = logs.data?.nextBefore;
+    if (!next) return;
+    setFilter({ logBefore: [...store.filters.logBefore, next] });
+    void logs.load({ force: true });
+  };
+
+  const newer = () => {
+    if (store.filters.logBefore.length === 0) return;
+    setFilter({ logBefore: store.filters.logBefore.slice(0, -1) });
+    void logs.load({ force: true });
+  };
+
+  return el(
+    "div",
+    {},
+    card(
+      "Logs",
+      el("p", {
+        class: "dim small",
+        text:
+          "Every line the core services wrote, with the fields it carried, newest first. Errors shows what " +
+          "failed; this shows everything, because the line that explains an incident is usually not an error. " +
+          "Extension runs are not here: workers have no database by design, so a runner's output reaches the " +
+          "host's log stream and the failure tail on its envelope, not this page.",
+      }),
+      live([sources], (data) =>
+        row(
+          el("label", { class: "inline", for: "logs-service", text: "Service" }),
+          el(
+            "select",
+            {
+              id: "logs-service",
+              onchange: (event) => {
+                setFilter({ logService: event.target.value, logBefore: [] });
+                void logs.load({ force: true });
+              },
+            },
+            [
+              el("option", { value: "", text: "all", selected: store.filters.logService === "" }),
+              ...(data?.services ?? []).map((name) =>
+                el("option", { value: name, text: name, selected: name === store.filters.logService }),
+              ),
+            ],
+          ),
+          el("label", { class: "inline", for: "logs-level", text: "Level" }),
+          el(
+            "select",
+            {
+              id: "logs-level",
+              onchange: (event) => {
+                setFilter({ logMinLevel: event.target.value, logBefore: [] });
+                void logs.load({ force: true });
+              },
+            },
+            [
+              el("option", { value: "", text: "all", selected: store.filters.logMinLevel === "" }),
+              ...LOG_LEVELS.map(([value, label]) =>
+                el("option", {
+                  value: String(value),
+                  text: `${label} and above`,
+                  selected: String(value) === store.filters.logMinLevel,
+                }),
+              ),
+            ],
+          ),
+          search,
+          correlation,
+          el("button", { class: "ghost", text: "Refresh", onclick: () => void logs.load({ force: true }) }),
+        ),
+      ),
+      live([logs], (data) => {
+        const lines = data?.logs ?? [];
+        if (lines.length === 0) {
+          return el("p", { class: "dim", text: "No log lines match these filters." });
+        }
+        return el(
+          "div",
+          {},
+          el(
+            "div",
+            { class: "logstream" },
+            lines.map((line) => {
+              const level = logLevelName(line.level);
+              const when = new Date(line.createdAt).toISOString().replace("T", " ").slice(0, 23);
+              const where = line.component ? `${line.service}/${line.component}` : line.service;
+              // The fields are shown verbatim rather than summarised: the whole
+              // point of this page is that nothing is editorialised away.
+              const fields =
+                line.fields && Object.keys(line.fields).length > 0
+                  ? JSON.stringify(line.fields)
+                  : "";
+              return el("div", { class: `logline log-${level}` }, [
+                el("span", { class: "log-time", text: when }),
+                el("span", { class: `log-level log-${level}`, text: level.toUpperCase() }),
+                el("span", { class: "log-where", text: where }),
+                el("span", { class: "log-msg", text: line.msg }),
+                fields ? el("span", { class: "log-fields", text: fields }) : null,
+              ]);
+            }),
+          ),
+          row(
+            el("button", {
+              class: "ghost",
+              text: "Newer",
+              disabled: store.filters.logBefore.length === 0,
+              onclick: newer,
+            }),
+            el("button", {
+              class: "ghost",
+              text: "Older",
+              disabled: !data?.nextBefore,
+              onclick: older,
+            }),
+            el("span", { class: "dim small", text: `${lines.length} line(s)` }),
+          ),
+        );
+      }),
+    ),
+  );
+};
+
 VIEWS.errors = (route) => {
   if (route.tab === "quarantine") return quarantinePanel();
 

--- a/src/core/api/dashboard/style.css
+++ b/src/core/api/dashboard/style.css
@@ -2380,3 +2380,86 @@ dialog::backdrop {
   background: var(--bad-bg);
   border-right-color: var(--bad-2);
 }
+
+/* ---- raw log stream -------------------------------------------------------
+ * One line per record, monospaced and not wrapped, because the value of this
+ * page is that lines stay comparable down the column. Overflow scrolls
+ * horizontally rather than reflowing: a wrapped log line hides how many lines
+ * there actually are.
+ */
+.logstream {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.55;
+  max-height: 68vh;
+  overflow: auto;
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 10px;
+  background: var(--bg-2, #0d1117);
+}
+
+.logline {
+  display: flex;
+  gap: 10px;
+  white-space: pre;
+  padding: 1px 0;
+}
+
+.logline + .logline {
+  border-top: 1px solid transparent;
+}
+
+.log-time {
+  color: var(--dimmer);
+  flex: 0 0 auto;
+}
+
+.log-level {
+  flex: 0 0 auto;
+  width: 5ch;
+  font-weight: 600;
+}
+
+.log-where {
+  color: var(--dimmer);
+  flex: 0 0 auto;
+}
+
+.log-msg {
+  flex: 0 0 auto;
+}
+
+/* Dimmed rather than hidden: the structured fields are usually the answer, but
+ * they should not out-shout the message. */
+.log-fields {
+  color: var(--dimmer);
+  flex: 0 0 auto;
+}
+
+.log-level.log-trace,
+.log-level.log-debug {
+  color: var(--dimmer);
+}
+
+.log-level.log-info {
+  color: var(--ok-2);
+}
+
+.log-level.log-warn {
+  color: var(--warn);
+}
+
+.log-level.log-error,
+.log-level.log-fatal {
+  color: var(--bad);
+}
+
+.logline.log-error .log-msg,
+.logline.log-fatal .log-msg {
+  color: var(--bad);
+}
+
+.logline.log-warn .log-msg {
+  color: var(--warn);
+}

--- a/src/core/api/routes/ops.ts
+++ b/src/core/api/routes/ops.ts
@@ -586,6 +586,89 @@ export function registerOpsRoutes(app: FastifyInstance, ctx: AppContext): void {
      * core/observability/errorFeed.ts, shared with the bot, the CLI and the
      * dashboard.
      */
+    /**
+     * Raw log lines, newest first.
+     *
+     * The errors feed above is a curated view: it shows what failed. This is
+     * the uncurated one — every line a core service emitted, with the fields it
+     * carried — because the questions that matter during an incident are often
+     * about lines that are not errors at all. What a check concluded, which
+     * titles a run skipped and why, what a decision was made on: all of that was
+     * previously readable only with shell access to the host, and only until the
+     * container restarted.
+     *
+     * Paged by `before` rather than an offset: the table is being appended to
+     * while it is read, so an offset would skip and repeat lines.
+     */
+    scope.get("/api/v1/admin/logs", { preHandler: requireScope("runs:read") }, async (req) => {
+      const query = parseOrThrow(
+        z.object({
+          limit: z.coerce.number().int().min(1).max(1000).default(200),
+          /** pino levels: 10 trace, 20 debug, 30 info, 40 warn, 50 error. */
+          minLevel: z.coerce.number().int().min(10).max(60).optional(),
+          service: z.string().max(64).optional(),
+          component: z.string().max(64).optional(),
+          runId: z.string().max(64).optional(),
+          jobId: z.string().max(64).optional(),
+          /** Case-insensitive substring over the message. */
+          q: z.string().min(1).max(200).optional(),
+          since: z.coerce.date().optional(),
+          /** Cursor: return lines strictly older than this timestamp. */
+          before: z.coerce.date().optional(),
+        }),
+        req.query ?? {},
+      );
+
+      const createdAt: { gte?: Date; lt?: Date } = {};
+      if (query.since) createdAt.gte = query.since;
+      if (query.before) createdAt.lt = query.before;
+
+      const rows = await ctx.prisma.logEvent.findMany({
+        where: {
+          ...(query.minLevel === undefined ? {} : { level: { gte: query.minLevel } }),
+          ...(query.service ? { service: query.service } : {}),
+          ...(query.component ? { component: query.component } : {}),
+          ...(query.runId ? { runId: query.runId } : {}),
+          ...(query.jobId ? { jobId: query.jobId } : {}),
+          ...(query.q ? { msg: { contains: query.q, mode: "insensitive" as const } } : {}),
+          ...(Object.keys(createdAt).length > 0 ? { createdAt } : {}),
+        },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        take: query.limit,
+      });
+
+      const oldest = rows[rows.length - 1];
+      return {
+        logs: rows,
+        // Feed straight back as `before` to page further into the past.
+        nextBefore: rows.length === query.limit && oldest ? oldest.createdAt.toISOString() : null,
+        /**
+         * Extension runs are NOT here. Worker agents have no database by
+         * design, so a runner's output reaches the host's log stream and the
+         * failure tail on its envelope, but not this table. Said plainly so an
+         * empty result is not read as "nothing happened".
+         */
+        covers: ["core-api", "core-scheduler", "core-processor", "core-uploader"],
+      };
+    });
+
+    /** Distinct services and components present, for the log page's filters. */
+    scope.get("/api/v1/admin/logs/sources", { preHandler: requireScope("runs:read") }, async () => {
+      const [services, components] = await Promise.all([
+        ctx.prisma.logEvent.findMany({ distinct: ["service"], select: { service: true }, take: 50 }),
+        ctx.prisma.logEvent.findMany({
+          distinct: ["component"],
+          select: { component: true },
+          where: { component: { not: null } },
+          take: 200,
+        }),
+      ]);
+      return {
+        services: services.map((row) => row.service).sort(),
+        components: components.map((row) => row.component).filter(Boolean).sort(),
+      };
+    });
+
     scope.get("/api/v1/admin/errors", { preHandler: requireScope("runs:read") }, async (req) => {
       const query = parseOrThrow(
         z.object({

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -844,9 +844,28 @@ function cardOnUpload(
   };
 }
 
+/**
+ * Where a carded chapter's `externalUrl` should point, best first: the
+ * chapter itself, then the series page, then the publisher's homepage.
+ *
+ * The chapter link leads: it is the most specific answer, and a reader who
+ * follows it gets the publisher's own page for exactly the chapter the card
+ * describes -- which may well have come back, since publishers rotate chapters
+ * in and out of free access rather than deleting them. The series page is the
+ * next best thing when the chapter link was never recorded, and the domain root
+ * is the last resort that at least reaches the publisher.
+ *
+ * This does not weaken `isCarded`, which recognises our work by
+ * `externalUrl && pages > 0` -- the card supplies the page, so the url is free
+ * to stay useful.
+ */
 function resolveReplacementUrl(liveExternalUrl: string | null, chapter: Chapter): string | null {
+  const chapterUrl = (chapter.chapterUrl ?? "").trim();
+  if (isHttpUrl(chapterUrl)) return chapterUrl;
+
   const mangaUrl = (chapter.mangaUrl ?? "").trim();
   if (isHttpUrl(mangaUrl)) return mangaUrl;
+
   for (const candidate of [liveExternalUrl, chapter.chapterUrl, chapter.mangaUrl]) {
     const root = domainRoot(candidate);
     if (root) return root;

--- a/src/core/md/unavailableCard.ts
+++ b/src/core/md/unavailableCard.ts
@@ -14,6 +14,14 @@ import type { Chapter } from "./types.js";
  * MangaDex is preferred over the stored row wherever both have an answer,
  * because the row is a mirror that may be days old while the card is about to
  * become the chapter's only page.
+ *
+ * The chapter URL is the one exception, and it inverts for a reason. Marking a
+ * chapter unavailable REPOINTS its externalUrl away from the chapter -- to the
+ * series page, or the publisher's homepage -- so on anything already carded the
+ * live value is that replacement, not the chapter. Preferring MangaDex there
+ * would print the series page under "SOURCE" and lose the original chapter link
+ * for good, and every re-card would do it again. The stored row still holds
+ * where the chapter actually was, so it wins.
  */
 export function unavailableCardOptions(input: {
   chapter: Chapter;
@@ -39,7 +47,10 @@ export function unavailableCardOptions(input: {
     chapterTitle: attrs?.title ?? chapter.chapterTitle,
     extensionName: chapter.extensionName ?? "Unknown",
     chapterLanguage: attrs?.translatedLanguage || chapter.chapterLanguage,
-    chapterUrl: attrs?.externalUrl ?? chapter.chapterUrl,
+    // The row first: see the note above. MangaDex's value is only used when the
+    // row never recorded a chapter url, and even then it may already be a
+    // replacement rather than the chapter.
+    chapterUrl: chapter.chapterUrl ?? attrs?.externalUrl ?? null,
     availableFrom: chapter.chapterTimestamp,
     availableTo: input.unavailableAt ?? chapter.chapterExpire,
     footerNote: input.footerNote ?? null,

--- a/src/core/observability/logSink.ts
+++ b/src/core/observability/logSink.ts
@@ -1,0 +1,174 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+/**
+ * Keeps log lines so the dashboard can show them.
+ *
+ * Logs went to stdout and nowhere else, which made `docker compose logs` on the
+ * host the only way to read them. Anything a run reported — why a chapter was
+ * skipped, what a check concluded — was unreadable to an operator and to the
+ * admin API, and gone entirely once the container restarted.
+ *
+ * Three properties matter more than completeness here:
+ *
+ *  - Logging must never block. Every write lands in memory and returns; the
+ *    database is touched on a timer, off the caller's path. A slow or missing
+ *    database changes throughput, not behaviour.
+ *  - The buffer must never grow without bound. A database outage is exactly
+ *    when logging gets loud, so the buffer is capped and drops the OLDEST lines
+ *    first: during an incident the newest lines are the ones being read.
+ *  - A failed flush must not cascade. Losing diagnostic lines is a nuisance;
+ *    an exception thrown out of a log call would take down whatever was being
+ *    logged about.
+ */
+
+interface PendingLog {
+  level: number;
+  service: string;
+  component: string | null;
+  runId: string | null;
+  jobId: string | null;
+  msg: string;
+  fields: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+/**
+ * How many lines may wait in memory, and how often they are written.
+ *
+ * A second of buffering is short enough that the page feels live and long
+ * enough that a busy run inserts in batches of hundreds rather than one
+ * statement per line.
+ */
+const MAX_BUFFERED = 5_000;
+const FLUSH_INTERVAL_MS = 1_000;
+const MAX_BATCH = 500;
+
+/** Fields pino puts on every line, which have their own columns. */
+const OWN_COLUMNS = new Set(["level", "time", "service", "component", "runId", "jobId", "msg", "pid", "hostname"]);
+
+class LogSink {
+  private buffer: PendingLog[] = [];
+  private prisma: PrismaClient | null = null;
+  private timer: NodeJS.Timeout | null = null;
+  private flushing = false;
+  private dropped = 0;
+
+  /**
+   * Start writing to the database.
+   *
+   * Called by the core services once they have a Prisma client. Worker agents
+   * never call it — they have no database by design — so on a worker the sink
+   * stays a bounded in-memory ring that costs a few hundred kilobytes and is
+   * never read.
+   */
+  enable(prisma: PrismaClient): void {
+    this.prisma = prisma;
+    if (this.timer) return;
+    this.timer = setInterval(() => void this.flush(), FLUSH_INTERVAL_MS);
+    // Never hold the process open for the sake of log flushing.
+    this.timer.unref();
+  }
+
+  /** One serialised pino line. Never throws: a bad line is dropped. */
+  write(line: string): void {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const fields: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!OWN_COLUMNS.has(key)) fields[key] = value;
+    }
+
+    const time = parsed["time"];
+    const entry: PendingLog = {
+      level: typeof parsed["level"] === "number" ? (parsed["level"] as number) : 30,
+      service: asString(parsed["service"]) ?? "unknown",
+      component: asString(parsed["component"]),
+      runId: asString(parsed["runId"]),
+      jobId: asString(parsed["jobId"]),
+      msg: asString(parsed["msg"]) ?? "",
+      fields: Object.keys(fields).length > 0 ? fields : null,
+      createdAt: typeof time === "string" || typeof time === "number" ? new Date(time) : new Date(),
+    };
+
+    if (this.buffer.length >= MAX_BUFFERED) {
+      // Oldest first: during an outage the newest lines are what anyone reads.
+      this.buffer.shift();
+      this.dropped += 1;
+    }
+    this.buffer.push(entry);
+  }
+
+  /**
+   * Write what is buffered. Safe to call concurrently; overlapping calls return
+   * immediately rather than double-inserting.
+   */
+  async flush(): Promise<void> {
+    if (this.flushing || this.prisma === null || this.buffer.length === 0) return;
+    this.flushing = true;
+    try {
+      const batch = this.buffer.splice(0, MAX_BATCH);
+      if (this.dropped > 0) {
+        // Recorded in-band so a gap in the page is visible rather than implied.
+        batch.unshift({
+          level: 40,
+          service: "core",
+          component: "logSink",
+          runId: null,
+          jobId: null,
+          msg: `log buffer overflowed; ${this.dropped} line(s) dropped`,
+          fields: { dropped: this.dropped },
+          createdAt: new Date(),
+        });
+        this.dropped = 0;
+      }
+      await this.prisma.logEvent.createMany({
+        // Prisma distinguishes "SQL NULL" from "JSON null" for a nullable Json
+        // column, so an absent `fields` has to say which it means.
+        data: batch.map((row) => ({
+          ...row,
+          fields: row.fields === null ? Prisma.JsonNull : (row.fields as Prisma.InputJsonValue),
+        })),
+      });
+    } catch {
+      // Deliberately silent: reporting a logging failure through the logger is
+      // how a database outage becomes an infinite loop.
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  /**
+   * Delete lines older than `days`.
+   *
+   * Diagnostic volume, not an audit trail: `audit_events` records decisions and
+   * is kept indefinitely, while this table would grow without limit for no
+   * lasting benefit.
+   */
+  async prune(days: number): Promise<number> {
+    if (this.prisma === null) return 0;
+    const before = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    try {
+      const { count } = await this.prisma.logEvent.deleteMany({
+        where: { createdAt: { lt: before } },
+      });
+      return count;
+    } catch {
+      return 0;
+    }
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+/**
+ * Process-wide, because pino is configured once at startup and the services
+ * each build several child loggers from it.
+ */
+export const logSink = new LogSink();

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+import { logSink } from "./core/observability/logSink.js";
 
 let prisma: PrismaClient | undefined;
 
@@ -10,6 +11,11 @@ export function getPrisma(databaseUrl?: string): PrismaClient {
     prisma = new PrismaClient(
       databaseUrl ? { datasources: { db: { url: databaseUrl } } } : undefined,
     );
+    // Start persisting logs here rather than in each service, so a service
+    // cannot be added later and quietly not appear in the log page. Worker
+    // agents never reach this — they have no DATABASE_URL by design — so the
+    // sink stays an unread in-memory buffer there.
+    logSink.enable(prisma);
   }
   return prisma;
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,15 +1,38 @@
-import { pino, type Logger } from "pino";
+import { pino, multistream, type Logger } from "pino";
+import { Writable } from "node:stream";
+import { logSink } from "./core/observability/logSink.js";
 
 /**
  * Structured JSON logs. Every log line in job-processing paths should carry
  * the correlation fields via child loggers: runId, jobId, attempt, workerId.
+ *
+ * Lines go to stdout as they always have, and also to `logSink`, which the core
+ * services persist so the dashboard can show them. stdout is kept because it is
+ * what `docker compose logs` reads and what a crash loop leaves behind — the
+ * database copy is the convenient one, not the authoritative one.
  */
 export function createLogger(service: string, level = "info"): Logger {
-  return pino({
-    level,
-    base: { service },
-    timestamp: pino.stdTimeFunctions.isoTime,
+  const toSink = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      // Never let persistence fail a log call; the sink swallows its own
+      // errors, and this guards the parse/serialise path around it.
+      try {
+        logSink.write(chunk.toString("utf8"));
+      } catch {
+        /* ignore */
+      }
+      callback();
+    },
   });
+
+  return pino(
+    {
+      level,
+      base: { service },
+      timestamp: pino.stdTimeFunctions.isoTime,
+    },
+    multistream([{ stream: process.stdout }, { stream: toSink }]),
+  );
 }
 
 export type { Logger };

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -13,6 +13,7 @@ import { autoSyncExtensions } from "../core/webhooks/autoSync.js";
 import { parseRepoList } from "../core/api/routes/webhooks.js";
 import { BundleStore } from "../core/store/bundles.js";
 import { AuditLog } from "../core/store/settings.js";
+import { logSink } from "../core/observability/logSink.js";
 
 const config = loadConfig();
 const log = createLogger("core-scheduler", config.logLevel);
@@ -58,6 +59,10 @@ const metricsServer = await startMetricsServer({
   defaultPort: 8101,
 });
 
+/** Once an hour is often enough for a retention window measured in days. */
+const LOG_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+let lastLogPrune = 0;
+
 log.info("core-scheduler started");
 while (running) {
   // Checked at the top of the iteration so the exit goes through the teardown
@@ -79,6 +84,20 @@ while (running) {
     await collectInventoryMetrics(prisma);
   } catch (err) {
     log.warn({ err }, "publishing inventory metrics failed");
+  }
+
+  // Log retention. Here rather than on its own timer because the scheduler is
+  // the one core service guaranteed to be running exactly once, and a delete
+  // that runs a few minutes late costs nothing. Failing is not worth a warning
+  // every tick: the next pass covers the same rows.
+  if (Date.now() - lastLogPrune > LOG_PRUNE_INTERVAL_MS) {
+    lastLogPrune = Date.now();
+    try {
+      const pruned = await logSink.prune(config.logRetentionDays);
+      if (pruned > 0) log.info({ pruned, days: config.logRetentionDays }, "pruned old log events");
+    } catch (err) {
+      log.warn({ err }, "pruning log events failed");
+    }
   }
 
   await sleep(config.schedulerIntervalSeconds * 1000);

--- a/test/unit/card.test.ts
+++ b/test/unit/card.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildChapterCardSvg, type ChapterCardOptions } from "../../src/core/md/card.js";
 import { measureText, missingGlyphs, assertRenderable } from "../../src/core/md/fonts.js";
+import { unavailableCardOptions } from "../../src/core/md/unavailableCard.js";
 
 const base = (over: Partial<ChapterCardOptions> = {}): ChapterCardOptions => ({
   mangaName: "Black Clover",
@@ -94,6 +95,50 @@ describe("chapter card", () => {
     // itself, and the row is the more believable half.
     expect(paywalled).not.toContain("AVAILABLE");
     expect(buildChapterCardSvg(base())).toContain("AVAILABLE");
+  });
+});
+
+describe("card source url on a re-card", () => {
+  const row = {
+    chapterUrl: "https://mangaplus.shueisha.co.jp/viewer/1018557",
+    mangaUrl: "https://mangaplus.shueisha.co.jp/titles/100246",
+    chapterNumber: "42",
+    chapterTitle: "A chapter",
+    chapterLanguage: "en",
+    extensionName: "mangaplus",
+    chapterTimestamp: null,
+    chapterExpire: null,
+  } as unknown as Parameters<typeof unavailableCardOptions>[0]["chapter"];
+
+  /** A chapter that has ALREADY been carded: its externalUrl was repointed. */
+  const carded = {
+    attributes: {
+      chapter: "42",
+      title: "A chapter",
+      translatedLanguage: "en",
+      // The series page, written by the previous carding — not the chapter.
+      externalUrl: "https://mangaplus.shueisha.co.jp/titles/100246",
+      pages: 1,
+      version: 2,
+    },
+    relationships: [],
+  } as unknown as Parameters<typeof unavailableCardOptions>[0]["detail"];
+
+  it("keeps the original chapter link as the card's source", () => {
+    // Carding repoints externalUrl, so on a re-card MangaDex's value is the
+    // replacement. Preferring it would print the series page under SOURCE and
+    // lose where the chapter actually was — permanently, and again on every
+    // subsequent re-card.
+    const options = unavailableCardOptions({ chapter: row, detail: carded });
+    expect(options.chapterUrl).toBe("https://mangaplus.shueisha.co.jp/viewer/1018557");
+  });
+
+  it("falls back to MangaDex only when the row never had a chapter url", () => {
+    const options = unavailableCardOptions({
+      chapter: { ...row, chapterUrl: null } as typeof row,
+      detail: carded,
+    });
+    expect(options.chapterUrl).toBe("https://mangaplus.shueisha.co.jp/titles/100246");
   });
 });
 

--- a/test/unit/chapters.test.ts
+++ b/test/unit/chapters.test.ts
@@ -93,7 +93,11 @@ describe("unavailableCardOptions", () => {
     expect(opts.chapterNumber).toBe("12.5");
     expect(opts.chapterTitle).toBe("Live title");
     expect(opts.chapterLanguage).toBe("ja");
-    expect(opts.chapterUrl).toBe("https://publisher.example/live");
+    // The url is the deliberate exception. Carding repoints externalUrl, so on
+    // an already-carded chapter MangaDex's value is that replacement rather
+    // than the chapter; taking it would print the replacement under SOURCE and
+    // lose the original chapter link, again on every re-card. The row keeps it.
+    expect(opts.chapterUrl).toBe("https://publisher.example/ch/12");
     // The extension never appears on the MangaDex resource, so it always comes
     // from our row.
     expect(opts.extensionName).toBe("exampleext");


### PR DESCRIPTION
Three things, one of which was about to corrupt 2,261 chapters.

## Carded chapters kept pointing at the chapter (`de69348`)

Two URL rules were pulling in opposite directions.

The card's SOURCE line preferred MangaDex's `externalUrl` over the stored row. But carding **repoints** that URL away from the chapter — so on anything already carded the live value *is* the replacement. Printing it under SOURCE loses where the chapter actually was, permanently, and again on every re-card. Re-carding the existing 2,261 unavailable chapters would have stamped the series page into all of them. The row still knows, so the row wins; MangaDex is consulted only when the row never recorded a URL. Every other field still prefers the live value, which is what keeps a card current.

`externalUrl` itself now degrades **chapter → series → homepage** rather than skipping the chapter. The chapter link is the most specific answer, and publishers rotate chapters in and out of free access rather than deleting them, so it is frequently the one that starts working again. This does not weaken `isCarded`, which recognises our work by `externalUrl && pages > 0` — the card supplies the page, so the URL is free to stay useful.

The existing "prefers what MangaDex holds" test keeps every other field and has its URL expectation inverted: the behaviour change stated plainly rather than a test bent to fit.

## Logs are kept, and the dashboard has a page for them (`075a6cf`)

Logs went to stdout and nowhere else, so reading them meant shell access to the host and they vanished on restart. That is why the page-count check's own report could not be read back through the admin API after the run that produced it.

Lines now also reach a bounded in-memory sink that the core services flush to `log_events` on a timer. Three properties matter more than completeness:

- **Logging never blocks.** Writes land in memory and return; a slow database changes throughput, not behaviour.
- **The buffer never grows without bound**, and drops the *oldest* lines first — a database outage is exactly when logging gets loud, and the newest lines are the ones being read. The dropped count is written in-band, so a gap is visible rather than implied.
- **A failed flush stays silent.** Reporting a logging failure through the logger is how an outage becomes an infinite loop.

Enabled in `getPrisma` rather than per service, so a service added later cannot quietly go missing. Worker agents never reach it (no `DATABASE_URL` by design) and there it is an unread ring buffer. Pruned on a retention window by the scheduler. This is diagnostic volume — `audit_events` remains the audit trail and is kept indefinitely.

The page is the uncurated counterpart to Errors: Errors answers *what failed*, this answers *what happened*, which is the question during an incident and the line that explains one is usually not an error. Fields shown verbatim, monospaced and unwrapped so lines stay comparable, paged by timestamp rather than offset because the table is appended to while it is read.

**It states plainly that extension runs are not included.** Workers have no database, and the executor keeps only a stderr tail forwarded on error. Carrying runner output here means putting it on the result envelope — a separate change. Claiming coverage it does not have would make an empty result read as "nothing happened".

## Page-check budget now fits the job (extensions `184a7da`)

The ceiling on viewer calls was 20000, which is no ceiling: the catalogue is ~6,300 chapters against a 2 req/s throttle, so a clean run with the check on would spend ~52 minutes on viewer calls alone plus ~9 on title calls, against a job killed at 3600s. It would have died mid-sweep.

Now 2000 calls (~17 min). Running out is safe by construction — an unchecked chapter is treated as alive, so a short run under-reports rather than unpublishing anything.

Budget alone was not enough: the old code sliced the first N of whatever order the ids arrived in, so every run re-checked the same opening chapters and never reached the middle — a sweep that could not converge however often it ran. The budget is now spent on `midChapterList` first, where every refusal observed so far has come from, and the log names what was left unchecked broken down by slot.

Typecheck, lint and 886 unit tests pass.