### PR TITLE
Fix runDelete's orphaned archive rows, pin tests to UTC, add a Restores tab

### DIFF
--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -1025,6 +1025,7 @@ const NAV = [
     tabs: [
       ["uploaded", "On MangaDex"],
       ["unavailable", "Unavailable"],
+      ["restores", "Restores"],
       ["deleted", "Deleted"],
       ["edited", "Edited"],
     ],
@@ -4039,8 +4040,65 @@ const CHAPTER_ARCHIVE_LABELS = {
   edited: "Last edited",
 };
 
+/**
+ * Chapters whose card we decided was wrong, and whether it actually came off.
+ *
+ * The task state is not the answer. A restore can report DONE and change
+ * nothing -- 23 chapters were recorded that way while every one kept its card.
+ * Which archive the chapter is in NOW is the answer, so that is what `outcome`
+ * reports and what this page is sorted around.
+ */
+function chapterRestores() {
+  const restores = new Resource("chapter-restores", () => api("/chapters/restores?limit=200"));
+  return el(
+    "div",
+    {},
+    card(
+      "Restores",
+      el("p", {
+        class: "dim small",
+        text:
+          "Chapters an audit or an operator judged wrongly carded, and what became of the attempt. " +
+          "“Still carded” means the card is on the chapter right now, whatever the task says.",
+      }),
+      live([restores], (data) => {
+        const rows = data?.restores ?? [];
+        const counts = data?.counts ?? {};
+        return el("div", {}, [
+          el("p", {
+            class: "small",
+            text:
+              `${counts.stillCarded ?? 0} still carded · ${counts.restored ?? 0} restored · ` +
+              `${counts.gone ?? 0} no longer on MangaDex`,
+          }),
+          table(
+            ["Chapter", "Series", "Lang", "Ch", "Outcome", "Task", "Last error"],
+            rows.map((r) => [
+              el("code", { text: (r.mdChapterId ?? "—").slice(0, 8) }),
+              r.mangaName ?? "—",
+              r.chapterLanguage ?? "—",
+              r.chapterNumber ?? "—",
+              el("span", {
+                class: r.outcome === "still-carded" ? "warn-text" : "dim",
+                text: r.outcome,
+              }),
+              r.taskState ?? "—",
+              el("span", { class: "dim small", text: (r.lastError ?? "").slice(0, 90) }),
+            ]),
+            { empty: "No un-card attempts recorded." },
+          ),
+        ]);
+      }),
+    ),
+  );
+}
+
 VIEWS.chapters = (route) => {
   if (route.param) return chapterDetail(route.param);
+  // Not an archive: these are chapters spread across archives, grouped by a
+  // decision made about them. It shares the section because that is where an
+  // operator looks, not because it shares the listing machinery.
+  if (route.tab === "restores") return chapterRestores();
   const archive = route.tab ?? "uploaded";
   const f = () => store.filters;
   const cursors = () => f().chapterCursors[archive] ?? [];

--- a/src/core/api/routes/chapters.ts
+++ b/src/core/api/routes/chapters.ts
@@ -720,6 +720,103 @@ export function registerChapterRoutes(app: FastifyInstance, ctx: AppContext): vo
       },
     );
 
+    /**
+     * Chapters we decided should NOT be carded, and what became of that.
+     *
+     * A RESTORE task means somebody (or a removal audit) judged the card wrong.
+     * Whether the card is actually off is not the task's state -- a restore can
+     * report DONE and change nothing, which is how 23 chapters were recorded as
+     * restored while every one kept its card. The honest signal is which
+     * archive the chapter sits in now: `unavailable` means still carded,
+     * `uploaded` means the card really came off.
+     */
+    scope.get(
+      "/api/v1/admin/chapters/restores",
+      { preHandler: requireScope("chapters:read") },
+      async (req) => {
+        const query = parseOrThrow(
+          z.object({
+            outcome: z.enum(["all", "still-carded", "restored"]).default("all"),
+            limit: z.coerce.number().int().min(1).max(MAX_PAGE).default(DEFAULT_PAGE),
+          }),
+          req.query ?? {},
+        );
+
+        const tasks = await ctx.prisma.uploadTask.findMany({
+          where: { kind: "RESTORE" },
+          orderBy: { updatedAt: "desc" },
+          take: query.limit,
+          select: { id: true, state: true, attempt: true, lastError: true, updatedAt: true, chapter: true },
+        });
+
+        const rowOf = (value: unknown): Record<string, unknown> =>
+          value !== null && typeof value === "object" ? (value as Record<string, unknown>) : {};
+        const idOf = (task: (typeof tasks)[number]): string | null => {
+          const id = rowOf(task.chapter)["mdChapterId"];
+          return typeof id === "string" ? id : null;
+        };
+
+        const ids = tasks.map(idOf).filter((id): id is string => id !== null);
+        const [carded, live, deleted] = await Promise.all([
+          ctx.prisma.unavailableChapter.findMany({
+            where: { mdChapterId: { in: ids } },
+            select: { mdChapterId: true },
+          }),
+          ctx.prisma.uploadedChapter.findMany({
+            where: { mdChapterId: { in: ids } },
+            select: { mdChapterId: true },
+          }),
+          ctx.prisma.deletedChapter.findMany({
+            where: { mdChapterId: { in: ids } },
+            select: { mdChapterId: true },
+          }),
+        ]);
+        const cardedIds = new Set(carded.map((r) => r.mdChapterId));
+        const liveIds = new Set(live.map((r) => r.mdChapterId));
+        const deletedIds = new Set(deleted.map((r) => r.mdChapterId));
+
+        const rows = tasks
+          .map((task) => {
+            const mdChapterId = idOf(task);
+            const chapter = rowOf(task.chapter);
+            const outcome = !mdChapterId
+              ? "unknown"
+              : cardedIds.has(mdChapterId)
+                ? "still-carded"
+                : deletedIds.has(mdChapterId)
+                  ? "gone"
+                  : liveIds.has(mdChapterId)
+                    ? "restored"
+                    : "unknown";
+            return {
+              mdChapterId,
+              outcome,
+              taskState: task.state,
+              attempt: task.attempt,
+              lastError: task.lastError,
+              at: task.updatedAt,
+              extension: chapter["extensionName"] ?? null,
+              mangaName: chapter["mangaName"] ?? null,
+              mdMangaId: chapter["mdMangaId"] ?? null,
+              chapterNumber: chapter["chapterNumber"] ?? null,
+              chapterLanguage: chapter["chapterLanguage"] ?? null,
+              chapterUrl: chapter["chapterUrl"] ?? null,
+            };
+          })
+          .filter((row) => query.outcome === "all" || row.outcome === query.outcome);
+
+        return {
+          restores: rows,
+          counts: {
+            stillCarded: rows.filter((r) => r.outcome === "still-carded").length,
+            restored: rows.filter((r) => r.outcome === "restored").length,
+            gone: rows.filter((r) => r.outcome === "gone").length,
+          },
+          limit: query.limit,
+        };
+      },
+    );
+
     scope.get("/api/v1/admin/chapters", { preHandler: requireScope("chapters:read") }, async (req) => {
       const query = parseOrThrow(
         z.object({

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -483,6 +483,10 @@ export class UploadTaskWorkers {
       if (owned.gone) {
         log.info({ mdChapterId }, "chapter already gone from MangaDex, nothing to delete");
         metrics.uploadsTotal.inc({ outcome: "delete_already_gone" });
+        // Still archive it. The chapter is gone either way, and leaving the
+        // live rows behind is what makes the archives describe chapters that
+        // no longer exist.
+        await this.archiveDeleted(mdChapterId, chapter);
         this.queue("Delete", chapter, mdChapterId, true, "Chapter no longer on MangaDex.");
         return;
       }
@@ -512,19 +516,37 @@ export class UploadTaskWorkers {
       throw new TaskError(message);
     }
 
-    // Archive first, then drop the live row; deletion is irreversible, so the
-    // record of what was removed outlives it (legacy deleter.py appended to the
-    // `deleted` collection for exactly this reason).
+    await this.archiveDeleted(mdChapterId, chapter);
+    metrics.uploadsTotal.inc({ outcome: "delete_ok" });
+    log.info({ mdChapterId }, "chapter deleted from MangaDex and archived");
+    this.queue("Delete", chapter, mdChapterId, true);
+  }
+
+  /**
+   * Record a chapter as deleted and take it out of the live archives.
+   *
+   * Archive first, then drop the live rows: deletion is irreversible, so the
+   * record of what was removed outlives it (legacy deleter.py appended to the
+   * `deleted` collection for the same reason).
+   *
+   * BOTH live archives are cleared, which is the part that was missing. A
+   * chapter can be in `uploaded` or in `unavailable`, never both, and delete
+   * only ever cleared `uploaded` -- so deleting a CARDED chapter left its
+   * `unavailable_chapters` row behind for good. Nothing removes those later,
+   * so the archive kept describing chapters MangaDex no longer has: 13 of them
+   * on RuriDragon alone, which is how a query for "carded chapters" answered 36
+   * when only 23 existed.
+   */
+  private async archiveDeleted(mdChapterId: string, chapter: Chapter): Promise<void> {
     const columns = chapterToColumns({ ...chapter, mdChapterId });
-    await this.deps.prisma.deletedChapter.upsert({
+    const { prisma } = this.deps;
+    await prisma.deletedChapter.upsert({
       where: { mdChapterId },
       create: { mdChapterId, ...columns },
       update: { ...columns, deletedAt: new Date() },
     });
-    await this.deps.prisma.uploadedChapter.deleteMany({ where: { mdChapterId } });
-    metrics.uploadsTotal.inc({ outcome: "delete_ok" });
-    log.info({ mdChapterId }, "chapter deleted from MangaDex and archived");
-    this.queue("Delete", chapter, mdChapterId, true);
+    await prisma.uploadedChapter.deleteMany({ where: { mdChapterId } });
+    await prisma.unavailableChapter.deleteMany({ where: { mdChapterId } });
   }
 
   // --------------------------------------------------------- UNAVAILABLE

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -59,6 +59,17 @@ export default async function setup(): Promise<() => Promise<void>> {
           await client.query(`CREATE DATABASE "${dbName}"`);
           created = !reuse;
         }
+        // Pin the test database to UTC, whatever timezone the server or the
+        // developer's machine runs in.
+        //
+        // Every timestamp column here is `timestamp without time zone` and
+        // Prisma writes JS Dates as UTC, so any SQL comparing one against
+        // `now()` is comparing UTC to the server's local clock. On a machine
+        // set to UTC+03 that makes a heartbeat written a second ago look three
+        // hours old: workers read as dead, leases as expired, backoffs as
+        // elapsed. Seven integration tests failed that way and none of them had
+        // anything wrong with them.
+        await client.query(`ALTER DATABASE "${dbName}" SET timezone = 'UTC'`);
       } finally {
         await client.end();
       }

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -1309,6 +1309,63 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
       });
       expect(archived.chapterNumber).toBe("1");
     });
+
+    /**
+     * Deleting a CARDED chapter has to clear the unavailable archive too.
+     *
+     * A chapter lives in `uploaded` or in `unavailable`, never both, and delete
+     * only ever cleared `uploaded`. So deleting a carded chapter left its
+     * `unavailable_chapters` row behind permanently, and nothing removes those
+     * later: the archive kept describing chapters MangaDex no longer holds. On
+     * RuriDragon that was 13 rows, which is how a query for "still carded"
+     * answered 36 when the real number was 23.
+     */
+    it("clears the unavailable archive when a carded chapter is deleted", async () => {
+      // Card it first, which is what puts the row in `unavailable`.
+      await run(false);
+      expect(await prisma.unavailableChapter.count({ where: { mdChapterId: uuid(1) } })).toBe(1);
+
+      const calls: string[] = [];
+      const workers = new UploadTaskWorkers({
+        prisma,
+        md: {
+          ...stubMd(calls),
+          deleteChapter: async () => {
+            calls.push("deleteChapter");
+            return true;
+          },
+        } as never,
+        notifier: notifier as never,
+        settings: new SettingsStore(prisma),
+        config,
+        log,
+      });
+
+      const task = await prisma.uploadTask.create({
+        data: {
+          kind: "DELETE",
+          dedupeKey: `del-${uuid(1)}`,
+          state: "LEASED",
+          chapter: {
+            mdChapterId: uuid(1),
+            mdMangaId: uuid(900),
+            mdGroupId: uuid(800),
+            chapterNumber: "1",
+            chapterLanguage: "en",
+            mangaName: "Test Series",
+            extensionName: "exampleext",
+            imageArtifacts: [],
+          },
+        },
+      });
+      await workers.execute(task);
+
+      expect(calls).toContain("deleteChapter");
+      expect(await prisma.unavailableChapter.count({ where: { mdChapterId: uuid(1) } })).toBe(0);
+      expect(await prisma.uploadedChapter.count({ where: { mdChapterId: uuid(1) } })).toBe(0);
+      // The record of what was removed outlives the chapter.
+      expect(await prisma.deletedChapter.count({ where: { mdChapterId: uuid(1) } })).toBe(1);
+    });
   });
 
   // ---- asking the publisher whether a series is still there ----


### PR DESCRIPTION
Three independent fixes.

## 1. `runDelete` orphaned `unavailable_chapters` rows (`8dedce6`)

A chapter lives in `uploaded` **or** `unavailable`, never both, and delete only ever cleared `uploaded`. Deleting a **carded** chapter therefore left its `unavailable_chapters` row behind permanently, and nothing removes those later — so the archive kept describing chapters MangaDex no longer holds. 13 of them on RuriDragon alone, which is why a query for "still carded" answered 36 when the real number was 23.

The already-gone branch had the same gap with a worse excuse: it reported success and archived nothing at all, so a chapter that vanished upstream kept both its live row and its card record.

Both paths now go through one `archiveDeleted`. Pinned by an integration test that cards a chapter, deletes it, and asserts both live archives are clear and the deleted record survives.

## 2. Integration tests pinned to UTC (`84e265f`)

Seven integration tests failed on a machine set to UTC+03, and none of them had anything wrong with them.

Every timestamp column is `timestamp without time zone` and Prisma writes JS Dates as UTC, so SQL comparing one against `now()` compares UTC to the server's local clock. On a +03 host a heartbeat written a second ago reads as three hours old: workers look dead, leases expired, backoffs elapsed. That was claim fairness, lease requeues, retry budgets and timestamp cursors — one cause, none of it real.

`ALTER DATABASE … SET timezone = 'UTC'` at creation makes the suite independent of the host. Verified by setting the server *back* to `Asia/Riyadh`: passes either way, where the same run previously failed 8.

Production is `Etc/UTC` and was never affected.

## 3. Chapters → Restores tab (`abca0bd`)

Lists every chapter an audit or operator judged wrongly carded, with the outcome derived from **where the chapter actually is** rather than from the task state.

That distinction is the whole point: a restore can report DONE and change nothing — 23 chapters were recorded restored while every one kept its card. `unavailable` = still carded, `uploaded` = the card really came off, `deleted` = moot.

Previously the only way to see the wrongly-carded ones was to already know their ids: filtering Chapters by the series returned 200 rows with nothing separating the 23 from the ~177 that are carded correctly.

## Tests

900/900 unit. Integration 405/406 — the one failure is the pre-existing `scopedRun > uploads a chapter the publisher lists that MangaDex never got`, which fails on master too. Left standing deliberately: it asserts a clean run should upload only the genuinely-missing chapter and it uploaded four, which is the shape of a duplicate-creating bug and not something to quietly delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6