### PR TITLE
Actually drain the RESTORE queue

### DIFF
--- a/src/services/uploader.ts
+++ b/src/services/uploader.ts
@@ -26,7 +26,19 @@ import { startMetricsServer } from "../core/observability/metricsServer.js";
 /** Long enough for a full page set at the MangaDex ratelimit. */
 const LEASE_TTL_SECONDS = 600;
 const IDLE_SLEEP_MS = 5_000;
-const KIND_ORDER: UploadTaskKind[] = ["DELETE", "EDIT", "UPLOAD", "UNAVAILABLE"];
+/**
+ * Which queues this drains, and in what order.
+ *
+ * A kind missing from this list is never claimed at all: `claim` takes one
+ * kind, so a task of a kind nobody asks for waits forever in PENDING with
+ * nothing to say it is stuck. RESTORE was added as a task kind and a worker
+ * without being added here, and 39 restore tasks sat untouched because of it.
+ *
+ * RESTORE goes first because it is the corrective verb: it takes a card off a
+ * chapter that should not have one, and until it runs a reader is looking at
+ * "no longer available" over a chapter they can actually read.
+ */
+const KIND_ORDER: UploadTaskKind[] = ["RESTORE", "DELETE", "EDIT", "UPLOAD", "UNAVAILABLE"];
 
 const config = loadConfig();
 const log = createLogger("core-uploader", config.logLevel);


### PR DESCRIPTION
RESTORE was added as a task kind in #64, given a worker, and wired into the API and the dashboard — and then never added to `KIND_ORDER`, the list `core-uploader` iterates.

`claim` takes one kind at a time, so a kind nobody asks for is never claimed. **39 restore tasks are sitting in `PENDING` in production right now**, nothing leased, nothing failing, nothing to indicate they are stuck.

That is the worst shape a queue bug can take: a task that errors dead-letters and surfaces in the errors feed, while a task of an unasked-for kind looks exactly like a task waiting its turn.

RESTORE drains **first**. It is the corrective verb — it takes a card off a chapter that should not have one — and until it runs a reader is looking at "no longer available on the publisher" above a chapter they can actually read. Everything else can wait behind that.

This unblocks the 39 chapters queued for restore in #64: the ones a scoped recheck carded after judging four languages it never fetched.

Typecheck, lint, 889 unit tests pass.
