### PR TITLE
Add watchtower for automatic image updates

### DIFF
--- a/docker/core/.env.example
+++ b/docker/core/.env.example
@@ -131,6 +131,13 @@ TUNNEL_TOKEN=
 # PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.5
 # PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.5
 
+# --- optional: automatic updates --------------------------------------------
+
+# `watchtower` auto-pulls new images. It has no effect on the pinned tags above:
+# point both at `:latest` to use it. Caveats are above the service in
+# docker-compose.yml. Turn it off with `docker compose stop watchtower`.
+# WATCHTOWER_POLL_INTERVAL=300
+
 # The image the dashboard's enrolment snippet tells a NEW WORKER HOST to run.
 # This deployment does not run it, it only hands out the name, so it is set
 # separately from the two above and should track whatever workers ought to be

--- a/docker/core/.env.production.example
+++ b/docker/core/.env.production.example
@@ -21,6 +21,8 @@
 PUBLOADER_ENV=prod
 
 # --- images (PINNED; bump deliberately, never track `latest`) --------------
+# While these stay pinned, watchtower does nothing here. Move them to `:latest`
+# to auto-update prod.
 PUBLOADER_CORE_IMAGE=ardax/publoader-core:2.1.5
 PUBLOADER_MIGRATE_IMAGE=ardax/publoader-core-migrate:2.1.5
 

--- a/docker/core/docker-compose.yml
+++ b/docker/core/docker-compose.yml
@@ -46,6 +46,10 @@ x-app-security: &app-security
     options:
       max-size: "20m"
       max-file: "5"
+  labels:
+    # Marks the container auto-updatable. On the anchor so it covers exactly our
+    # own images; postgres and cloudflared don't inherit it and are never touched.
+    com.centurylinklabs.watchtower.scope: publoader
 
 # Every core service reads the same base config. Kept in one anchor so a new
 # tuning knob is added to all four at once rather than to whichever one the
@@ -513,6 +517,46 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  # --- watchtower -----------------------------------------------------------
+  # Pulls new images for the scoped services and recreates them, so a push
+  # lands without a deploy. Two things to know:
+  #
+  #  - It does NOTHING against a pinned tag. Point PUBLOADER_CORE_IMAGE and
+  #    PUBLOADER_MIGRATE_IMAGE at `:latest` for it to have any effect.
+  #  - `depends_on` orders `compose up`, not watchtower. `migrate` is included
+  #    (hence INCLUDE/REVIVE_STOPPED) so schema changes do get applied, but
+  #    ordering against the app services is best effort: a release changing both
+  #    schema and code can throw failed queries for a few seconds.
+  #
+  # It holds the Docker socket, which is root on the host. Front it with a
+  # socket proxy if that matters more than the convenience.
+  watchtower:
+    image: containrrr/watchtower:latest
+    restart: unless-stopped
+    environment:
+      WATCHTOWER_SCOPE: publoader
+      WATCHTOWER_POLL_INTERVAL: ${WATCHTOWER_POLL_INTERVAL:-300}
+      # This host has filled its disk on old image layers before.
+      WATCHTOWER_CLEANUP: "true"
+      WATCHTOWER_INCLUDE_STOPPED: "true"
+      WATCHTOWER_REVIVE_STOPPED: "true"
+      WATCHTOWER_NO_STARTUP_MESSAGE: "true"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - edge
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 256m
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    # Unlabelled on purpose: it does not update itself.
 
 networks:
   # Database plane. `internal: true` removes the default gateway from this


### PR DESCRIPTION
Pulls new images for the scoped services and recreates them, so a push lands without a deploy.

**Scope.** The `watchtower.scope=publoader` label sits on the shared `x-app-security` anchor, which is inherited by exactly the six services running our images (`core-api`, `core-scheduler`, `core-processor`, `core-uploader`, `migrate`, `publoader-bot`). Postgres and cloudflared do not inherit it and are never touched — excluded structurally rather than by a list that drifts. Watchtower is unlabelled itself, so it does not update itself.

`WATCHTOWER_CLEANUP` is on: this host filled its disk on accumulated image layers this morning, which stopped Postgres from starting at all.

## Two caveats

**Inert on production as-is.** `.env.production.example` pins `2.1.5` and says "never track `latest`". I did not change that — it is a deliberate policy. Watchtower does nothing there until both `PUBLOADER_CORE_IMAGE` and `PUBLOADER_MIGRATE_IMAGE` point at a moving tag. Staging already tracks `latest`, so it takes effect there on first `up`.

**Migration ordering is best effort.** `depends_on: migrate` orders `compose up`, not watchtower, which recreates containers directly. `migrate` is included (hence `INCLUDE_STOPPED`/`REVIVE_STOPPED`) so schema changes do get applied, but a release carrying both a migration and code can throw failed queries for a few seconds before migrate lands. Non-destructive — Prisma just errors — but real: today's release carried a migration.

It also holds the Docker socket, which is root on the host. Standard watchtower trade, and a step down from this stack's posture of no published ports and all capabilities dropped. A socket proxy in front would narrow it.

## Verification

No Docker available locally, so `docker compose config` was not run. Validated that the YAML parses and that label inheritance resolves to exactly the six intended services, with postgres, cloudflared and watchtower excluded. Worth an eyeball on first `up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6