### PR TITLE
Jitter the publisher fetch interval, and make it configurable

### DIFF
--- a/runner-node/runner.mjs
+++ b/runner-node/runner.mjs
@@ -210,6 +210,17 @@ function log(level, message, fields) {
 
 const FETCH_DEFAULTS = {
   minIntervalMs: 500,
+  /**
+   * Extra random delay, as a fraction of minIntervalMs, added to every gap.
+   *
+   * A fixed interval is a fingerprint independent of volume: requests landing
+   * exactly 500ms apart for an hour look like nothing else. Worse, workers
+   * handed segments of the same run start within milliseconds of each other,
+   * so without this they march in step across several addresses at once.
+   *
+   * Only ever ADDS delay, so the politeness floor is untouched.
+   */
+  jitterRatio: 0.5,
   timeoutMs: 30_000,
   maxRetries: 3,
   maxRedirects: 5,
@@ -263,9 +274,11 @@ async function drain(res) {
   }
 }
 
-function createGuardedFetch(allowedHosts) {
+function createGuardedFetch(allowedHosts, throttle = {}) {
   const nextAllowedAt = new Map();
   const state = { requestCount: 0 };
+  const minIntervalMs = throttle.minIntervalMs ?? FETCH_DEFAULTS.minIntervalMs;
+  const jitterRatio = throttle.jitterRatio ?? FETCH_DEFAULTS.jitterRatio;
 
   const requireAllowed = (url) => {
     if (url.protocol !== "http:" && url.protocol !== "https:") {
@@ -276,10 +289,22 @@ function createGuardedFetch(allowedHosts) {
     }
   };
 
+  /** minIntervalMs plus a random fraction of it; never less. */
+  const spacing = () =>
+    jitterRatio > 0
+      ? minIntervalMs + Math.floor(Math.random() * minIntervalMs * jitterRatio)
+      : minIntervalMs;
+
   const awaitTurn = async (host) => {
     const at = Date.now();
+    // The first request to a host waits a random slice of one interval rather
+    // than firing immediately, so workers given segments of the same run do
+    // not start in lockstep and then stay that way for the whole run.
+    if (!nextAllowedAt.has(host)) {
+      nextAllowedAt.set(host, at + Math.floor(Math.random() * minIntervalMs * jitterRatio));
+    }
     const readyAt = Math.max(at, nextAllowedAt.get(host) ?? 0);
-    nextAllowedAt.set(host, readyAt + FETCH_DEFAULTS.minIntervalMs);
+    nextAllowedAt.set(host, readyAt + spacing());
     if (readyAt > at) await sleep(readyAt - at);
   };
 
@@ -413,11 +438,41 @@ function resolveDataFilePath(bundleDir, dataFiles, name) {
   return target;
 }
 
+/**
+ * Throttle settings from the extension's DATABASE configuration, so pacing can
+ * be changed from the dashboard without publishing a bundle.
+ *
+ *   fetch_jitter           false turns the randomness off entirely
+ *   fetch_jitter_ratio     size of the random extra, as a fraction of the gap
+ *   fetch_min_interval_ms  the gap itself
+ *
+ * Every value is clamped, and a nonsense one falls back to the default rather
+ * than being obeyed. The floor on the interval matters most: this is the only
+ * thing pacing our requests at a publisher, and a stray 0 in a config field
+ * should not be able to turn it into a flood.
+ */
+function readThrottle(overrideOptions) {
+  const options = overrideOptions && typeof overrideOptions === "object" ? overrideOptions : {};
+  const num = (value, fallback, min, max) => {
+    const parsed = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.min(max, Math.max(min, parsed));
+  };
+
+  const enabled = options.fetch_jitter !== false;
+  return {
+    minIntervalMs: num(options.fetch_min_interval_ms, FETCH_DEFAULTS.minIntervalMs, 100, 60_000),
+    jitterRatio: enabled
+      ? num(options.fetch_jitter_ratio, FETCH_DEFAULTS.jitterRatio, 0, 5)
+      : 0,
+  };
+}
+
 function buildContext(bundleDir, manifest, mangaIdMap, overrideOptions) {
   const allowedHosts = Array.isArray(manifest.allowed_hosts) ? manifest.allowed_hosts : [];
   const dataFiles =
     manifest.data_files && typeof manifest.data_files === "object" ? manifest.data_files : {};
-  const { guarded, state } = createGuardedFetch(allowedHosts);
+  const { guarded, state } = createGuardedFetch(allowedHosts, readThrottle(overrideOptions));
 
   const ctx = {
     manifest: Object.freeze({ ...manifest }),

--- a/src/extsdk/guardedFetch.ts
+++ b/src/extsdk/guardedFetch.ts
@@ -43,6 +43,17 @@ export interface GuardedFetchOptions {
   fetchImpl?: typeof fetch;
   /** Minimum gap between two requests to the same host. */
   minIntervalMs?: number;
+  /**
+   * Extra random delay, as a fraction of `minIntervalMs`, added to every gap.
+   *
+   * A fixed interval is a fingerprint. Requests landing exactly 500ms apart for
+   * an hour look like nothing else, whatever the volume, and several workers
+   * starting one run together march in step from the first request.
+   *
+   * Only ever ADDS: the floor stays `minIntervalMs`, so the politeness this
+   * throttle exists to guarantee is unchanged. 0 restores the metronome.
+   */
+  jitterRatio?: number;
   /** Per-attempt wall-clock timeout. */
   timeoutMs?: number;
   /** Retries AFTER the first attempt, for 5xx and transport errors. */
@@ -54,6 +65,8 @@ export interface GuardedFetchOptions {
   /** Injected for tests. */
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
+  /** Injected for tests; defaults to Math.random. */
+  random?: () => number;
   log?: (message: string, fields?: Record<string, unknown>) => void;
 }
 
@@ -65,6 +78,8 @@ export interface GuardedFetch {
 
 const DEFAULTS = {
   minIntervalMs: 500,
+  /** 500ms becomes 500-750ms, and a run's first request lands somewhere inside that. */
+  jitterRatio: 0.5,
   timeoutMs: 30_000,
   maxRetries: 3,
   maxRedirects: 5,
@@ -127,6 +142,8 @@ export function createGuardedFetch(opts: GuardedFetchOptions): GuardedFetch {
   const maxRetries = opts.maxRetries ?? DEFAULTS.maxRetries;
   const maxRedirects = opts.maxRedirects ?? DEFAULTS.maxRedirects;
   const maxRetryAfterMs = opts.maxRetryAfterMs ?? DEFAULTS.maxRetryAfterMs;
+  const jitterRatio = opts.jitterRatio ?? DEFAULTS.jitterRatio;
+  const random = opts.random ?? Math.random;
   const now = opts.now ?? (() => Date.now());
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const log = opts.log ?? (() => {});
@@ -140,10 +157,27 @@ export function createGuardedFetch(opts: GuardedFetchOptions): GuardedFetch {
    * reserved before awaiting so concurrent callers queue behind each other
    * instead of all reading the same stale timestamp.
    */
+  /**
+   * `minIntervalMs` plus a random fraction of it. Never less, so the politeness
+   * floor is untouched; the point is only that the gaps stop being identical.
+   */
+  function spacing(): number {
+    if (jitterRatio <= 0) return minIntervalMs;
+    return minIntervalMs + Math.floor(random() * minIntervalMs * jitterRatio);
+  }
+
   async function awaitTurn(host: string): Promise<void> {
     const at = now();
+    // First request to this host starts somewhere inside one interval rather
+    // than immediately. Several workers handed segments of the same run begin
+    // within milliseconds of each other, and without this they stay in step
+    // for the whole run -- a synchronised pattern across addresses, which is
+    // exactly what looks coordinated from the far end.
+    if (!nextAllowedAt.has(host)) {
+      nextAllowedAt.set(host, at + Math.floor(random() * minIntervalMs * jitterRatio));
+    }
     const readyAt = Math.max(at, nextAllowedAt.get(host) ?? 0);
-    nextAllowedAt.set(host, readyAt + minIntervalMs);
+    nextAllowedAt.set(host, readyAt + spacing());
     const wait = readyAt - at;
     if (wait > 0) await sleep(wait);
   }

--- a/test/unit/guardedFetch.test.ts
+++ b/test/unit/guardedFetch.test.ts
@@ -293,6 +293,9 @@ describe("guardedFetch politeness", () => {
       fetchImpl,
       minIntervalMs: 500,
       now: () => clock,
+      // Jitter off: this asserts the FLOOR, which is the part that must hold
+      // whatever the randomness does.
+      random: () => 0,
       sleep: async (ms) => {
         slept.push(ms);
         clock += ms;
@@ -312,6 +315,7 @@ describe("guardedFetch politeness", () => {
       fetchImpl,
       minIntervalMs: 500,
       now: () => 0,
+      random: () => 0,
       sleep: async (ms) => {
         slept.push(ms);
       },
@@ -319,6 +323,87 @@ describe("guardedFetch politeness", () => {
     await fetchGuarded("https://example.com/1");
     await fetchGuarded("https://other.test/1");
     expect(slept).toEqual([]);
+  });
+
+  /**
+   * A fixed gap is a fingerprint on its own.
+   *
+   * Requests landing exactly 500ms apart for an hour look like nothing a person
+   * produces, whatever the volume, and workers handed segments of the same run
+   * start within milliseconds of each other — so without jitter they march in
+   * step across several addresses at once, which is the pattern most worth not
+   * showing a publisher.
+   *
+   * The floor is the invariant: jitter may only ever ADD.
+   */
+  it("adds a random extra to each gap, never less than the floor", async () => {
+    const slept: number[] = [];
+    let clock = 0;
+    const { fetchImpl } = recorder(() => new Response("ok"));
+    const fetchGuarded = createGuardedFetch({
+      allowedHosts: ["example.com"],
+      fetchImpl,
+      minIntervalMs: 500,
+      jitterRatio: 0.5,
+      // Maximum jitter, so the upper bound is exercised rather than averaged.
+      random: () => 0.999,
+      now: () => clock,
+      sleep: async (ms) => {
+        slept.push(ms);
+        clock += ms;
+      },
+    });
+    await fetchGuarded("https://example.com/1");
+    await fetchGuarded("https://example.com/2");
+    await fetchGuarded("https://example.com/3");
+
+    // First request staggered, then gaps inside [500, 750].
+    for (const wait of slept) {
+      expect(wait).toBeGreaterThanOrEqual(0);
+      expect(wait).toBeLessThanOrEqual(750);
+    }
+    const gaps = slept.slice(1);
+    for (const gap of gaps) expect(gap).toBeGreaterThanOrEqual(500);
+  });
+
+  it("staggers the first request so parallel workers do not start in lockstep", async () => {
+    const slept: number[] = [];
+    const { fetchImpl } = recorder(() => new Response("ok"));
+    const fetchGuarded = createGuardedFetch({
+      allowedHosts: ["example.com"],
+      fetchImpl,
+      minIntervalMs: 500,
+      jitterRatio: 0.5,
+      random: () => 0.5,
+      now: () => 0,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    await fetchGuarded("https://example.com/1");
+    // Without the stagger this is 0 for every worker at once.
+    expect(slept[0]).toBe(125);
+  });
+
+  it("restores an exact interval when jitter is turned off", async () => {
+    const slept: number[] = [];
+    let clock = 0;
+    const { fetchImpl } = recorder(() => new Response("ok"));
+    const fetchGuarded = createGuardedFetch({
+      allowedHosts: ["example.com"],
+      fetchImpl,
+      minIntervalMs: 500,
+      jitterRatio: 0,
+      random: () => 0.999,
+      now: () => clock,
+      sleep: async (ms) => {
+        slept.push(ms);
+        clock += ms;
+      },
+    });
+    await fetchGuarded("https://example.com/1");
+    await fetchGuarded("https://example.com/2");
+    expect(slept).toEqual([500]);
   });
 
   it("counts every request it issues, hops included", async () => {


### PR DESCRIPTION
Requests left at exactly `minIntervalMs` apart. That is a fingerprint on its own, independent of volume — nothing else produces a request every 500ms for an hour.

Worse for your case: workers handed segments of one run start within milliseconds of each other, so they **marched in step from the first request**. A synchronised pattern across several addresses at once is the shape most worth not showing a publisher, and it only became possible now that clean runs are partitioned across a fleet.

## What changed

Each gap carries a random extra, and the first request to a host waits a random slice of one interval instead of firing immediately.

**Jitter only ever ADDS.** The floor stays `minIntervalMs`, so the politeness this throttle exists to guarantee is untouched. That is the invariant the tests pin.

## Config

From the extension's database config, so pacing changes without publishing a bundle — same surface as `verify_pages`, editable from the dashboard:

| key | default | meaning |
|---|---|---|
| `fetch_jitter` | `true` | `false` turns the randomness off entirely |
| `fetch_jitter_ratio` | `0.5` | size of the random extra, so 500ms becomes 500–750ms |
| `fetch_min_interval_ms` | `500` | the gap itself |

All three are clamped and a nonsense value falls back to the default rather than being obeyed. The floor on the interval matters most: this throttle is the only thing pacing our requests at a publisher, and a stray `0` in a config field must not be able to turn it into a flood.

## Both implementations

Applied in `src/extsdk/guardedFetch.ts` **and** `runner-node/runner.mjs`. The runner carries its own copy and is the one that actually executes extensions in the spawned process — changing only the SDK would have looked correct and done nothing in production.

## Tests

`guardedFetch.test.ts` 25 → 28. The two existing throttle tests now inject `random`, because what they assert is the floor and host-independence, which must hold whatever the randomness does. New tests cover: the extra stays within `[minInterval, minInterval * (1 + ratio)]`, the first request is staggered rather than immediate, and `jitterRatio: 0` restores an exact interval.

906/906 unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6