### PR TITLE
Give the integration fixtures an uploader, and name Logs in the no-script fallback

### DIFF
--- a/src/core/api/dashboard/index.html
+++ b/src/core/api/dashboard/index.html
@@ -20,7 +20,7 @@
         <h2>JavaScript required</h2>
         <p>
           The control plane renders its views in the browser. The navigation offers Overview;
-          Runs, Queues, Activity and Errors under Work; Extensions, Chapters, Tracked and
+          Runs, Queues, Activity, Errors and Logs under Work; Extensions, Chapters, Tracked and
           Untracked under Catalogue; Workers under Fleet; and Users, Tokens, Permissions,
           Audit, System, Maintenance and Docs under Admin.
           Enable scripting for this origin, or use the <code>publoader-admin</code> CLI instead.

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -33,10 +33,16 @@ import { closeDb, dbReady, resetDb, testPrisma } from "./db.js";
 describe.skipIf(!dbReady())("chapter management endpoints", () => {
   const prisma = testPrisma();
   const ADMIN_TOKEN = "test-admin-token-0123456789";
+  /** The MangaDex account these fixtures pretend publoader uploads as. */
+  const BOT_USER_ID = "74d95af1-7492-4fca-bc44-10c9142703e8";
   const config = loadConfig({
     DATABASE_URL: process.env.TEST_DATABASE_URL!,
     ADMIN_TOKEN,
     LOG_LEVEL: "error",
+    // Every destructive path is gated on this; without it the uploader
+    // correctly refuses to touch anything and the card tests below would pass
+    // for the wrong reason.
+    MANGADEX_BOT_USER_ID: BOT_USER_ID,
   });
   const log = createLogger("test-chapters", "error");
   let app: FastifyInstance;
@@ -1162,7 +1168,13 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
         version: 3,
         createdAt: "2026-01-01T00:00:00.000Z",
       },
-      relationships: [{ id: uuid(800), type: "scanlation_group" }],
+      relationships: [
+        { id: uuid(800), type: "scanlation_group" },
+        // The uploader refuses to write to a chapter it cannot show this
+        // account uploaded, so without an uploader these tests would exercise
+        // that refusal rather than the card flow.
+        { id: BOT_USER_ID, type: "user" },
+      ],
     });
 
     function stubMd(calls: string[]): MdExtendedApi {

--- a/test/integration/extensionConfig.test.ts
+++ b/test/integration/extensionConfig.test.ts
@@ -21,6 +21,8 @@ import { closeDb, dbReady, resetDb, testPrisma } from "./db.js";
 describe.skipIf(!dbReady())("extension config tables", () => {
   const prisma = testPrisma();
   const store = new ExtensionConfigStore(prisma);
+  /** The MangaDex account these fixtures pretend publoader uploads as. */
+  const BOT_USER_ID = "74d95af1-7492-4fca-bc44-10c9142703e8";
 
   beforeEach(async () => {
     await resetDb(prisma);
@@ -233,6 +235,10 @@ describe.skipIf(!dbReady())("extension config tables", () => {
       relationships: [
         { id: "22222222-2222-4222-8222-222222222222", type: "scanlation_group" },
         { id: "11111111-1111-4111-8111-111111111111", type: "manga" },
+        // Removal decisions refuse to touch a chapter they cannot show this
+        // account uploaded, so a fixture without an uploader exercises that
+        // refusal rather than the override rules under test here.
+        { id: BOT_USER_ID, type: "user" },
       ],
     }) as unknown as MdChapter;
 
@@ -257,6 +263,7 @@ describe.skipIf(!dbReady())("extension config tables", () => {
       languages: ["en"],
       groupId: "22222222-2222-4222-8222-222222222222",
       cleanDb: false,
+      botUserId: BOT_USER_ID,
     });
     expect(sameResult.skippedDifferentId).toHaveLength(1);
     expect(sameResult.toUpload).toHaveLength(0);
@@ -278,6 +285,7 @@ describe.skipIf(!dbReady())("extension config tables", () => {
       languages: ["en"],
       groupId: "22222222-2222-4222-8222-222222222222",
       cleanDb: false,
+      botUserId: BOT_USER_ID,
     });
     expect(languageResult.toRemove).toHaveLength(0);
 
@@ -300,6 +308,7 @@ describe.skipIf(!dbReady())("extension config tables", () => {
       {
         groupId: "22222222-2222-4222-8222-222222222222",
         multiChapters: overrideOptions.multi_chapters,
+        botUserId: BOT_USER_ID,
       },
     );
     expect(dupes.map((c) => c.id)).toEqual(["eeee1111-1111-4111-8111-111111111111"]);

--- a/test/integration/scopedRun.test.ts
+++ b/test/integration/scopedRun.test.ts
@@ -24,6 +24,8 @@ describe.skipIf(!dbReady())("scoped runs", () => {
   const log = createLogger("test-scoped-run", "error");
 
   const GROUP = "0a0a0a0a-0000-4000-8000-00000000000a";
+  /** The MangaDex account these fixtures pretend publoader uploads as. */
+  const BOT = "74d95af1-7492-4fca-bc44-10c9142703e8";
   const SERIES_A = "11111111-0000-4000-8000-000000000001";
   const SERIES_B = "22222222-0000-4000-8000-000000000002";
   const BUNDLE = "a".repeat(64);
@@ -58,6 +60,10 @@ describe.skipIf(!dbReady())("scoped runs", () => {
         // Which manga a chapter belongs to is read off the relationship, so it
         // has to be here for the removal pass to bucket it.
         { id: externalUrl?.includes("/b/") ? SERIES_B : SERIES_A, type: "manga" },
+        // And who uploaded it, for the same reason: the removal passes refuse
+        // to touch a chapter they cannot show this account uploaded, so a
+        // fixture without an uploader tests that refusal rather than removal.
+        { id: BOT, type: "user" },
       ],
     } as unknown as MdChapter;
   }
@@ -227,7 +233,7 @@ describe.skipIf(!dbReady())("scoped runs", () => {
       stillListed: A_LOST_ONE,
     });
 
-    const processor = new RunProcessor(prisma, fakeMd(), log);
+    const processor = new RunProcessor(prisma, fakeMd(), log, { botUserId: BOT });
     await processor.processRun({
       id: run.id,
       extension: "testext",
@@ -251,7 +257,7 @@ describe.skipIf(!dbReady())("scoped runs", () => {
       stillListed: A_LOST_ONE,
     });
 
-    const processor = new RunProcessor(prisma, fakeMd(), log);
+    const processor = new RunProcessor(prisma, fakeMd(), log, { botUserId: BOT });
     await processor.processRun({
       id: run.id,
       extension: "testext",
@@ -273,7 +279,7 @@ describe.skipIf(!dbReady())("scoped runs", () => {
   it("still unpublishes an absent series when the run did claim to cover everything", async () => {
     const { run } = await runWithEnvelope({ scopeMangaIds: [], stillListed: A_LOST_ONE });
 
-    const processor = new RunProcessor(prisma, fakeMd(), log);
+    const processor = new RunProcessor(prisma, fakeMd(), log, { botUserId: BOT });
     await processor.processRun({
       id: run.id,
       extension: "testext",
@@ -298,7 +304,7 @@ describe.skipIf(!dbReady())("scoped runs", () => {
   it("visits a scoped series that reported no updates at all", async () => {
     const { run } = await runWithEnvelope({ scopeMangaIds: [SERIES_A], stillListed: [] });
     // Nothing listed anywhere: the publisher has dropped series A entirely.
-    const processor = new RunProcessor(prisma, fakeMd(), log);
+    const processor = new RunProcessor(prisma, fakeMd(), log, { botUserId: BOT });
     await processor.processRun({
       id: run.id,
       extension: "testext",
@@ -340,7 +346,7 @@ describe.skipIf(!dbReady())("scoped runs", () => {
       updated: [],
     });
 
-    const processor = new RunProcessor(prisma, fakeMd(), log);
+    const processor = new RunProcessor(prisma, fakeMd(), log, { botUserId: BOT });
     await processor.processRun({
       id: run.id,
       extension: "testext",
@@ -372,7 +378,7 @@ describe.skipIf(!dbReady())("scoped runs", () => {
       updated: [],
     });
 
-    const processor = new RunProcessor(prisma, fakeMd(), log);
+    const processor = new RunProcessor(prisma, fakeMd(), log, { botUserId: BOT });
     await processor.processRun({
       id: run.id,
       extension: "testext",
@@ -390,7 +396,7 @@ describe.skipIf(!dbReady())("scoped runs", () => {
 
   it("marks the run processed either way", async () => {
     const { run } = await runWithEnvelope({ scopeMangaIds: [SERIES_A], stillListed: A_LOST_ONE });
-    const processor = new RunProcessor(prisma, fakeMd(), log);
+    const processor = new RunProcessor(prisma, fakeMd(), log, { botUserId: BOT });
     await processor.processRun({
       id: run.id,
       extension: "testext",


### PR DESCRIPTION
Fixes 7 of the 8 integration failures on `master`. **These were mine** — I fixed the twelve unit tests the ownership gate broke and did not check that the integration suite has its own fixtures. They need a database, so I could not run them locally; that explains the miss but does not excuse shipping it.

## The ownership gate had nowhere to prove itself (6 tests)

`uploadedByBot` refuses to touch a chapter it cannot show this account uploaded, and fails closed on an unread uploader. The integration fixtures build chapters with `scanlation_group` and `manga` relationships but no `user`, and construct `RunProcessor` with no bot id — so those tests were exercising the *refusal* rather than the behaviour their titles describe:

- `scopedRun` × 3 — removal passes removing nothing (`expected [] to deeply equal [...]`)
- `chapters` × 2 — the card worker returning before opening an edit session (`expected [ 'chapterById' ] to include 'beginEditSession'`)
- `extensionConfig` × 1 — duplicate resolution finding nothing

They now carry a `user` relationship and are handed the bot id.

## The no-script fallback is a real bug, not a stale test (1 test)

`index.html`'s `<noscript>` block enumerates the sections the navigation offers. I added Logs to `NAV` in `app.js` and not there, so the two disagreed — meaning the one page a reader without scripting is *told about* would have been the one page that did not exist for them. The test asserting the fallback names every section caught exactly that.

## Not fixed here

`scopedRun > uploads a chapter the publisher lists that MangaDex never got` fails **identically** (`expected [ 'a1', 'a3', 'b1', 'b2' ] to deeply equal [ 'a3' ]`) on the #57 merge at 2026-08-26 23:11, before this branch existed. Platform CI has been red since 26 Aug 10:37; last green was #53.

It is about upload/duplicate matching rather than removal, so nothing here touches it. Fixing it means inferring what the change that introduced it intended, and I would be guessing — worth its own look.

Typecheck, lint and 886 unit tests pass. The integration suite is verified by CI on this PR, since it needs a database.