### PR TITLE
Partition clean runs across the fleet too

### DIFF
--- a/src/core/scheduler/service.ts
+++ b/src/core/scheduler/service.ts
@@ -215,11 +215,25 @@ export class SchedulerService {
           mangaIds: [...opts.scope.mangaIds],
         },
       ];
-    } else if (manifest.partition && opts.kind !== "CLEAN") {
-      // CLEAN runs are all-or-nothing over the full catalogue; never partition
-      // them; a missing segment must not read as "chapters were removed".
+    } else if (manifest.partition) {
+      // CLEAN runs are partitioned too, which they did not used to be. The old
+      // rule was "never partition a clean run, a missing segment must not read
+      // as chapters were removed". That requirement has not changed; it is now
+      // enforced where it belongs instead of by refusing to split the work:
+      //
+      //  - mergeEnvelopes turns the run's whole listing to null the moment ANY
+      //    segment reports `allChapters: null`, so one segment that could not
+      //    produce a catalogue disables removal for the entire run.
+      //  - processRun refuses a CLEAN run with any uncommitted segment.
+      //  - failedManga is unioned across segments, never intersected.
+      //  - only series some segment actually covered reach the removal pass.
+      //
+      // Splitting also SHRINKS the blast radius of a segment that lies: it
+      // endangers its own slice rather than the whole catalogue, which is
+      // strictly better than the single job it replaces.
+      //
       // The DB (TrackedManga) is the source of truth for the tracked catalogue;
- // bundle data files only seed it at publish time.
+      // bundle data files only seed it at publish time.
       const tracked = await this.prisma.trackedManga.findMany({
         where: { extension: manifest.name },
         select: { namespace: true, mangaId: true },

--- a/test/integration/schedules.test.ts
+++ b/test/integration/schedules.test.ts
@@ -290,4 +290,67 @@ describe.skipIf(!dbReady())("multi-slot schedules", () => {
     expect(runs).toHaveLength(1);
     expect(runs[0]?.kind).toBe("UPDATE");
   });
+
+  /**
+   * Clean runs are partitioned across the fleet like every other kind.
+   *
+   * They used to be the exception, on the rule that "a missing segment must not
+   * read as chapters were removed". That requirement still holds; it is now
+   * enforced where it belongs rather than by refusing to split the work --
+   * `mergeEnvelopes` nulls the whole run's listing if ANY segment reports no
+   * catalogue, `processRun` refuses a CLEAN run with an uncommitted segment,
+   * and `failedManga` is unioned across segments. Splitting also shrinks what
+   * one bad segment can reach, from the catalogue to its own slice.
+   *
+   * The point of partitioning at all is that publishers rate-limit per source
+   * IP, so one worker doing every series is one address doing it.
+   */
+  const partitioned = { ...manifest, partition: { maxSegments: 4, minMangaPerSegment: 25 } };
+  const bundle = { sha256: "b".repeat(64) };
+
+  const seedTracked = async (count: number): Promise<void> => {
+    await prisma.trackedManga.createMany({
+      data: Array.from({ length: count }, (_, i) => ({
+        extension: "mangaplus",
+        mangaId: `s-${i}`,
+        mdMangaId: `11111111-1111-4111-8111-${String(i).padStart(12, "0")}`,
+      })),
+    });
+  };
+
+  it("partitions a CLEAN run across segments", async () => {
+    await seedTracked(120);
+    const scheduler = new SchedulerService(prisma, log, { baseSeconds: 1, maxSeconds: 2 });
+
+    const result = await scheduler.createRunForExtension(partitioned as never, bundle as never, {
+      idempotencyKey: "clean-partitioned",
+      kind: "CLEAN",
+      triggeredBy: "test",
+    });
+
+    expect(result.segments).toBeGreaterThan(1);
+    const jobs = await prisma.job.findMany({ where: { runId: result.runId } });
+    expect(jobs).toHaveLength(result.segments);
+    // Every tracked series lands in exactly one segment: overlapping subsets
+    // would fetch twice, and a gap would leave series nothing vouches for.
+    const covered = jobs.flatMap((job) => job.segmentMangaIds);
+    expect(new Set(covered).size).toBe(120);
+  });
+
+  it("still runs a SCOPED clean as a single segment", async () => {
+    await seedTracked(120);
+    const scheduler = new SchedulerService(prisma, log, { baseSeconds: 1, maxSeconds: 2 });
+
+    // Scope means "these titles and no others", which the processor has to be
+    // able to tell from a catalogue-wide answer. Partitioning it would erase
+    // that distinction.
+    const result = await scheduler.createRunForExtension(partitioned as never, bundle as never, {
+      idempotencyKey: "clean-scoped",
+      kind: "CLEAN",
+      triggeredBy: "test",
+      scope: { mangaIds: ["s-1"], mdMangaIds: ["11111111-1111-4111-8111-000000000001"] },
+    });
+
+    expect(result.segments).toBe(1);
+  });
 });


### PR DESCRIPTION
Clean runs were the one kind never split, on the rule that *"a missing segment must not read as chapters were removed"*. That requirement has not changed — but refusing to partition is the wrong place to enforce it, and it pinned every full catalogue sweep to a single worker. That is one IP doing all the scraping, against publishers that rate-limit per IP.

## Why it is safe now

The guarantees the old rule stood in for are already enforced where they belong:

- **`mergeEnvelopes` nulls the entire run's listing** the moment ANY segment reports `allChapters: null` — one segment that could not produce a catalogue disables removal for the whole run.
- **`processRun` refuses** a CLEAN run with any uncommitted segment (`missingJobs > 0`).
- **`failedManga` is unioned across segments, never intersected** — a series any segment could not read is skipped by all of them.
- Only series some segment actually covered reach the removal pass.

And the argument that settles it: splitting **shrinks** the blast radius. A segment that returns a thin listing endangers its own slice rather than the whole catalogue — strictly better than the single job it replaces.

## What does not change

**Scoped runs stay unpartitioned.** Scope means "these titles and no others", and the processor has to be able to tell that from a catalogue-wide answer. Partitioning it would erase the distinction.

The partition config is per-extension and unchanged; MangaPlus already carried `{maxSegments: 4, minMangaPerSegment: 25}`. This only stops CLEAN being excluded from it.

## Tests

Two new integration tests — and worth noting the rule being changed had **no coverage at all**. `computeSegments` was tested for determinism, but nothing asserted whether a clean run partitioned either way.

- a CLEAN run over a partitioned extension produces >1 segment, one job per segment, and every tracked series lands in exactly one of them (no overlap, no gap)
- a SCOPED clean run is still exactly one segment

13/13 in that file, 900/900 unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6