### PR TITLE
Announce a run once, and report cards the publisher has invalidated

### DIFF
--- a/prisma/migrations/20260828000000_run_summary_notified/migration.sql
+++ b/prisma/migrations/20260828000000_run_summary_notified/migration.sql
@@ -1,0 +1,7 @@
+-- Announce a run's "Found N chapters" summary once.
+--
+-- Processing is not resumable: an interrupted run stays in INGESTING and the
+-- next tick starts it again from the top, re-sending whatever it had already
+-- sent. A container restart mid-run is ordinary -- watchtower does one on every
+-- deploy -- and a single clean run announced itself four times in an evening.
+ALTER TABLE "runs" ADD COLUMN "summary_notified_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,6 +155,15 @@ model Run {
   /// that as "the publisher dropped it" would unpublish the catalogue.
   scopeMangaIds      String[]  @default([]) @map("scope_manga_ids")
   triggeredBy        String?   @map("triggered_by")
+  /// When the "Found N chapters" summary was announced, so it is announced once.
+  ///
+  /// Processing is not resumable: a run that is interrupted stays in INGESTING
+  /// and the next tick starts it again from the top, re-sending anything it had
+  /// already sent. A container restart mid-run is ordinary -- watchtower does it
+  /// on every deploy -- and one clean run announced itself four times in an
+  /// evening because of it. Claimed atomically, so two processors racing the
+  /// same run still send once.
+  summaryNotifiedAt  DateTime? @map("summary_notified_at")
   scheduledFor       DateTime? @map("scheduled_for")
   startedAt          DateTime? @map("started_at")
   completedAt        DateTime? @map("completed_at")

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -224,6 +224,72 @@ export class RunProcessor {
     }
   }
 
+  /**
+   * Carded chapters the publisher is listing again.
+   *
+   * Nothing else notices these. `findExtraChapters` skips anything already
+   * carded -- it has to, because carding repoints `externalUrl` away from the
+   * publisher's chapter, so a carded chapter looks unlisted on every later run
+   * and would be re-queued forever. The cost of that exclusion is that carding
+   * is one-way: once a chapter is carded, no pass ever asks about it again.
+   *
+   * So a chapter the publisher takes down and later re-opens keeps its card
+   * indefinitely, showing readers "no longer available" over something they can
+   * read. MangaPlus re-opens chapters for events routinely; a single sweep
+   * found 36 in that state, against 74 carded by an actual misjudgement.
+   *
+   * This only REPORTS. Removing the card is a different problem and currently
+   * an unsolved one -- MangaDex accepts the commit that would do it and changes
+   * nothing -- so queueing restores here would just fill the dead-letter queue.
+   * Naming them is what lets somebody act when that is fixed.
+   */
+  private async reportRevivedChapters(
+    extension: string,
+    listing: Chapter[] | null,
+    log: Logger,
+  ): Promise<void> {
+    // No catalogue, no evidence: an UPDATE run's listing is null, and absence
+    // from a partial one means nothing.
+    if (listing === null) return;
+
+    const listed = new Set<string>();
+    for (const chapter of listing) {
+      if (chapter.chapterUrl) listed.add(chapter.chapterUrl);
+    }
+    if (listed.size === 0) return;
+
+    const carded = await this.prisma.unavailableChapter.findMany({
+      where: { extension, chapterUrl: { not: null } },
+      select: {
+        mdChapterId: true,
+        chapterUrl: true,
+        chapterNumber: true,
+        chapterLanguage: true,
+        mangaName: true,
+      },
+    });
+
+    const revived = carded.filter((row) => row.chapterUrl && listed.has(row.chapterUrl));
+    if (revived.length === 0) return;
+
+    log.warn(
+      {
+        extension,
+        revived: revived.length,
+        carded: carded.length,
+        // Capped: the count is the alarm, and the whole list belongs in a
+        // query rather than in one log line.
+        sample: revived.slice(0, 20).map((row) => ({
+          mdChapterId: row.mdChapterId,
+          manga: row.mangaName,
+          language: row.chapterLanguage,
+          chapter: row.chapterNumber,
+        })),
+      },
+      "carded chapters are listed by the publisher again; their cards are now wrong",
+    );
+  }
+
   /** Process every run currently waiting in INGESTING. Returns the count. */
   async tick(): Promise<number> {
     const attempted = new Set<string>();
@@ -580,6 +646,8 @@ export class RunProcessor {
       groupId,
       log,
     );
+
+    await this.reportRevivedChapters(run.extension, merged.allChapters, log);
 
     log.info({ ...totals, dupes }, "run processed");
     await this.markProcessed(run.id, log);

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -332,7 +332,26 @@ export class RunProcessor {
         "scoped run: not announcing a run summary for a probe of part of the catalogue",
       );
     } else {
-      await this.reportRunSummary(run.extension, merged.untrackedManga, merged.updatedChapters.length);
+      // Once per run, not once per attempt. Processing is not resumable: an
+      // interrupted run stays in INGESTING and the next tick starts it again
+      // from the top. A restart mid-run is ordinary -- a deploy causes one --
+      // and this line re-announced the same run four times in an evening.
+      //
+      // The conditional update IS the claim: whoever flips it from null sends,
+      // so two processors racing the same run still announce once.
+      const claimed = await this.prisma.run.updateMany({
+        where: { id: run.id, summaryNotifiedAt: null },
+        data: { summaryNotifiedAt: new Date() },
+      });
+      if (claimed.count === 1) {
+        await this.reportRunSummary(
+          run.extension,
+          merged.untrackedManga,
+          merged.updatedChapters.length,
+        );
+      } else {
+        log.info("run summary already announced; not repeating it for this attempt");
+      }
     }
 
     const updatedByManga = groupByMdManga(merged.updatedChapters);

--- a/test/integration/scopedRun.test.ts
+++ b/test/integration/scopedRun.test.ts
@@ -394,6 +394,67 @@ describe.skipIf(!dbReady())("scoped runs", () => {
     expect(uploads.map((task) => (task.chapter as { chapterId: string }).chapterId)).toEqual(["a3"]);
   });
 
+  /**
+   * A carded chapter the publisher is listing again.
+   *
+   * Nothing else can notice these: `findExtraChapters` skips anything already
+   * carded, because carding repoints `externalUrl` and a carded chapter would
+   * otherwise look unlisted forever. The price of that exclusion is that
+   * carding is one-way, so a chapter taken down and later re-opened keeps its
+   * card and goes on telling readers it is unavailable. A real sweep found 36
+   * in that state.
+   */
+  it("reports carded chapters the publisher lists again", async () => {
+    const warns: { msg: string; fields: Record<string, unknown> }[] = [];
+    const capturing = (): never => {
+      const node = {
+        child: () => capturing(),
+        info: () => undefined,
+        debug: () => undefined,
+        error: () => undefined,
+        warn: (fields: Record<string, unknown>, msg?: string) => {
+          warns.push({ msg: msg ?? "", fields });
+        },
+      };
+      return node as never;
+    };
+
+    // Carded, but its publisher link is one the listing below still carries.
+    await prisma.unavailableChapter.create({
+      data: {
+        mdChapterId: "aaaa1111-0000-4000-8000-000000000001",
+        unavailableAt: new Date("2026-08-26T12:00:00Z"),
+        extension: "testext",
+        chapterUrl: "https://publisher.example/a/1",
+        chapterNumber: "1",
+        chapterLanguage: "en",
+        mangaName: "Series A",
+        mdMangaId: SERIES_A,
+      },
+    });
+
+    const { run } = await runWithEnvelope({
+      scopeMangaIds: [],
+      stillListed: [
+        { mdMangaId: SERIES_A, mangaId: "series-a", chapterId: "a1", url: "https://publisher.example/a/1" },
+      ],
+      updated: [],
+    });
+
+    const processor = new RunProcessor(prisma, fakeMd(), capturing(), { botUserId: BOT });
+    await processor.processRun({
+      id: run.id,
+      extension: "testext",
+      bundleSha256: BUNDLE,
+      kind: "CLEAN",
+      scopeMangaIds: [],
+    });
+
+    const revived = warns.find((w) => w.msg.includes("listed by the publisher again"));
+    expect(revived).toBeTruthy();
+    expect(revived?.fields["revived"]).toBe(1);
+  });
+
   it("marks the run processed either way", async () => {
     const { run } = await runWithEnvelope({ scopeMangaIds: [SERIES_A], stillListed: A_LOST_ONE });
     const processor = new RunProcessor(prisma, fakeMd(), log, { botUserId: BOT });


### PR DESCRIPTION
Two changes, both from what tonight's sweep turned up.

## 1. "Found N chapters", once per run (`3056a66`)

The same run kept announcing itself. `core-processor started` appears **4 times** between 20:44 and 23:04 with **no errors anywhere** — the run was not failing, it was being killed mid-flight and starting over.

Processing is not resumable: an interrupted run stays in `INGESTING` and the next tick calls `processRun` again **from the top**, re-sending anything already sent. `reportRunSummary` fires early, before the long per-title reads, so every restart re-announced.

What kept restarting it was **watchtower**, doing exactly what it was added to do — each merge triggers a build, and it deploys within five minutes. Several PRs landed tonight.

`runs.summary_notified_at` records that the summary was said. The conditional update **is** the claim, so two processors racing the same run still announce once.

## 2. Report carded chapters the publisher lists again (`098f81b`)

`findExtraChapters` skips anything already carded — it has to, since carding repoints `externalUrl`, so a carded chapter looks unlisted on every later run and would be re-queued forever. The price of that exclusion is that **carding is one-way**: once carded, no pass ever asks about the chapter again.

So a chapter the publisher takes down and later re-opens keeps its card indefinitely, telling readers "no longer available" over something they can read.

Joining tonight's catalogue against the carded archive found **110 carded chapters that MangaPlus is listing today**:

| | count | cause |
|---|---|---|
| RuriDragon (id/fr/es/th) | 36 | language-coverage bug, already fixed |
| Kindergarten WARS (es/th/pt-br/fr) | 35 | same bug |
| MagiLumiere en | 3 | same series as the #8 id mis-mapping |
| Katekyo Hitman Reborn! es, Ghost Girl, Metaphor, +8 more | 36 | **carded correctly, chapter has since returned** |

That last group is the point. Those cards were right when applied; MangaPlus re-opens chapters for events routinely, and nothing ever notices. The number grows on its own.

A clean run already holds both halves — the publisher catalogue and our carded archive — so it now compares them and warns.

**Reporting only.** Removing the card is a separate, currently unsolved problem (MangaDex accepts the commit and changes nothing), so queueing restores would only fill the dead-letter queue. Naming them is what lets someone act when that is fixed.

## Tests

903/903 unit. The detection is covered by a new integration test using a capturing logger. The one failing test in `scopedRun.test.ts` is the pre-existing `uploads a chapter the publisher lists that MangaDex never got`, which fails on master too and is deliberately left standing — it looks like a genuine duplicate-creating bug.

## Why merging this matters for #9

#9 is queued as a **10-chapter trial** rather than all 2,425, because I could not tell from timestamps whether the commit-echo fix (PR #72) made the 23:01 image. Merging this and letting watchtower deploy puts that fix provably live, and the remaining 2,415 can go without risking thousands of false "card did not land" failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6