### PR TITLE
Fix the two checks that would misfire on the re-card and duplicate sweeps

### DIFF
--- a/src/core/md/client.ts
+++ b/src/core/md/client.ts
@@ -717,9 +717,6 @@ export class MdClient implements MdExtendedApi {
         // one another and hard-delete them.
         ...(typeof pages === "number" ? { pages } : {}),
         ...(isUnavailable === true ? { isUnavailable: true } : {}),
-        // Identifies the page content, which is how a replaced card is told
-        // apart from a commit that returned 200 and changed nothing.
-        ...(str("hash") !== null ? { hash: str("hash") as string } : {}),
       },
       relationships: (entity.relationships ?? []).map((rel) => ({ id: rel.id, type: rel.type })),
     };

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -678,7 +678,7 @@ export class UploadTaskWorkers {
         // every one of them regenerated and change none.
         await this.confirmCardLanded(
           mdChapterId,
-          { pages: attrs.pages ?? 0, hash: attrs.hash ?? null },
+          { pages: attrs.pages ?? 0, version: attrs.version },
           log,
         );
 
@@ -710,10 +710,20 @@ export class UploadTaskWorkers {
    *
    *  - a chapter with no pages must come back with at least one. That is a card
    *    where there was none.
-   *  - a chapter that already had a card must come back with a DIFFERENT page
-   *    hash. The count stays at one either way, so it says nothing about
-   *    whether the image was replaced, and re-carding thousands of chapters
-   *    whose commits all quietly did nothing would look identical to success.
+   *  - a chapter that already had a card must come back with a HIGHER version.
+   *    The page count stays at one either way, so it says nothing about whether
+   *    the image was replaced, and re-carding thousands of chapters whose
+   *    commits all quietly did nothing would look identical to success.
+   *
+   * The version is the available signal for that second case, and it is a sound
+   * one: a commit that does real work bumps it, and the no-op commit behind the
+   * un-carding bug leaves it untouched -- that chapter sat at version 7 across
+   * repeated attempts while MangaDex answered 200 every time.
+   *
+   * Page CONTENT would be the more direct thing to compare, and it is not
+   * available: `GET /chapter/{id}` returns no `hash` field at all. Comparing it
+   * was the first attempt here and it failed every re-card it saw, because the
+   * value was absent rather than merely unchanged.
    *
    * Re-read a few times before giving up. MangaDex serves chapter reads from a
    * cache that lags its own writes, so the first read after a commit can still
@@ -722,11 +732,11 @@ export class UploadTaskWorkers {
    */
   private async confirmCardLanded(
     mdChapterId: string,
-    before: { pages: number; hash: string | null },
+    before: { pages: number; version: number },
     log: Logger,
   ): Promise<void> {
     let pages: number | null = null;
-    let hash: string | null = null;
+    let version: number | null = null;
 
     for (let attempt = 1; attempt <= CARD_CONFIRM_ATTEMPTS; attempt += 1) {
       if (attempt > 1) {
@@ -737,16 +747,17 @@ export class UploadTaskWorkers {
       }
       const after = await this.deps.md.chapterById(mdChapterId);
       pages = after?.attributes.pages ?? null;
-      hash = after?.attributes.hash ?? null;
+      version = after?.attributes.version ?? null;
 
       const gainedAPage = before.pages === 0 && (pages ?? 0) > 0;
-      const replacedTheImage = before.pages > 0 && hash !== null && hash !== before.hash;
-      if (gainedAPage || replacedTheImage) return;
+      const commitDidWork = before.pages > 0 && version !== null && version > before.version;
+      if (gainedAPage || commitDidWork) return;
     }
 
     throw new TaskError(
       `the card did not land on chapter ${mdChapterId}: pages ${before.pages} -> ` +
-        `${pages === null ? "unknown" : pages}, hash ${before.hash ?? "none"} -> ${hash ?? "none"}`,
+        `${pages === null ? "unknown" : pages}, version ${before.version} -> ` +
+        `${version === null ? "unknown" : version}`,
     );
   }
 

--- a/src/core/md/types.ts
+++ b/src/core/md/types.ts
@@ -75,19 +75,6 @@ export interface MdChapter {
      * this flag only when it is `true`.
      */
     isUnavailable?: boolean;
-    /**
-     * MangaDex's identifier for the CONTENT of this chapter's pages.
-     *
-     * Carried for one reason: it is the only thing that distinguishes one card
-     * from another. Replacing a card leaves the page count at one either way,
-     * so `pages` cannot say whether a re-card actually replaced the image or
-     * whether the commit quietly did nothing -- and a commit that quietly does
-     * nothing is a thing MangaDex demonstrably returns 200 for.
-     *
-     * Optional: absent on chapters with no pages, which is every live external
-     * chapter.
-     */
-    hash?: string;
   };
   relationships: { id: string; type: string }[];
 }

--- a/src/core/processor/dedupe.ts
+++ b/src/core/processor/dedupe.ts
@@ -640,14 +640,46 @@ function decideCandidates(input: DecideInput): {
 // ---------------------------------------------------------------------------
 
 /**
+ * Does this link identify a chapter, or merely a publisher?
+ *
+ * Carding repoints externalUrl at the best link it can find: the chapter, then
+ * the series, then -- when neither is known -- the publisher's bare domain.
+ * That last one is not an identity. Every chapter that fell through to it
+ * carries the same url while being a different chapter, so keying duplicates on
+ * it buckets unrelated chapters together and hard-deletes all but the oldest.
+ *
+ * A scan of 773 series found exactly three "duplicates" and all three were
+ * this: distinct RuriDragon chapters -- en 5 and 6, es-la 4, 5 and 6 -- whose
+ * only shared feature was `https://mangaplus.shueisha.co.jp/`. Applying it
+ * would have deleted three live chapters.
+ *
+ * Anything with a real path is left alone, because that is where genuine
+ * chapter links live and where `multi_chapters` does its work.
+ */
+function identifiesAChapter(url: string): boolean {
+  try {
+    return new URL(url).pathname.replace(/\/+$/, "") !== "";
+  } catch {
+    // Unparseable: it cannot be shown to identify anything, so it does not.
+    return false;
+  }
+}
+
+/**
  * Chapters that duplicate one another. External/link chapters are keyed on
- * their exact externalUrl; image chapters fall back to volume + number.
- * Language is part of every key, so the same chapter in two languages is never
- * a duplicate of itself.
+ * their exact externalUrl; image chapters, and link chapters whose url names
+ * only the publisher, fall back to volume + number. Language is part of every
+ * key, so the same chapter in two languages is never a duplicate of itself.
+ *
+ * The url key is deliberately kept for real links rather than tightened with
+ * the chapter number. `multi_chapters` exists precisely to say which numbers
+ * legitimately share one publisher link, so that an undeclared extra copy is
+ * still caught; adding the number here would make every number its own bucket
+ * and quietly retire that whole mechanism.
  */
 function dupeKey(mdChapter: MdChapter): string {
   const attrs = mdChapter.attributes;
-  if (attrs.externalUrl) {
+  if (attrs.externalUrl && identifiesAChapter(attrs.externalUrl)) {
     return JSON.stringify([attrs.translatedLanguage, "url", attrs.externalUrl]);
   }
   return JSON.stringify([attrs.translatedLanguage, "image", attrs.volume, attrs.chapter]);

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -1163,7 +1163,7 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
      * able to describe both sides of that: the chapter before it is carded, and
      * the chapter after.
      */
-    const detail = (pages = 0, hash = "card-hash"): MdChapterDetail => ({
+    const detail = (pages = 0, version = 3): MdChapterDetail => ({
       id: uuid(1),
       attributes: {
         volume: null,
@@ -1171,9 +1171,9 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
         title: "Chapter one",
         translatedLanguage: "en",
         externalUrl: null,
-        version: 3,
+        version,
         createdAt: "2026-01-01T00:00:00.000Z",
-        ...(pages > 0 ? { pages, hash } : {}),
+        ...(pages > 0 ? { pages } : {}),
       },
       relationships: [
         { id: uuid(800), type: "scanlation_group" },
@@ -1196,7 +1196,9 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
       return {
         chapterById: async () => {
           calls.push("chapterById");
-          return detail(carded ? 1 : 0);
+          // A committed card means a page and a bumped version, which is what
+          // the uploader re-reads to confirm the work actually landed.
+          return carded ? detail(1, 4) : detail(0, 3);
         },
         beginEditSession: async () => {
           calls.push("beginEditSession");

--- a/test/unit/dedupe.test.ts
+++ b/test/unit/dedupe.test.ts
@@ -353,6 +353,46 @@ describe("findDuplicateChapters", () => {
   });
 
   /**
+   * A link naming only the publisher is not a chapter identity.
+   *
+   * Carding repoints externalUrl at the chapter, else the series, else the
+   * publisher's bare domain. Chapters that fell through to that last one all
+   * carry the same url while being different chapters, so keying duplicates on
+   * it buckets them together and hard-deletes all but the oldest.
+   *
+   * A scan of 773 series found three "duplicates" and all three were this:
+   * distinct RuriDragon chapters sharing `https://mangaplus.shueisha.co.jp/`.
+   * Applying it would have deleted three live chapters.
+   */
+  it("does not treat a bare publisher domain as chapter identity", () => {
+    const five = mdChapter("ruri-5", {
+      chapter: "5",
+      externalUrl: "https://mangaplus.shueisha.co.jp/",
+    });
+    const six = mdChapter("ruri-6", {
+      chapter: "6",
+      externalUrl: "https://mangaplus.shueisha.co.jp/",
+    });
+    expect(findDuplicateChapters([five, six], { groupId: "grp", botUserId: BOT })).toEqual([]);
+  });
+
+  it("still dedupes on a url that does name a chapter", () => {
+    // The protection above must not cost the detection it exists to make safe:
+    // a real link still buckets, which is also what `multi_chapters` relies on.
+    const first = withCreatedAt(
+      mdChapter("same-old", { chapter: "7", externalUrl: "https://pub.example/c/7" }),
+      "2024-01-01T00:00:00+00:00",
+    );
+    const second = withCreatedAt(
+      mdChapter("same-new", { chapter: "8", externalUrl: "https://pub.example/c/7" }),
+      "2025-01-01T00:00:00+00:00",
+    );
+    expect(
+      findDuplicateChapters([first, second], { groupId: "grp", botUserId: BOT }).map((c) => c.id),
+    ).toEqual(["same-new"]);
+  });
+
+  /**
    * The regression this file exists to prevent from recurring. Marking a
    * chapter unavailable repoints its externalUrl at the publisher's manga page
    * rather than clearing it, so every carded chapter of a series carries the


### PR DESCRIPTION
Two live-behaviour fixes, both found by testing small before running at scale. Both block the re-card sweep (#9) and the dead-chapter sweep (#11).

## 1. A bare publisher domain is not a chapter identity (`a09759a`)

A report-only duplicate scan over **773 series** found 3 duplicates. **All three were false.** They were distinct RuriDragon chapters — en 5 and 6, es-la 4, 5 and 6 — whose only shared feature was the externalUrl `https://mangaplus.shueisha.co.jp/`.

Carding repoints externalUrl at the chapter, else the series, else the publisher's bare domain. That last one means "no link found" — it is not an identity, and every chapter that fell through to it carries it. Keyed on url, they bucket together and everything but the oldest is **hard-deleted**.

Applying that scan would have deleted three live chapters.

Now a url only counts as identity when it has a path. Anything naming just the publisher falls back to volume + number, which separates chapter 5 from chapter 6 correctly.

**This is the one that matters most for deploying.** `deleteDuplicates` runs on *every* run, not just clean ones, so any MangaPlus run on the current code would delete those three live chapters.

Deliberately **not** fixed by adding the chapter number to the url key — that was the first attempt, it passed all 900 unit tests, and it quietly disabled `multi_chapters`, which works by declaring which numbers legitimately share one link so an *undeclared* extra copy is still caught. The integration test caught it.

## 2. Confirm a re-card by version, not page hash (`d5e028a`)

The card-landed check compared the page hash, and `GET /chapter/{id}` returns no `hash` field at all — absent, not unchanged. So the comparison could never be true and **every re-card failed it**. A test chapter was carded five times, correctly, and dead-lettered anyway with `pages 1 -> 1, hash none -> none`.

Caught by queueing 2 chapters instead of the 2,504 the sweep would have taken.

Version is the signal that is actually available and is a sound one: that chapter went 7 → 13 across the five re-cards, while the no-op commit behind the un-carding bug leaves it pinned at 7 no matter how often it is retried. `hash` is removed from the chapter mapping rather than left unused, since nothing populates it and a permanently-undefined field invites the same mistake again.

## Verification

- 900/900 unit tests, `tsc` and `eslint` clean.
- Integration suite run against a real Postgres: **8 failed / 397 passed**, the identical pre-existing set that master fails (master: **12 failed / 393 passed**). No new failures.
- New tests pin both the bare-domain case and that a real chapter url still dedupes (which `multi_chapters` relies on).

## After this deploys

Re-scan duplicates in report mode expecting 0, requeue the one dead-lettered re-card to confirm the version check, then start #9 in batches and #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6