### PR TITLE
Stop the false card failures, and the Discord spam they caused

### DIFF
--- a/src/core/md/client.ts
+++ b/src/core/md/client.ts
@@ -180,8 +180,15 @@ export interface MdChapterDetail extends MdChapter {
 
 export interface MdCommitResult {
   id: string;
-  /** Present when MangaDex echoed the committed chapter; carries the bumped version. */
-  attributes?: { version?: number };
+  /**
+   * Present when MangaDex echoed the committed chapter.
+   *
+   * This echo is the WRITE path's own answer, so it does not lag the way a
+   * subsequent read does: `GET /chapter/{id}` is served from a cache that can
+   * still show the pre-commit chapter seconds later. Confirming a card against
+   * a read alone failed tasks whose commit had plainly worked.
+   */
+  attributes?: { version?: number; pages?: number };
 }
 
 export interface MdUploadedImage {
@@ -1207,9 +1214,14 @@ export class MdClient implements MdExtendedApi {
       "upload session committed",
     );
     const version = typed.attributes?.version;
+    const pages = typed.attributes?.pages;
+    const echoed = {
+      ...(typeof version === "number" ? { version } : {}),
+      ...(typeof pages === "number" ? { pages } : {}),
+    };
     return {
       id: typed.id,
-      ...(typeof version === "number" ? { attributes: { version } } : {}),
+      ...(Object.keys(echoed).length > 0 ? { attributes: echoed } : {}),
     };
   }
 

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -35,12 +35,14 @@ const IMAGE_BATCH_SIZE = 10;
 /**
  * How hard to look for the card before deciding it did not land.
  *
- * MangaDex serves chapter reads from a cache that lags its own writes, so the
- * first read after a commit can still show the old chapter. A few seconds of
- * patience is much cheaper than dead-lettering a re-card that actually worked.
+ * Only reached when the commit echoed nothing useful; the echo is checked
+ * first and does not lag. This is the fallback, and it is generous on purpose:
+ * three attempts two seconds apart was NOT enough, and every premature verdict
+ * failed a task whose commit had worked, which then retried and uploaded
+ * another card. Twenty seconds of waiting is far cheaper than that.
  */
-const CARD_CONFIRM_ATTEMPTS = 3;
-const CARD_CONFIRM_DELAY_MS = 2_000;
+const CARD_CONFIRM_ATTEMPTS = 5;
+const CARD_CONFIRM_DELAY_MS = 5_000;
 
 /** Failure that should send the task back to the queue with its message intact. */
 export class TaskError extends Error {
@@ -736,6 +738,7 @@ export class UploadTaskWorkers {
         await this.confirmCardLanded(
           mdChapterId,
           { pages: attrs.pages ?? 0, version: attrs.version },
+          committed,
           log,
         );
 
@@ -790,8 +793,23 @@ export class UploadTaskWorkers {
   private async confirmCardLanded(
     mdChapterId: string,
     before: { pages: number; version: number },
+    committed: { attributes?: { version?: number; pages?: number } } | null,
     log: Logger,
   ): Promise<void> {
+    // The commit's own echo first, because it cannot lag: it is the write
+    // path's answer, where `GET /chapter/{id}` is served from a cache that can
+    // still show the pre-commit chapter seconds afterwards. Trusting only the
+    // read failed tasks whose commit had plainly worked -- a chapter reported
+    // as `pages 0 -> 0, version 2 -> 2` was sitting at pages 1, version 3 by
+    // the time anyone looked. Each of those retried and re-uploaded another
+    // card.
+    const echo = committed?.attributes;
+    if (echo) {
+      const echoedAPage = before.pages === 0 && (echo.pages ?? 0) > 0;
+      const echoedAWrite = before.pages > 0 && (echo.version ?? 0) > before.version;
+      if (echoedAPage || echoedAWrite) return;
+    }
+
     let pages: number | null = null;
     let version: number | null = null;
 

--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -68,6 +68,15 @@ export class UploadTaskWorkers {
    * and it saves a query per task.
    */
   private sendSuccesses = false;
+  /**
+   * Work done per kind since that kind's queue was last empty.
+   *
+   * A drain is not a single pass: while a run is processing, tasks arrive in a
+   * trickle and the uploader wakes for one at a time. Reporting each pass
+   * produced a message a minute, every one of them claiming the queue was
+   * finished. These totals wait until it actually is.
+   */
+  private readonly queueTotals = new Map<string, { processed: number; failed: number }>();
 
   constructor(private readonly deps: TaskWorkerDeps) {}
 
@@ -175,17 +184,43 @@ export class UploadTaskWorkers {
    * with identical messages. The failures are reported by their own per-chapter
    * embeds, which is where an operator can act on them.
    */
-  async flushQueueSummary(counts: Map<string, { processed: number; failed: number }>): Promise<void> {
-    if (!this.deps.notifier.enabled) return;
-    const embeds: DiscordEmbedInput[] = [];
+  async flushQueueSummary(
+    counts: Map<string, { processed: number; failed: number }>,
+    /** PENDING + LEASED still waiting per kind, after this pass. */
+    remaining: Map<string, number>,
+  ): Promise<void> {
+    // Totals are accumulated across passes and only reported once the queue is
+    // actually empty. A drain is not one pass: work arrives in a trickle while
+    // a run is processing, so the uploader wakes, handles one task, and sleeps.
+    // Reporting per pass turned that into a message a minute, each announcing
+    // "finished all items in queue" over a queue that plainly was not finished.
     for (const [kind, count] of counts) {
-      if (count.processed === 0 && count.failed === 0) continue;
+      const total = this.queueTotals.get(kind) ?? { processed: 0, failed: 0 };
+      total.processed += count.processed;
+      total.failed += count.failed;
+      this.queueTotals.set(kind, total);
+    }
+
+    if (!this.deps.notifier.enabled) {
+      // Still clear, or the totals grow forever on a deployment with no webhook.
+      for (const kind of [...this.queueTotals.keys()]) {
+        if ((remaining.get(kind) ?? 0) === 0) this.queueTotals.delete(kind);
+      }
+      return;
+    }
+
+    const embeds: DiscordEmbedInput[] = [];
+    for (const [kind, total] of [...this.queueTotals]) {
+      // Not empty yet: keep counting and say nothing.
+      if ((remaining.get(kind) ?? 0) > 0) continue;
+      this.queueTotals.delete(kind);
+      if (total.processed === 0 && total.failed === 0) continue;
       // UNAVAILABLE is summary-only: a per-chapter embed for a bulk
       // "mark these unavailable" pass is hundreds of messages nobody reads.
       if (kind === "UNAVAILABLE") {
-        embeds.push(queueSummaryEmbed(kind, count.processed, count.failed));
+        embeds.push(queueSummaryEmbed(kind, total.processed, total.failed));
       }
-      if (count.processed > 0) embeds.push(queueFinishedEmbed(kind));
+      if (total.processed > 0) embeds.push(queueFinishedEmbed(kind));
     }
     if (embeds.length > 0) await this.deps.notifier.send(embeds);
   }

--- a/src/services/uploader.ts
+++ b/src/services/uploader.ts
@@ -96,12 +96,25 @@ async function drain(kind: UploadTaskKind): Promise<{ processed: number; failed:
   return { processed, failed };
 }
 
-async function publishDepths(): Promise<void> {
+/**
+ * Publish queue depths, and report what is still waiting per kind.
+ *
+ * The second half is what tells `flushQueueSummary` whether a queue is
+ * genuinely empty. Only PENDING and LEASED count: a DONE or DEAD_LETTER row is
+ * settled and will not be worked again, so counting it would mean no queue is
+ * ever "finished" and the summary would never be sent at all.
+ */
+async function publishDepths(): Promise<Map<string, number>> {
   const depths = await tasks.depths();
   metrics.uploadTasks.reset();
+  const remaining = new Map<string, number>();
   for (const row of depths) {
     metrics.uploadTasks.set({ kind: row.kind, state: row.state }, row.count);
+    if (row.state === "PENDING" || row.state === "LEASED") {
+      remaining.set(row.kind, (remaining.get(row.kind) ?? 0) + row.count);
+    }
   }
+  return remaining;
 }
 
 // Before the loop, so a port clash fails the deploy instead of leaving the
@@ -154,8 +167,10 @@ while (running) {
     }
 
     await workers.flushNotifications();
-    await workers.flushQueueSummary(drained);
-    await publishDepths();
+    // Depths first: the summary only announces a queue as finished once
+    // nothing is left in it, so it needs this pass's remainder to decide.
+    const remaining = await publishDepths();
+    await workers.flushQueueSummary(drained, remaining);
 
     if (claimed === 0 && running) await sleep(IDLE_SLEEP_MS);
   } catch (err) {

--- a/test/unit/queueSummary.test.ts
+++ b/test/unit/queueSummary.test.ts
@@ -11,6 +11,12 @@ import type { DiscordEmbedInput } from "../../src/core/md/webhook.js";
  * single stuck task produced that message every few minutes, indefinitely, in a
  * channel where it is indistinguishable from real completions. Announcing a
  * queue as finished when nothing left it is also simply untrue.
+ *
+ * The same untruth had a second source: a drain is not one pass. While a run is
+ * processing, tasks arrive in a trickle, so the uploader wakes, handles one, and
+ * sleeps. Reporting per pass turned a single clean run into a message a minute,
+ * every one of them announcing a queue that plainly was not finished. So the
+ * totals now accumulate and are only reported once nothing is left to claim.
  */
 describe("flushQueueSummary", () => {
   const workersWith = (): { workers: UploadTaskWorkers; sent: DiscordEmbedInput[][] } => {
@@ -28,34 +34,86 @@ describe("flushQueueSummary", () => {
   const titles = (sent: DiscordEmbedInput[][]): string[] =>
     sent.flat().map((embed) => embed.title ?? "");
 
+  /** Nothing left to claim: the queue really is finished. */
+  const drained = new Map<string, number>();
+
   it("announces a queue as finished once it has actually completed work", async () => {
     const { workers, sent } = workersWith();
-    await workers.flushQueueSummary(new Map([["DELETE", { processed: 3, failed: 0 }]]));
+    await workers.flushQueueSummary(new Map([["DELETE", { processed: 3, failed: 0 }]]), drained);
     expect(titles(sent)).toEqual(["Delete: Finished all items in queue"]);
   });
 
   it("says nothing about finishing when every task failed and was requeued", async () => {
     const { workers, sent } = workersWith();
-    await workers.flushQueueSummary(new Map([["DELETE", { processed: 0, failed: 2 }]]));
+    await workers.flushQueueSummary(new Map([["DELETE", { processed: 0, failed: 2 }]]), drained);
     expect(sent).toEqual([]);
   });
 
   it("still announces a partially failed drain, which did empty some of the queue", async () => {
     const { workers, sent } = workersWith();
-    await workers.flushQueueSummary(new Map([["UPLOAD", { processed: 1, failed: 1 }]]));
+    await workers.flushQueueSummary(new Map([["UPLOAD", { processed: 1, failed: 1 }]]), drained);
     expect(titles(sent)).toEqual(["Upload: Finished all items in queue"]);
   });
 
   it("keeps the unavailable summary, which is where a failure count is reported", async () => {
     const { workers, sent } = workersWith();
-    await workers.flushQueueSummary(new Map([["UNAVAILABLE", { processed: 0, failed: 4 }]]));
+    await workers.flushQueueSummary(
+      new Map([["UNAVAILABLE", { processed: 0, failed: 4 }]]),
+      drained,
+    );
     expect(titles(sent)).toEqual(["0 chapters marked unavailable"]);
     expect(sent.flat()[0]?.description).toContain("Failed: 4");
   });
 
   it("sends nothing at all for a queue that did nothing", async () => {
     const { workers, sent } = workersWith();
-    await workers.flushQueueSummary(new Map([["EDIT", { processed: 0, failed: 0 }]]));
+    await workers.flushQueueSummary(new Map([["EDIT", { processed: 0, failed: 0 }]]), drained);
     expect(sent).toEqual([]);
+  });
+
+  it("stays quiet while work is still queued", async () => {
+    const { workers, sent } = workersWith();
+    // One task handled, three still waiting: this drain is not over, and the
+    // uploader will be back in a few seconds for the next one.
+    await workers.flushQueueSummary(
+      new Map([["UPLOAD", { processed: 1, failed: 0 }]]),
+      new Map([["UPLOAD", 3]]),
+    );
+    expect(sent).toEqual([]);
+  });
+
+  it("reports one total for a drain that took several passes", async () => {
+    const { workers, sent } = workersWith();
+    await workers.flushQueueSummary(
+      new Map([["UNAVAILABLE", { processed: 1, failed: 0 }]]),
+      new Map([["UNAVAILABLE", 2]]),
+    );
+    await workers.flushQueueSummary(
+      new Map([["UNAVAILABLE", { processed: 1, failed: 1 }]]),
+      new Map([["UNAVAILABLE", 1]]),
+    );
+    expect(sent).toEqual([]);
+
+    // The pass that empties it reports everything since the queue was last
+    // clear, not just its own share.
+    await workers.flushQueueSummary(
+      new Map([["UNAVAILABLE", { processed: 1, failed: 0 }]]),
+      drained,
+    );
+    expect(titles(sent)).toEqual([
+      "3 chapters marked unavailable",
+      "Unavailable: Finished all items in queue",
+    ]);
+    expect(sent.flat()[0]?.description).toContain("Failed: 1");
+  });
+
+  it("does not re-announce a queue that is already settled", async () => {
+    const { workers, sent } = workersWith();
+    await workers.flushQueueSummary(new Map([["EDIT", { processed: 2, failed: 0 }]]), drained);
+    expect(titles(sent)).toEqual(["Edit: Finished all items in queue"]);
+
+    // A later idle pass has nothing to add, and must not repeat itself.
+    await workers.flushQueueSummary(new Map(), drained);
+    expect(titles(sent)).toEqual(["Edit: Finished all items in queue"]);
   });
 });


### PR DESCRIPTION
Two fixes for what you saw tonight. They share a root cause.

## 1. The card DID land — my check was too impatient (`0b0b090`)

`the card did not land on chapter 6ee4330a…: pages 0 -> 0, version 2 -> 2`

That chapter is sitting at **pages 1, version 3, updatedAt 22:26:07**. The commit worked. `GET /chapter/{id}` is served from a cache that can still show the pre-commit chapter, and three attempts two seconds apart did not outlast it — so the guard threw on a write that had succeeded.

Every false verdict requeued the task, which re-rendered and re-uploaded **another card**. So it also burned MangaDex writes and climbed the version each time.

The commit response is the write path's own answer and does not lag, so it is now consulted first: a first card is confirmed by the echoed page count, a re-card by the echoed version (`pages` is now carried on `MdCommitResult`). The read remains a fallback for a commit that echoes nothing useful, with five attempts five seconds apart — twenty seconds of waiting is far cheaper than failing work that succeeded.

## 2. "Finished all items in queue", once a minute (`4bd9d54`)

The same retries fed this, but it was broken independently: the message fired on **every uploader pass that processed anything**, and a drain is not one pass. While a run is processing, tasks arrive in a trickle — the uploader wakes, handles one, sleeps, repeats. One clean run turned that into a message a minute, each announcing a queue that plainly was not finished, plus a "1 chapters marked unavailable" beside it.

Totals now accumulate per kind and are reported **once, when nothing is left to claim**. PENDING and LEASED count as left; DONE and DEAD_LETTER are settled, and counting those would mean no queue is ever finished and the summary never sent at all.

## Tests

`queueSummary.test.ts` grew from 5 to 8 — the existing five caught the signature change, and two new ones pin the behaviour that was wrong: stays quiet while work is still queued, and reports one combined total for a drain that took several passes.

903/903 unit, 45/45 on the chapters integration file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6