### PR TITLE
Stop removing across unfetched languages, add un-carding, and a root-only SQL endpoint

### DIFF
--- a/prisma/migrations/20260827120000_restore_task_kind/migration.sql
+++ b/prisma/migrations/20260827120000_restore_task_kind/migration.sql
@@ -1,0 +1,6 @@
+-- Take the card back off a chapter.
+--
+-- Carding was one-way: findExtraChapters skips anything already carded, so
+-- nothing revisited one and a chapter carded by mistake stayed carded. Adding
+-- the kind is additive; no existing row changes.
+ALTER TYPE "UploadTaskKind" ADD VALUE 'RESTORE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,6 +81,14 @@ enum UploadTaskKind {
   EDIT
   DELETE
   UNAVAILABLE
+  /// Take the card back off a chapter: strip the card image and leave the
+  /// chapter as an ordinary external link again.
+  ///
+  /// Carding was a one-way door until this existed. findExtraChapters skips
+  /// anything already carded, so nothing ever revisited one, and a chapter
+  /// carded by mistake stayed carded — which is how 213 live RuriDragon
+  /// chapters ended up with "no longer available" over a working link.
+  RESTORE
 }
 
 enum UploadOutcome {

--- a/runner-node/runner.mjs
+++ b/runner-node/runner.mjs
@@ -413,7 +413,7 @@ function resolveDataFilePath(bundleDir, dataFiles, name) {
   return target;
 }
 
-function buildContext(bundleDir, manifest, mangaIdMap) {
+function buildContext(bundleDir, manifest, mangaIdMap, overrideOptions) {
   const allowedHosts = Array.isArray(manifest.allowed_hosts) ? manifest.allowed_hosts : [];
   const dataFiles =
     manifest.data_files && typeof manifest.data_files === "object" ? manifest.data_files : {};
@@ -424,6 +424,20 @@ function buildContext(bundleDir, manifest, mangaIdMap) {
     mangaIdMap: invertMangaIdMap(mangaIdMap),
     fetch: (input, init) => guarded(input, init),
     dataFile: (name) => readFile(resolveDataFilePath(bundleDir, dataFiles, name), "utf8"),
+    /**
+     * The extension's configuration as the DATABASE holds it.
+     *
+     * The lease has always carried this and the context never exposed it, so an
+     * extension's only source of configuration was the copy baked into its own
+     * bundle — which meant changing one setting required publishing a new
+     * bundle, and the operator-editable config the dashboard writes reached the
+     * runner and stopped there.
+     *
+     * Frozen, and never merged into `dataFile` output on the extension's
+     * behalf: which of the two wins is the extension's decision to state
+     * explicitly, not something to have happen to it silently.
+     */
+    overrideOptions: Object.freeze({ ...(overrideOptions ?? {}) }),
     log: (message, fields) => log("info", String(message), { source: "extension", ...(fields ?? {}) }),
   };
   return { ctx, fetchState: state };
@@ -678,7 +692,7 @@ async function runJob(job, bundleDir, outputDir) {
   const segmentIds = new Set((job.segmentMangaIds ?? []).map(String));
   const cleanRun = String(job.kind ?? "").toUpperCase() === "CLEAN";
 
-  const { ctx, fetchState } = buildContext(bundleDir, manifest, mangaIdMap);
+  const { ctx, fetchState } = buildContext(bundleDir, manifest, mangaIdMap, job.overrideOptions);
 
   // Import and factory construction are properties of the bundle: retrying the
   // same pinned sha256 would fail identically, so they raise ContractError

--- a/src/contracts/extensionApi.ts
+++ b/src/contracts/extensionApi.ts
@@ -104,6 +104,20 @@ export interface ExtensionContext {
   /** The extension's manifest (validated copy; read-only). */
   readonly manifest: Readonly<Record<string, unknown>>;
   /**
+   * The extension's configuration as the DATABASE holds it — what the dashboard
+   * edits, not what the bundle shipped with.
+   *
+   * The lease has always carried this and the context never exposed it, so the
+   * only configuration an extension could read was the copy inside its own
+   * bundle. That made every setting a release: flipping one flag meant
+   * publishing a new bundle, and the operator-editable config reached the
+   * runner and went no further.
+   *
+   * The two are NOT merged here. Which wins is the extension's own decision and
+   * belongs in the extension, stated plainly, rather than happening to it.
+   */
+  readonly overrideOptions: Readonly<Record<string, unknown>>;
+  /**
    * External manga id -> MangaDex title id, from the platform's
    * DB-authoritative tracked map (includes titles auto-created since the
    * bundle was published).

--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -5166,6 +5166,9 @@ function chapterBulkBar(selected, scope, rows, data, activeFilter, archive, relo
     }),
     bulk("Edit…", "edit", false),
     bulk("Mark unavailable…", "unavailable", false),
+    // Only where there are cards to take off. Offering it on `uploaded` would
+    // list an action that refuses every chapter it is given.
+    archive === "unavailable" ? bulk("Remove card…", "restore", false) : null,
     bulk("Delete…", "delete", true),
     el("span", { class: "grow" }),
     el(
@@ -5817,6 +5820,27 @@ function chapterBulkDialog({ action, archive, target, targeting, done }) {
               maxlength: "600",
             }),
           )
+        : action === "restore"
+        ? el(
+            "div",
+            {},
+            el("p", {
+              text:
+                "The card image comes off and each chapter goes back to being an ordinary external " +
+                "link. Use this when a chapter was carded by mistake and is still readable at the " +
+                "publisher.",
+            }),
+            ...field(
+              "externalUrl",
+              "Publisher link",
+              "Blank keeps the chapter's stored link, which is the one it had before it was carded. " +
+                "Fill this in only when that link is itself wrong.",
+              { maxlength: "2048", placeholder: "https://…" },
+            ),
+            ...field("reason", "Reason (recorded against every chapter in the audit trail)", "", {
+              maxlength: "500",
+            }),
+          )
         : el(
             "div",
             {},
@@ -5848,6 +5872,13 @@ function chapterBulkDialog({ action, archive, target, targeting, done }) {
     if (action === "unavailable") {
       const note = inputs.footerNote.value.trim();
       return { force: force.checked, ...(note ? { footerNote: note } : {}) };
+    }
+    if (action === "restore") {
+      // Blank means "keep the chapter's stored link", which is the usual case;
+      // the field exists for when that link is itself what was wrong.
+      const url = inputs.externalUrl.value.trim();
+      const why = inputs.reason.value.trim();
+      return { ...(url ? { externalUrl: url } : {}), ...(why ? { reason: why } : {}) };
     }
     const reason = inputs.reason.value.trim();
     return reason ? { reason } : {};
@@ -5906,7 +5937,9 @@ function chapterBulkDialog({ action, archive, target, targeting, done }) {
       ? "Edit these chapters on MangaDex"
       : action === "unavailable"
         ? "Mark these chapters unavailable"
-        : "Delete these chapters from MangaDex",
+        : action === "restore"
+          ? "Take the card off these chapters"
+          : "Delete these chapters from MangaDex",
     body,
   );
 }

--- a/src/core/api/routes/chapters.ts
+++ b/src/core/api/routes/chapters.ts
@@ -289,7 +289,7 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
       req: FastifyRequest,
       reply: FastifyReply,
       opts: {
-        kind: "EDIT" | "DELETE" | "UNAVAILABLE";
+        kind: "EDIT" | "DELETE" | "UNAVAILABLE" | "RESTORE";
         row: ChapterRow;
         sidecars: Record<string, unknown>;
         audit: string;
@@ -1267,7 +1267,7 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
       req: FastifyRequest,
       reply: FastifyReply,
       opts: {
-        kind: "EDIT" | "DELETE" | "UNAVAILABLE";
+        kind: "EDIT" | "DELETE" | "UNAVAILABLE" | "RESTORE";
         body: { ids?: string[]; filter?: z.infer<typeof BulkFilter>; dryRun: boolean; confirm: boolean };
         /** Per-chapter task sidecars. Constant across the set by construction. */
         sidecars: Record<string, unknown>;
@@ -1278,7 +1278,10 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
       },
     ): Promise<FastifyReply> {
       const { kind, body } = opts;
-      const archive = body.filter?.archive ?? "uploaded";
+      // RESTORE selects from the carded chapters by definition, so a filter
+      // that does not say otherwise means "the unavailable ones". Defaulting it
+      // to `uploaded` like the other verbs would silently match nothing.
+      const archive = body.filter?.archive ?? (opts.kind === "RESTORE" ? "unavailable" : "uploaded");
 
       let ids: string[];
       let capped = false;
@@ -1299,7 +1302,11 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
         // Only the UNAVAILABLE path needs this: `locate` may have resolved the
         // chapter from `uploaded`, which does not answer whether a card is
         // already posted.
-        opts.kind === "UNAVAILABLE" ? ctx.chapters.manyByIds("unavailable", ids) : Promise.resolve([]),
+        // RESTORE needs it for the opposite test: UNAVAILABLE refuses a chapter
+        // that is already carded, RESTORE refuses one that is not.
+        opts.kind === "UNAVAILABLE" || opts.kind === "RESTORE"
+          ? ctx.chapters.manyByIds("unavailable", ids)
+          : Promise.resolve([]),
         ctx.uploadTasks.forDedupeKeys(ids),
       ]);
       const alreadyUnavailable = new Set(unavailableRows.map((row) => row.mdChapterId));
@@ -1316,6 +1323,15 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
           return {
             outcome: "needs_force",
             reason: "already marked unavailable; pass force: true to post a fresh card over the old one",
+          };
+        }
+        // Restoring a chapter that was never carded would open an edit session
+        // to change nothing. Refused here rather than discovered by the worker,
+        // so a filter that selected too much is visible in the dry run.
+        if (kind === "RESTORE" && !alreadyUnavailable.has(id)) {
+          return {
+            outcome: "not_found",
+            reason: "this chapter is not marked unavailable, so it has no card to remove",
           };
         }
         const task = taskByChapter.get(id);
@@ -1571,6 +1587,47 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
           },
           auditAction: "chapter.unavailable",
           auditDetail: { force: body.force, footerNote: body.footerNote ?? null, bulkKind: "unavailable" },
+        });
+      },
+    );
+
+    /**
+     * Take the card back off, leaving an ordinary external chapter.
+     *
+     * The counterpart to `bulk/unavailable`, and until now it did not exist:
+     * carding was one-way, because `findExtraChapters` skips anything already
+     * carded so nothing ever revisited one. A chapter carded by mistake stayed
+     * carded, which is how 213 live RuriDragon chapters ended up under "no
+     * longer available on the publisher" with a working link beneath it.
+     *
+     * The card image is removed and `externalUrl` is kept, since it is the
+     * chapter's only remaining way to reach the publisher. `externalUrl` in the
+     * body overrides it, for the case where the stored link is the one that was
+     * wrong.
+     */
+    scope.post(
+      "/api/v1/admin/chapters/bulk/restore",
+      { preHandler: [requireScope("chapters:write"), requireAdminRole] },
+      async (req, reply) => {
+        const body = parseOrThrow(
+          bulkBody({
+            externalUrl: z.string().url().max(2048).optional(),
+            reason: z.string().max(500).optional(),
+          }),
+          req.body ?? {},
+        );
+        return runBulk(req, reply, {
+          kind: "RESTORE",
+          body,
+          sidecars: {
+            ...(body.externalUrl ? { externalUrl: body.externalUrl } : {}),
+          },
+          auditAction: "chapter.restore",
+          auditDetail: {
+            reason: body.reason ?? null,
+            externalUrl: body.externalUrl ?? null,
+            bulkKind: "restore",
+          },
         });
       },
     );

--- a/src/core/api/routes/ops.ts
+++ b/src/core/api/routes/ops.ts
@@ -652,6 +652,108 @@ export function registerOpsRoutes(app: FastifyInstance, ctx: AppContext): void {
       };
     });
 
+    /**
+     * Run SQL against the platform's own database.
+     *
+     * Deployment here is compose-only: there is no psql on the host and no
+     * published port, by design — a reachable 5432 has been the entry point in
+     * enough incidents. That left no way to answer a question the API happens
+     * not to expose, which is how several of this session's investigations
+     * stalled.
+     *
+     * The trade is real and worth stating. This is unrestricted read/write over
+     * HTTP, so it is fenced accordingly:
+     *
+     *  - ROOT ONLY. Not a `pa_…` token however scoped, and not a dashboard
+     *    session however privileged. Scopes are for delegating a capability;
+     *    this one is not delegable, so it is gated on the credential itself
+     *    rather than on a scope somebody could be granted.
+     *  - READ ONLY unless asked otherwise. The statement runs inside a
+     *    transaction marked read-only, so an UPDATE fails at the database
+     *    rather than on a check here that could be wrong.
+     *  - Writing needs `write` AND `confirm`, the same shape as every other
+     *    destructive verb, so a typo cannot become a mutation.
+     *  - Every statement is audited before it runs, including the ones that
+     *    fail, because "what was run against the database" is exactly the
+     *    question an incident asks.
+     *  - A statement timeout, so a careless join cannot hold a connection the
+     *    scheduler needs.
+     */
+    scope.post("/api/v1/admin/sql", async (req, reply) => {
+      if (req.principal?.kind !== "root") {
+        return reply.code(403).send({
+          error:
+            "direct SQL is restricted to the root ADMIN_TOKEN; it is not available to API tokens " +
+            "or dashboard sessions",
+        });
+      }
+
+      const body = parseOrThrow(
+        z
+          .object({
+            sql: z.string().min(1).max(20_000),
+            /** Allow the statement to modify data. Requires `confirm` too. */
+            write: z.boolean().default(false),
+            confirm: z.boolean().default(false),
+            /** Rows returned to the caller; the query itself is not rewritten. */
+            limit: z.coerce.number().int().min(1).max(5_000).default(200),
+            timeoutMs: z.coerce.number().int().min(100).max(60_000).default(15_000),
+          })
+          .strict(),
+        req.body ?? {},
+      );
+
+      if (body.write && !body.confirm) {
+        return reply
+          .code(400)
+          .send({ error: "a write needs confirm: true alongside write: true" });
+      }
+
+      // Audited BEFORE running: a statement that fails, or hangs, is the one
+      // most worth having a record of.
+      await ctx.audit.record(actor(req), body.write ? "sql.write" : "sql.read", undefined, {
+        sql: body.sql.slice(0, 4_000),
+        write: body.write,
+      });
+
+      const started = Date.now();
+      try {
+        const rows = await ctx.prisma.$transaction(async (tx) => {
+          await tx.$executeRawUnsafe(`SET LOCAL statement_timeout = ${body.timeoutMs}`);
+          if (!body.write) {
+            // Enforced by Postgres, not by inspecting the statement: parsing SQL
+            // to decide whether it writes is a guess, and a wrong guess here is
+            // an unintended mutation.
+            await tx.$executeRawUnsafe("SET LOCAL transaction_read_only = on");
+          }
+          return (await tx.$queryRawUnsafe(body.sql)) as unknown[];
+        });
+
+        const list = Array.isArray(rows) ? rows : [];
+        return {
+          ok: true,
+          write: body.write,
+          rowCount: list.length,
+          truncated: list.length > body.limit,
+          durationMs: Date.now() - started,
+          // BigInt is what Postgres returns for count(*) and for bigint columns,
+          // and JSON cannot carry it; stringifying keeps the value exact rather
+          // than rounding it into a double.
+          rows: JSON.parse(
+            JSON.stringify(list.slice(0, body.limit), (_key, value) =>
+              typeof value === "bigint" ? value.toString() : value,
+            ),
+          ) as unknown[],
+        };
+      } catch (err) {
+        return reply.code(400).send({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+          durationMs: Date.now() - started,
+        });
+      }
+    });
+
     /** Distinct services and components present, for the log page's filters. */
     scope.get("/api/v1/admin/logs/sources", { preHandler: requireScope("runs:read") }, async () => {
       const [services, components] = await Promise.all([

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -132,6 +132,8 @@ export class UploadTaskWorkers {
         return this.runDelete(chapter, log);
       case "UNAVAILABLE":
         return this.runUnavailable(chapter, raw, log);
+      case "RESTORE":
+        return this.runRestore(chapter, raw, log);
       default:
         throw new TaskError(`unknown upload task kind ${String(task.kind)}`);
     }
@@ -675,6 +677,126 @@ export class UploadTaskWorkers {
     await this.archiveUnavailable(mdChapterId, chapter, detail);
     metrics.uploadsTotal.inc({ outcome: "unavailable_ok" });
     this.queue("Unavailable", chapter, mdChapterId, true);
+  }
+
+  /**
+   * Take the card back off a chapter.
+   *
+   * Carding was a one-way door: `findExtraChapters` skips anything already
+   * carded, so nothing ever revisited one, and a chapter carded by mistake
+   * stayed carded. 213 live RuriDragon chapters were carded by a run that
+   * compared four languages it had never fetched, and there was no way to undo
+   * a single one of them.
+   *
+   * The undo is an edit session committed with NO pages, which removes the card
+   * image and leaves an ordinary external chapter. `externalUrl` is set from
+   * the stored row's chapter link, or from `externalUrl` on the task when an
+   * operator supplies one -- the row keeps the publisher's real chapter link
+   * (see `unavailableCardOptions`), which is what makes this recoverable at all.
+   */
+  private async runRestore(
+    chapter: Chapter,
+    raw: Record<string, unknown>,
+    log: Logger,
+  ): Promise<void> {
+    const { md } = this.deps;
+    const mdChapterId = chapter.mdChapterId;
+    if (!mdChapterId) throw new TaskError("restore task has no mdChapterId");
+
+    const owned = await this.ownership(mdChapterId);
+    if (!owned.ok) {
+      if (owned.gone) {
+        log.info({ mdChapterId }, "chapter is gone from MangaDex, nothing to restore");
+        this.queue("Restore", chapter, mdChapterId, true, "Chapter no longer on MangaDex.");
+        return;
+      }
+      log.error(
+        { mdChapterId, reason: owned.reason },
+        "refusing to restore a chapter this account did not upload",
+      );
+      this.queue("Restore", chapter, mdChapterId, false, `Refused: ${owned.reason}`);
+      return;
+    }
+
+    const detail = owned.detail;
+    const attrs = detail.attributes;
+    if (!isCarded(detail)) {
+      // Already an ordinary external chapter. Archiving is the right end state:
+      // a re-queued restore should not open a session to change nothing.
+      log.info({ mdChapterId }, "chapter carries no card, nothing to restore");
+      await this.archiveRestored(mdChapterId, chapter);
+      this.queue("Restore", chapter, mdChapterId, true, "No card to remove.");
+      return;
+    }
+
+    const groups = detail.relationships
+      .filter((rel) => rel.type === "scanlation_group")
+      .map((rel) => rel.id);
+
+    // An operator may correct the link while restoring; otherwise the row's
+    // chapter url wins, and only then the value MangaDex currently holds --
+    // which on a carded chapter is the replacement, not the chapter.
+    const replacement = readString(raw, "externalUrl") ?? chapter.chapterUrl ?? attrs.externalUrl;
+
+    const openSession = await md.currentUploadSession();
+    if (openSession) {
+      log.warn({ sessionId: openSession.id }, "removing stale upload session before restore");
+      await md.deleteUploadSession(openSession.id);
+    }
+
+    const session = await md.beginEditSession(mdChapterId, attrs.version);
+    try {
+      // No pages: this is what removes the card.
+      const committed = await md.commitUploadSession(
+        session.id,
+        {
+          volume: attrs.volume,
+          chapter: attrs.chapter,
+          title: attrs.title,
+          translatedLanguage: attrs.translatedLanguage,
+          externalUrl: replacement,
+        },
+        [],
+      );
+
+      let version = committed?.attributes?.version ?? null;
+      if (version === null) {
+        const refetched = await md.chapterById(mdChapterId);
+        version = refetched?.attributes.version ?? attrs.version;
+      }
+
+      const edited = await md.editChapter(mdChapterId, {
+        volume: attrs.volume,
+        chapter: attrs.chapter,
+        title: attrs.title,
+        translatedLanguage: attrs.translatedLanguage,
+        groups,
+        externalUrl: replacement,
+        version,
+      });
+      if (!edited) throw new TaskError(`couldn't restore externalUrl for chapter ${mdChapterId}`);
+    } catch (err) {
+      await this.safeDeleteSession(session.id, log);
+      this.queue("Restore", chapter, mdChapterId, false, errorMessage(err));
+      throw err;
+    }
+
+    await this.archiveRestored(mdChapterId, chapter);
+    log.info({ mdChapterId, externalUrl: replacement }, "card removed; chapter restored");
+    this.queue("Restore", chapter, mdChapterId, true);
+  }
+
+  /**
+   * Move a chapter out of the unavailable archive and back to uploaded.
+   *
+   * The row is what tells every later pass the chapter is carded, so leaving it
+   * behind would have the next run treat a restored chapter as still
+   * unavailable.
+   */
+  private async archiveRestored(mdChapterId: string, chapter: Chapter): Promise<void> {
+    const { prisma } = this.deps;
+    await prisma.unavailableChapter.deleteMany({ where: { mdChapterId } });
+    await this.recordUploadedChapter(chapter, mdChapterId);
   }
 
   /** Upload the card as page "0", retrying the way `_upload_card` does. */

--- a/src/core/processor/dedupe.ts
+++ b/src/core/processor/dedupe.ts
@@ -354,6 +354,26 @@ function findExtraChapters(input: DecideInput): MdChapter[] {
 
   const customLanguage = input.overrideOptions.custom_language ?? {};
   const allowedLanguages = new Set([...input.languages, ...Object.values(customLanguage)]);
+
+  /**
+   * The languages this run actually looked at for this series.
+   *
+   * One MangaDex title is fed by several of the publisher's titles — one per
+   * language — and a run does not always fetch all of them. A scoped recheck of
+   * RuriDragon fetched only the English title and reported eight English
+   * chapters; the pass below then compared every French, Spanish, Thai and
+   * Indonesian chapter on MangaDex against that English-only listing, found
+   * them all "missing", and carded 213 live chapters.
+   *
+   * Absence is only evidence about a language the run can actually speak for.
+   * A chapter in a language this listing never covered is not missing from it;
+   * it was never in scope, and the run has nothing to say about it.
+   *
+   * An empty catalogue is the deliberate exception: "the publisher has nothing
+   * for this series" carries no language, and must stay able to remove.
+   */
+  const coveredLanguages = new Set(input.allMangaChapters.map((c) => c.chapterLanguage));
+  const listingCoversEveryLanguage = input.allMangaChapters.length === 0;
   // Null urls are kept in the set deliberately: the comprehension
   // included them, so an MD chapter with no externalUrl is "still present"
   // whenever any extension chapter also lacks one.
@@ -374,8 +394,15 @@ function findExtraChapters(input: DecideInput): MdChapter[] {
       // subsequent run. Left in, it is re-queued forever — re-carded under
       // `unavailable`, hard-deleted under `delete`.
       !isCarded(mdChapter) &&
+      // A language the extension may not publish at all should not be on
+      // MangaDex under our group whatever this run happened to fetch, so that
+      // branch needs no coverage check.
       (!allowedLanguages.has(mdChapter.attributes.translatedLanguage) ||
-        !externalUrls.has(mdChapter.attributes.externalUrl)),
+        // "Missing from the listing" is only evidence for a language the run
+        // actually fetched. See `coveredLanguages`.
+        ((listingCoversEveryLanguage ||
+          coveredLanguages.has(mdChapter.attributes.translatedLanguage)) &&
+          !externalUrls.has(mdChapter.attributes.externalUrl))),
   );
 }
 

--- a/src/core/store/uploadTasks.ts
+++ b/src/core/store/uploadTasks.ts
@@ -22,7 +22,7 @@ import {
  * read-then-write anywhere, and nothing here can touch a LEASED row.
  */
 
-export const UPLOAD_TASK_KINDS = ["UPLOAD", "EDIT", "DELETE", "UNAVAILABLE"] as const;
+export const UPLOAD_TASK_KINDS = ["UPLOAD", "EDIT", "DELETE", "UNAVAILABLE", "RESTORE"] as const;
 export const UPLOAD_TASK_STATES = ["PENDING", "LEASED", "DONE", "FAILED", "DEAD_LETTER"] as const;
 
 /** States an operator may retry back into the queue. */

--- a/src/extsdk/context.ts
+++ b/src/extsdk/context.ts
@@ -31,6 +31,12 @@ export interface ExtensionContextOptions {
    * `UnsupportedMangaIdMapError`.
    */
   mangaIdMapNamespaced?: boolean | undefined;
+  /**
+   * The extension's configuration as the database holds it, which is what the
+   * dashboard edits. Passed through to `ctx.overrideOptions` untouched; the
+   * extension decides how it relates to the copy in its own bundle.
+   */
+  overrideOptions?: Record<string, unknown> | undefined;
   /** Overrides the manifest's allowed_hosts (tests only; normally omitted). */
   allowedHosts?: readonly string[] | undefined;
   /** Tuning/injection for the guarded fetch. */
@@ -160,6 +166,10 @@ export function createExtensionContext(opts: ExtensionContextOptions): CreatedEx
 
   const ctx: ExtensionContext = {
     manifest: Object.freeze({ ...manifest }),
+    // The database's copy of the extension's configuration, which is what the
+    // dashboard edits. Kept separate from `dataFile` rather than merged into
+    // it: which of the two wins is the extension's decision to state.
+    overrideOptions: Object.freeze({ ...(opts.overrideOptions ?? {}) }),
     mangaIdMap: invertMangaIdMap(opts.mangaIdMap ?? {}, {
       namespaced: opts.mangaIdMapNamespaced ?? false,
     }),

--- a/test/unit/failedManga.test.ts
+++ b/test/unit/failedManga.test.ts
@@ -107,6 +107,97 @@ describe("removal safety for an unreadable title", () => {
   });
 });
 
+describe("a run may only remove what it looked at", () => {
+  const mdChapter = (id: string, language: string, externalUrl: string): MdChapter =>
+    ({
+      id,
+      attributes: {
+        chapter: "50",
+        volume: null,
+        title: "t",
+        translatedLanguage: language,
+        externalUrl,
+        pages: 0,
+        version: 1,
+      },
+      relationships: [
+        { type: "manga", id: "md-manga" },
+        { type: "scanlation_group", id: "group" },
+        { type: "user", id: BOT },
+      ],
+    }) as unknown as MdChapter;
+
+  const listed = (language: string, url: string) =>
+    ({
+      chapterLanguage: language,
+      chapterUrl: url,
+      chapterId: url.split("/").pop() ?? null,
+      chapterNumber: "50",
+      mdMangaId: "md-manga",
+      imageArtifacts: [],
+    }) as unknown as NonNullable<DecideInput["allMangaChapters"]>[number];
+
+  it("leaves a language the listing never covered alone", () => {
+    // One MangaDex title is fed by one publisher title per language, and a
+    // scoped recheck may fetch only some of them. A recheck of RuriDragon
+    // fetched only the English title, and every French, Spanish, Thai and
+    // Indonesian chapter was then compared against that English-only listing,
+    // found "missing", and carded — 213 live chapters.
+    const result = decideForManga({
+      mangadexMangaId: "md-manga",
+      updatedChapters: [],
+      allMangaChapters: [listed("en", "https://pub.example/viewer/100")],
+      chaptersOnMd: [
+        mdChapter("en-50", "en", "https://pub.example/viewer/100"),
+        mdChapter("fr-50", "fr", "https://pub.example/viewer/700"),
+      ],
+      postedMdUpdates: [],
+      overrideOptions: {},
+      languages: ["en", "fr"],
+      groupId: "group",
+      cleanDb: true,
+      botUserId: BOT,
+    });
+    expect(result.toRemove).toEqual([]);
+  });
+
+  it("still removes a chapter missing from a language it did cover", () => {
+    // The counterpart: within a language the run fetched, absence is real
+    // evidence and must keep working.
+    const result = decideForManga({
+      mangadexMangaId: "md-manga",
+      updatedChapters: [],
+      allMangaChapters: [listed("en", "https://pub.example/viewer/100")],
+      chaptersOnMd: [mdChapter("en-51", "en", "https://pub.example/viewer/999")],
+      postedMdUpdates: [],
+      overrideOptions: {},
+      languages: ["en", "fr"],
+      groupId: "group",
+      cleanDb: true,
+      botUserId: BOT,
+    });
+    expect(result.toRemove.map((c) => c.id)).toEqual(["en-51"]);
+  });
+
+  it("still removes everything when the publisher genuinely lists nothing", () => {
+    // An empty catalogue names no language, so it must stay able to remove —
+    // otherwise a series the publisher really has dropped becomes untouchable.
+    const result = decideForManga({
+      mangadexMangaId: "md-manga",
+      updatedChapters: [],
+      allMangaChapters: [],
+      chaptersOnMd: [mdChapter("fr-50", "fr", "https://pub.example/viewer/700")],
+      postedMdUpdates: [],
+      overrideOptions: {},
+      languages: ["en", "fr"],
+      groupId: "group",
+      cleanDb: true,
+      botUserId: BOT,
+    });
+    expect(result.toRemove.map((c) => c.id)).toEqual(["fr-50"]);
+  });
+});
+
 describe("ownership gating", () => {
   const chapterBy = (id: string, uploader: string | null): MdChapter =>
     ({


### PR DESCRIPTION
The first commit fixes a live incident: **213 live chapters were carded** with "no longer available on the publisher" sitting above a working link.

## Removal judged languages the run never fetched (`40cb671`)

One MangaDex title is fed by several publisher titles, one per language, and a run does not always fetch all of them. A scoped recheck of RuriDragon fetched only the English title and reported **8 English chapters**. `findExtraChapters` then compared *every* chapter of that title — French, Spanish, Thai, Indonesian — against that English-only listing, found them all missing, and carded them. English survived, which is what made the pattern legible.

This is the hazard already documented for scoped runs (a listing is silent about what it never asked for), except the silence also runs along the **language axis within one title**, where nothing guarded it.

**I diagnosed this wrong twice before the data corrected me.** First I claimed `allChapters` was only the free window — refuted: it contained the fr chapter at exactly the URL that got carded. Then I claimed the recheck couldn't see all five language ids — refuted: all five are tracked. The audit rows added earlier (`pass: "no-longer-listed"`, two entries per chapter matching the two rechecks) are what identified the real cause.

Absence is now only evidence for a language the listing covers. Two cases still remove deliberately: a **disallowed** language (shouldn't be there regardless — an existing test caught me over-gating this and was right), and an **empty** catalogue (names no language, so a genuinely dropped series stays removable).

Checked and already correct: `dupeKey` has always led with `translatedLanguage`; edits match on the publisher's chapter URL. Removal was the only pass comparing across languages it had not read.

## Un-carding (`ce78c04`)

Carding was one-way — task kinds were `UPLOAD|EDIT|DELETE|UNAVAILABLE`, the only "restore" belonged to the errors feed, and `findExtraChapters` skips carded chapters so nothing revisited them. The 213 could not be reversed at all.

`RESTORE` opens an edit session and commits with **no pages**, removing the card image. `externalUrl` comes from the stored row — which still holds the real chapter link, because the card was changed to prefer the row over MangaDex precisely so this stayed recoverable — or from an operator correction.

Refuses what every destructive verb refuses (not ours, already gone), plus a chapter carrying no card, so an over-broad filter says so in the dry run. A filter without an archive means `unavailable`, since that is the only set it can act on.

On the dashboard it appears only where cards exist, with the publisher link editable.

## Root-only SQL (`ca251fa`)

The server is compose-only: no psql, no published port. Root credential only — not a `pa_` token however scoped, not a session however privileged, because this capability is not delegable. Read-only unless `write` **and** `confirm`, enforced by a read-only transaction rather than by parsing the statement (a wrong guess there is an unintended mutation). Audited **before** execution, so failures and timeouts are recorded too. Statement timeout; bigints stringified rather than rounded.

**Rotate `ADMIN_TOKEN` before deploying this** — it was pasted into a chat transcript earlier today and now gates database access.

## Also here

`f84cf3a` builds the three images as a matrix instead of sequentially, with `provenance`/`sbom` off — both architectures still built and asserted. `4576e29` repairs the integration fixtures my ownership gate broke, and names Logs in the no-script fallback.

## Still outstanding

The 213 are **not yet reversed**. That needs this deployed first (or the next run re-cards them), and a sample checked against MangaPlus — some of that back catalogue may genuinely be dead, so it is not a blanket restore.

Typecheck, lint, 889 unit tests pass.
