### PR TITLE
Raise the MangaDex rate, pace it from the headers, and stop bulk work starving the queues

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -103,7 +103,22 @@ const ConfigSchema = z.object({
    * than act on unverified ownership.
    */
   mdBotUserId: z.string().optional(),
-  mdRatelimitMs: z.coerce.number().int().default(2000),
+  /**
+   * FLOOR on the gap between MangaDex requests, not the pace.
+   *
+   * The pace comes from `x-ratelimit-remaining` on every response, which
+   * describes the budget as MangaDex sees it. This is only the fastest the
+   * client will go while that budget is healthy.
+   *
+   * It used to be the whole mechanism, and had to be set for the worst case:
+   * the limit is per IP while the gate is per process, so core-api,
+   * core-processor and core-uploader each kept a private metronome and none
+   * could see the other two spending the same allowance. 2000ms is a tenth of
+   * what MangaDex permits, and it cost every card about twelve seconds of pure
+   * waiting. With the headers doing the real work, three processes at this
+   * floor observe the same depletion and back off together.
+   */
+  mdRatelimitMs: z.coerce.number().int().default(250),
   uploadRetry: z.coerce.number().int().min(1).default(3),
 
   // Discord notifications (core only)

--- a/src/core/md/client.ts
+++ b/src/core/md/client.ts
@@ -58,6 +58,14 @@ const MAX_OFFSET = 10000;
 const MAX_PAGES = 500;
 const CREATED_AT_EPOCH = "2000-01-01T00:00:00";
 const REQUEST_TIMEOUT_MS = 30_000;
+/**
+ * Ceiling on header-derived spacing.
+ *
+ * A window with one request left and a long reset ahead computes a very wide
+ * gap, which would stall a drain on arithmetic rather than on any real limit.
+ * Past this, waiting for the reset and starting fresh is the better trade.
+ */
+const MAX_PACED_SPACING_MS = 5_000;
 /** Fallback pause when a 429 arrives with no Retry-After (model.py used 60s). */
 const RATELIMIT_FALLBACK_MS = 60_000;
 const BACKOFF_BASE_MS = 2_000;
@@ -121,6 +129,44 @@ export function optimisticLockVersion(err: unknown): number | null {
     if (Number.isInteger(version) && version > 0) return version;
   }
   return null;
+}
+
+/**
+ * What the last response's rate-limit headers imply about our pace.
+ *
+ * Exported and pure because it is the arithmetic that decides how hard this
+ * platform hits MangaDex, and that is worth testing directly rather than
+ * through a client that really sleeps.
+ *
+ * `null` means the headers said nothing usable, so the caller keeps whatever
+ * pace it had. Otherwise `spacingMs` is the gap to leave between requests, and
+ * a non-zero `waitMs` means the window is spent and nothing should go out until
+ * it rolls.
+ */
+export function pacedSpacing(
+  headers: Headers,
+  now: number,
+): { spacingMs: number; waitMs: number } | null {
+  // Presence first: `Number(null)` is 0, which is perfectly finite, so testing
+  // only the parse reads a MISSING header as "nothing left" -- and a route that
+  // sends no budget headers would be paced as though it were exhausted.
+  const remainingRaw = headers.get("x-ratelimit-remaining");
+  const resetRaw = headers.get("x-ratelimit-retry-after");
+  if (remainingRaw === null || resetRaw === null) return null;
+
+  const remaining = Number(remainingRaw);
+  const resetAt = Number(resetRaw);
+  if (!Number.isFinite(remaining) || !Number.isFinite(resetAt)) return null;
+
+  // A window that has already rolled says nothing about the next one, so fall
+  // back to the floor rather than pacing off a stale reading.
+  const msLeft = resetAt * 1000 - now;
+  if (msLeft <= 0) return { spacingMs: 0, waitMs: 0 };
+  if (remaining <= 0) return { spacingMs: 0, waitMs: msLeft + 1000 };
+
+  // Spread what is left across the time left. Self-correcting: the gap widens
+  // as the budget runs down and returns to the floor once the window rolls.
+  return { spacingMs: Math.min(msLeft / remaining, MAX_PACED_SPACING_MS), waitMs: 0 };
 }
 
 /** Generic MangaDex entity as it comes off the wire. */
@@ -279,6 +325,13 @@ export class MdClient implements MdExtendedApi {
   /** Serialises *slot acquisition* only; requests may still overlap in flight. */
   private gate: Promise<void> = Promise.resolve();
   private nextRequestAt = 0;
+  /**
+   * Spacing derived from the last response's rate-limit headers.
+   *
+   * Zero until MangaDex has told us something, so a fresh client runs at the
+   * configured floor rather than guessing at a budget it has not seen.
+   */
+  private pacedSpacingMs = 0;
 
   constructor(
     private readonly config: Config,
@@ -304,8 +357,36 @@ export class MdClient implements MdExtendedApi {
     await previous;
     const wait = this.nextRequestAt - Date.now();
     if (wait > 0) await sleep(wait);
-    this.nextRequestAt = Date.now() + this.config.mdRatelimitMs;
+    // The configured interval is a FLOOR, not the pace. What MangaDex says is
+    // left of the budget decides the rest; see paceFromHeaders.
+    this.nextRequestAt = Date.now() + Math.max(this.config.mdRatelimitMs, this.pacedSpacingMs);
     release();
+  }
+
+  /**
+   * Pace from what MangaDex says is left, instead of from a fixed guess.
+   *
+   * Every response carries `x-ratelimit-remaining` and, as a unix timestamp,
+   * `x-ratelimit-retry-after` for when the window resets. Spreading what is
+   * left over the time remaining is self-correcting: spacing widens as the
+   * budget runs down and returns to the floor once the window rolls.
+   *
+   * This is also the only honest way to pace THIS system. The limit is per IP
+   * and the gate is per process, so core-api, core-processor and core-uploader
+   * each held their own metronome and none of them could see the other two
+   * spending the same budget. A fixed interval had to be set for the worst
+   * case, which is why it sat at 2s -- a tenth of what MangaDex allows -- and
+   * every card paid twelve seconds of waiting for it. These headers describe
+   * the SHARED budget, so all three observe the same depletion and back off
+   * together without knowing about each other.
+   */
+  private paceFromHeaders(headers: Headers): void {
+    const paced = pacedSpacing(headers, Date.now());
+    if (!paced) return;
+    this.pacedSpacingMs = paced.spacingMs;
+    // Spent. Waiting for the reset here costs one pause; spending it is a 429
+    // for whichever caller gets there first.
+    if (paced.waitMs > 0) this.delayGate(paced.waitMs);
   }
 
   /** Push the gate out so every pending caller respects a server-side pause. */
@@ -415,6 +496,9 @@ export class MdClient implements MdExtendedApi {
         }
       }
       const status = response.status;
+      // Every response, not just the 429s. Learning only from rejections means
+      // only ever finding the limit by crossing it.
+      this.paceFromHeaders(response.headers);
 
       if (successfulCodes.includes(status) || (status >= 200 && status < 300)) {
         return { status, data };

--- a/src/services/uploader.ts
+++ b/src/services/uploader.ts
@@ -71,10 +71,29 @@ function retryDelaySeconds(attempt: number): number {
  * the two (see UploadTaskWorkers.flushQueueSummary). `claimed` is what decides
  * whether the loop sleeps, since a pass that only failed still did I/O.
  */
+/**
+ * How many tasks of one kind a single pass may take before yielding.
+ *
+ * Without a bound, `drain` empties its kind completely before returning, and
+ * the kinds are visited in a fixed order. A bulk backfill therefore owns the
+ * uploader for as long as it takes: 2,425 re-cards at roughly twenty seconds
+ * each is thirteen hours during which UPLOAD is never looked at again, so a
+ * chapter published in the meantime simply waits. That is the queue "not doing
+ * anything" while plainly being busy.
+ *
+ * UNAVAILABLE gets the small slice because it is the bulk verb -- cards are
+ * backfill, and nobody is waiting on one the way a reader waits on a chapter.
+ * The others keep a large budget: they are ordinary work, and yielding after
+ * every hundred costs a claim query.
+ */
+const DEFAULT_DRAIN_BUDGET = 100;
+const DRAIN_BUDGET: Partial<Record<UploadTaskKind, number>> = { UNAVAILABLE: 10 };
+
 async function drain(kind: UploadTaskKind): Promise<{ processed: number; failed: number }> {
   let processed = 0;
   let failed = 0;
-  while (running) {
+  const budget = DRAIN_BUDGET[kind] ?? DEFAULT_DRAIN_BUDGET;
+  while (running && processed + failed < budget) {
     const task = await tasks.claim(kind, LEASE_TTL_SECONDS);
     if (!task) break;
     const leaseId = task.leaseId ?? "";

--- a/test/unit/pacedSpacing.test.ts
+++ b/test/unit/pacedSpacing.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { pacedSpacing } from "../../src/core/md/client.js";
+
+/**
+ * How hard this platform hits MangaDex.
+ *
+ * The pace used to be a fixed interval, and it had to be set for the worst
+ * case: the limit is per IP while the gate is per process, so core-api,
+ * core-processor and core-uploader each kept a private metronome and none of
+ * them could see the other two spending the same allowance. It sat at 2000ms,
+ * a tenth of what MangaDex permits, and every card paid about twelve seconds
+ * of pure waiting for it.
+ *
+ * These headers describe the SHARED budget, so all three observe the same
+ * depletion and back off together without knowing about each other. That makes
+ * this arithmetic the thing standing between a fast platform and a banned one,
+ * which is why it is a pure function with its own tests rather than something
+ * only exercised by a client that really sleeps.
+ */
+describe("pacedSpacing", () => {
+  const headers = (values: Record<string, string>): Headers => new Headers(values);
+  const NOW = 1_000_000_000_000;
+
+  it("says nothing when the headers are absent", () => {
+    // Not every route sends them, and a missing header is not a reading of
+    // zero: the caller keeps the pace it had rather than inventing one.
+    expect(pacedSpacing(headers({}), NOW)).toBeNull();
+  });
+
+  it("says nothing when the headers are not numbers", () => {
+    expect(
+      pacedSpacing(headers({ "x-ratelimit-remaining": "lots", "x-ratelimit-retry-after": "soon" }), NOW),
+    ).toBeNull();
+  });
+
+  it("spreads what is left across the time left", () => {
+    // 10 requests, 5 seconds: one every 500ms.
+    const paced = pacedSpacing(
+      headers({
+        "x-ratelimit-remaining": "10",
+        "x-ratelimit-retry-after": String((NOW + 5_000) / 1000),
+      }),
+      NOW,
+    );
+    expect(paced).toEqual({ spacingMs: 500, waitMs: 0 });
+  });
+
+  it("widens as the budget runs down", () => {
+    const early = pacedSpacing(
+      headers({ "x-ratelimit-remaining": "40", "x-ratelimit-retry-after": String((NOW + 20_000) / 1000) }),
+      NOW,
+    );
+    const late = pacedSpacing(
+      headers({ "x-ratelimit-remaining": "4", "x-ratelimit-retry-after": String((NOW + 20_000) / 1000) }),
+      NOW,
+    );
+    expect(early?.spacingMs).toBe(500);
+    expect(late?.spacingMs).toBe(5_000);
+    expect(late!.spacingMs).toBeGreaterThan(early!.spacingMs);
+  });
+
+  it("waits for the reset once the budget is spent", () => {
+    // Nothing left. Pausing here costs one wait; spending it costs a 429 for
+    // whichever caller happens to arrive first.
+    const paced = pacedSpacing(
+      headers({ "x-ratelimit-remaining": "0", "x-ratelimit-retry-after": String((NOW + 3_000) / 1000) }),
+      NOW,
+    );
+    expect(paced?.waitMs).toBe(4_000);
+    expect(paced?.spacingMs).toBe(0);
+  });
+
+  it("falls back to the floor once the window has rolled", () => {
+    // A stale reading describes a window that is already over, and pacing off
+    // it would keep the client slow for no reason.
+    const paced = pacedSpacing(
+      headers({ "x-ratelimit-remaining": "1", "x-ratelimit-retry-after": String((NOW - 10_000) / 1000) }),
+      NOW,
+    );
+    expect(paced).toEqual({ spacingMs: 0, waitMs: 0 });
+  });
+
+  it("caps the gap rather than stalling on arithmetic", () => {
+    // One request left and ten minutes to go computes a ten-minute gap. Past
+    // the cap, waiting for the reset is the better trade than pacing to it.
+    const paced = pacedSpacing(
+      headers({ "x-ratelimit-remaining": "1", "x-ratelimit-retry-after": String((NOW + 600_000) / 1000) }),
+      NOW,
+    );
+    expect(paced?.spacingMs).toBe(5_000);
+  });
+});


### PR DESCRIPTION
You asked why the upload queue was idle, why it was so slow, and to raise the limits using MangaDex's own headers. Three things, and the first is a real bug my re-card sweep exposed.

## 1. A bulk backfill starved the other queues

`drain(kind)` loops with no bound — it empties its kind completely before returning — and `KIND_ORDER` visits kinds in a fixed sequence. Once the uploader entered the UNAVAILABLE drain with 2,425 tasks it stayed there: at ~20s per card that is **~13 hours inside one call**, during which UPLOAD is never re-checked. A chapter published meanwhile simply waits. Nothing stuck; the loop never comes back round.

Each pass now takes a bounded slice and yields. UNAVAILABLE gets the small budget because it is the bulk verb — cards are backfill, and nobody waits on one the way a reader waits on a chapter.

## 2. Pace from the headers, not a fixed guess

The limit is **per IP**; the gate is **per process**. `core-api`, `core-processor` and `core-uploader` each kept a private metronome and none could see the other two spending the same allowance — so the interval had to be set for the worst case. That is how it reached `2000ms`, a tenth of what MangaDex permits, and why each re-card paid ~12s of pure waiting across its six calls.

Every response carries `x-ratelimit-remaining` and a reset timestamp. Spreading what is left across the time left is self-correcting: the gap widens as the budget runs down and returns to the floor once the window rolls. Those headers describe the **shared** budget, so all three processes back off together without knowing about each other — exactly what a fixed interval cannot do.

- read on **every** response, not just 429s: learning only from rejections means only ever finding the limit by crossing it
- `remaining: 0` waits for the reset — one pause beats a 429 for whoever arrives first
- spacing is capped, so "1 left, 10 minutes to go" does not stall a drain on arithmetic
- `mdRatelimitMs` becomes a **floor**, dropped to `250ms`

## 3. Not answered here: "next first"

`claim` orders `not_before ASC` — oldest eligible first, FIFO within a kind. Right for a backfill, wrong when new work lands behind it. The bounded drain fixes starvation *across* kinds; making newer chapters jump the queue *within* one needs an explicit priority column, which I have deliberately not added — that is a design decision worth making rather than assuming.

## Tests

The pacing arithmetic is a pure exported function with its own suite, because it decides how hard this platform hits MangaDex and deserves better than being exercised through a client that really sleeps.

It paid for itself on the first run: **`Number(null)` is `0`, which is perfectly finite**, so testing only the parse read a *missing* header as "nothing remaining". A route sending no budget headers would have been paced as exhausted, and one sending only a reset stamp would have triggered a wait nothing asked for.

7 new tests, **913/913** overall, tsc and eslint clean.

## Deploying this

`MANGADEX_RATELIMIT_MS=2000` is set explicitly in the server `.env` and **overrides the new default**. Remove or lower that line, or nothing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6