### PR TITLE
Keep the publisher's chapter link somewhere it cannot be overwritten

### DIFF
--- a/prisma/migrations/20260827220000_chapter_origins/migration.sql
+++ b/prisma/migrations/20260827220000_chapter_origins/migration.sql
@@ -1,0 +1,56 @@
+-- The chapter as the publisher first described it. Written once, never updated.
+--
+-- A chapter rebuilt from a MangaDex record takes its url from `externalUrl`,
+-- and on a carded chapter that is the REPLACEMENT link. Archiving one that way
+-- loses the publisher's real link with nothing left holding it. This row is
+-- written at first sight and never touched again.
+CREATE TABLE "chapter_origins" (
+    "md_chapter_id" TEXT NOT NULL,
+    "extension" TEXT NOT NULL,
+    "chapter_id" TEXT,
+    "chapter_url" TEXT,
+    "manga_id" TEXT,
+    "md_manga_id" TEXT,
+    "manga_name" TEXT,
+    "chapter_number" TEXT,
+    "chapter_volume" TEXT,
+    "chapter_title" TEXT,
+    "chapter_language" TEXT,
+    "first_seen_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "chapter_origins_pkey" PRIMARY KEY ("md_chapter_id")
+);
+
+CREATE INDEX "chapter_origins_extension_chapter_id_idx" ON "chapter_origins"("extension", "chapter_id");
+CREATE INDEX "chapter_origins_md_manga_id_idx" ON "chapter_origins"("md_manga_id");
+
+-- Backfill from what the live archives still hold. Both are written from the
+-- extension's own payload, so their urls are the genuine source links today --
+-- capture them before any further transition degrades them. `uploaded` wins
+-- over `unavailable` on conflict only because it is the earlier state; the two
+-- are disjoint in practice.
+INSERT INTO "chapter_origins" (
+    "md_chapter_id", "extension", "chapter_id", "chapter_url", "manga_id",
+    "md_manga_id", "manga_name", "chapter_number", "chapter_volume",
+    "chapter_title", "chapter_language", "first_seen_at"
+)
+SELECT
+    md_chapter_id, COALESCE(extension, 'unknown'), chapter_id, chapter_url,
+    manga_id, md_manga_id, manga_name, chapter_number, chapter_volume,
+    chapter_title, chapter_language, CURRENT_TIMESTAMP
+FROM "uploaded_chapters"
+WHERE md_chapter_id IS NOT NULL
+ON CONFLICT ("md_chapter_id") DO NOTHING;
+
+INSERT INTO "chapter_origins" (
+    "md_chapter_id", "extension", "chapter_id", "chapter_url", "manga_id",
+    "md_manga_id", "manga_name", "chapter_number", "chapter_volume",
+    "chapter_title", "chapter_language", "first_seen_at"
+)
+SELECT
+    md_chapter_id, COALESCE(extension, 'unknown'), chapter_id, chapter_url,
+    manga_id, md_manga_id, manga_name, chapter_number, chapter_volume,
+    chapter_title, chapter_language, CURRENT_TIMESTAMP
+FROM "unavailable_chapters"
+WHERE md_chapter_id IS NOT NULL
+ON CONFLICT ("md_chapter_id") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -875,6 +875,40 @@ model ClearedError {
   @@map("cleared_errors")
 }
 
+/// The chapter as the PUBLISHER first described it. Written once, never updated.
+///
+/// Everything else about a chapter degrades as it moves. `uploaded_chapters`
+/// and `unavailable_chapters` hold the extension's own data, but a chapter
+/// rebuilt from a MangaDex record (`chapterFromMdChapter`) takes its url from
+/// MangaDex's `externalUrl` -- and on a carded chapter that is the REPLACEMENT
+/// link, because carding repoints it. Archive such a chapter and the original
+/// publisher link is gone, with nothing left holding it.
+///
+/// So this is the one row that is written at first sight and never touched
+/// again. Later passes may record whatever MangaDex currently says; the answer
+/// to "what did the publisher actually give us" stays here.
+model ChapterOrigin {
+  /// The MangaDex chapter, which is the id every later flow has in hand.
+  mdChapterId     String   @id @map("md_chapter_id")
+  extension       String
+  /// The publisher's own chapter id, when the extension supplies one.
+  chapterId       String?  @map("chapter_id")
+  /// THE POINT OF THIS TABLE: the publisher's real chapter link.
+  chapterUrl      String?  @map("chapter_url")
+  mangaId         String?  @map("manga_id")
+  mdMangaId       String?  @map("md_manga_id")
+  mangaName       String?  @map("manga_name")
+  chapterNumber   String?  @map("chapter_number")
+  chapterVolume   String?  @map("chapter_volume")
+  chapterTitle    String?  @map("chapter_title")
+  chapterLanguage String?  @map("chapter_language")
+  firstSeenAt     DateTime @default(now()) @map("first_seen_at")
+
+  @@index([extension, chapterId])
+  @@index([mdMangaId])
+  @@map("chapter_origins")
+}
+
 /// How much discussion a MangaDex chapter carries, remembered so the duplicate
 /// scan does not re-ask about every chapter on every run.
 ///

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -984,6 +984,10 @@ export class UploadTaskWorkers {
       { ...chapter, mdChapterId },
       detail ? { mdAttributes: detail.attributes } : {},
     );
+    // Last honest moment for the url. The chapter is not carded yet, so even a
+    // payload rebuilt from MangaDex still carries the publisher's real link;
+    // one commit later it carries the replacement.
+    await this.rememberOrigin(chapter, mdChapterId);
     await this.deps.prisma.unavailableChapter.upsert({
       where: { mdChapterId },
       create: { mdChapterId, ...columns },
@@ -994,9 +998,49 @@ export class UploadTaskWorkers {
 
   // ------------------------------------------------------------- shared
 
+  /**
+   * Keep the chapter as the publisher described it, once and for good.
+   *
+   * Write-once by design: `update: {}` so a later pass can never overwrite it.
+   * That is the entire value. Everything else about a chapter degrades as it
+   * moves -- a chapter rebuilt from a MangaDex record takes its url from
+   * `externalUrl`, which on a carded chapter is the REPLACEMENT link -- so
+   * without this the publisher's real link is lost the first time a carded
+   * chapter is archived, and there is nothing left to recover it from.
+   *
+   * Never throws: losing provenance is bad, failing the upload that produced it
+   * is worse.
+   */
+  private async rememberOrigin(chapter: Chapter, mdChapterId: string): Promise<void> {
+    const extension = chapter.extensionName;
+    if (!extension) return;
+    try {
+      await this.deps.prisma.chapterOrigin.upsert({
+        where: { mdChapterId },
+        create: {
+          mdChapterId,
+          extension,
+          chapterId: chapter.chapterId ?? null,
+          chapterUrl: chapter.chapterUrl ?? null,
+          mangaId: chapter.mangaId ?? null,
+          mdMangaId: chapter.mdMangaId ?? null,
+          mangaName: chapter.mangaName ?? null,
+          chapterNumber: chapter.chapterNumber ?? null,
+          chapterVolume: chapter.chapterVolume ?? null,
+          chapterTitle: chapter.chapterTitle ?? null,
+          chapterLanguage: chapter.chapterLanguage ?? null,
+        },
+        update: {},
+      });
+    } catch (err) {
+      this.deps.log.warn({ err, mdChapterId }, "could not record the chapter's origin");
+    }
+  }
+
   private async recordUploadedChapter(chapter: Chapter, mdChapterId: string): Promise<void> {
     const { prisma } = this.deps;
     const columns = uploadedChapterColumns({ ...chapter, mdChapterId });
+    await this.rememberOrigin(chapter, mdChapterId);
 
     await prisma.uploadedChapter.upsert({
       where: { mdChapterId },

--- a/test/integration/chapters.test.ts
+++ b/test/integration/chapters.test.ts
@@ -1366,6 +1366,63 @@ describe.skipIf(!dbReady())("chapter management endpoints", () => {
       // The record of what was removed outlives the chapter.
       expect(await prisma.deletedChapter.count({ where: { mdChapterId: uuid(1) } })).toBe(1);
     });
+
+    /**
+     * The publisher's real link survives a later pass that no longer has it.
+     *
+     * Carding repoints `externalUrl`, so a chapter rebuilt from a MangaDex
+     * record afterwards carries the REPLACEMENT. If that could overwrite the
+     * origin row, the one place holding the publisher's actual chapter link
+     * would be destroyed by the very flows most likely to need it.
+     */
+    it("never overwrites a chapter's recorded origin", async () => {
+      const payload = (chapterUrl: string) => ({
+        mdChapterId: uuid(55),
+        mdMangaId: uuid(900),
+        mdGroupId: uuid(800),
+        chapterNumber: "1",
+        chapterLanguage: "en",
+        chapterUrl,
+        mangaName: "Test Series",
+        extensionName: "exampleext",
+        imageArtifacts: [],
+      });
+      const workers = () =>
+        new UploadTaskWorkers({
+          prisma,
+          md: stubMd([]),
+          notifier: notifier as never,
+          settings: new SettingsStore(prisma),
+          config,
+          log,
+        });
+
+      const first = await prisma.uploadTask.create({
+        data: {
+          kind: "UNAVAILABLE",
+          dedupeKey: `origin-a-${uuid(55)}`,
+          state: "LEASED",
+          chapter: payload("https://publisher.example/chapter/1"),
+        },
+      });
+      await workers().execute(first);
+
+      // A second pass that only knows the repointed link.
+      const second = await prisma.uploadTask.create({
+        data: {
+          kind: "UNAVAILABLE",
+          dedupeKey: `origin-b-${uuid(55)}`,
+          state: "LEASED",
+          chapter: payload("https://publisher.example/"),
+        },
+      });
+      await workers().execute(second);
+
+      const origin = await prisma.chapterOrigin.findUniqueOrThrow({
+        where: { mdChapterId: uuid(55) },
+      });
+      expect(origin.chapterUrl).toBe("https://publisher.example/chapter/1");
+    });
   });
 
   // ---- asking the publisher whether a series is still there ----


### PR DESCRIPTION
You asked whether the edited/deleted archives keep the original chapter data from the source. Mostly yes, with one hole worth closing.

## What was already safe

`uploaded_chapters` and `unavailable_chapters` are written from the **task payload** — the extension's own data — so their `chapter_url` is the genuine publisher link. `uploaded_ids` also maps `(extension, chapterId) → mdChapterId` permanently, though it stores no url.

## The hole

`chapterFromMdChapter` sets `chapterUrl: attrs.externalUrl` — MangaDex's **current** value. Carding repoints that away from the publisher's chapter, so any chapter rebuilt from a MangaDex record after carding carries the *replacement* link (the series page, or the bare domain). Archive one of those and the publisher's real link is gone with nothing left holding it.

That is not hypothetical: it is why the RuriDragon false-positive duplicates all shared `https://mangaplus.shueisha.co.jp/`, and the reason the #20 repair was possible at all was that those particular rows still held real `viewer/…` links.

## The table

`chapter_origins` — the chapter as the publisher first described it, keyed on `mdChapterId`, **written once and never updated**. The upsert uses `update: {}`, which is the entire design: later passes may record whatever MangaDex currently says, but the answer to "what did the publisher actually give us" stays put.

Written at upload, and again when a chapter is carded — the last honest moment for the url, since the chapter is not carded *yet* at that point, so even a MangaDex-derived payload still carries the real link. Never throws: losing provenance is bad, failing the upload that produced it is worse.

The migration **backfills from both live archives**, whose urls are still correct today, so all 6,263 uploaded and 2,527 carded chapters keep their links before any further transition can degrade them.

## Tests

New integration test pins the write-once guarantee: card a chapter with a real link, run a second pass carrying only the repointed one, assert the origin still holds the original.

Worth noting how it was found — the first version of the test shared a chapter id with an earlier test in the file and read back `null`. That was write-once working correctly (the earlier payload had no url and won); the test was wrong, not the code. It now uses its own id.

45/45 in that file, 900/900 unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6