### PR TITLE
Stop waiting on the read to confirm a re-card

### DIFF
--- a/src/core/md/taskWorkers.ts
+++ b/src/core/md/taskWorkers.ts
@@ -815,6 +815,24 @@ export class UploadTaskWorkers {
       if (echoedAPage || echoedAWrite) return;
     }
 
+    // Re-cards stop here. The echo above is free; the read below is not, and
+    // for a re-card it cannot take the fast path at all: the page count stays
+    // at one, and MangaDex's commit echo reports a STALE version (it said 7
+    // for a chapter that had reached 13). So every re-card fell through to the
+    // read loop and sat out MangaDex's cache -- 15 to 20 seconds of sleeping,
+    // which was two thirds of the time a re-card took and the reason a 2,425
+    // chapter sweep was measured in days.
+    //
+    // What that bought was small. A re-card replaces an image on a chapter
+    // already carded, so a silent failure leaves the OLD card in place rather
+    // than a live chapter looking dead. The dangerous direction -- a card that
+    // never landed on a live chapter -- is the first-card case, which keeps its
+    // confirmation because the echoed page count settles it without waiting.
+    if (before.pages > 0) {
+      log.info({ mdChapterId }, "re-card committed; not waiting on the read to confirm it");
+      return;
+    }
+
     let pages: number | null = null;
     let version: number | null = null;
 


### PR DESCRIPTION
You deleted `MANGADEX_RATELIMIT_MS=2000` and the rate did not move — 2.0/min before, 2.0/min after. So my confident diagnosis was wrong, and the timings show where the time actually goes:

```
upload session committed  →  +20.0s  →  unavailable card regenerated
                          →  +14.5s  →
                          →  +14.6s  →
```

Those cluster at multiples of five seconds because that is `CARD_CONFIRM_DELAY_MS`. **15–20s of each ~30s card was `confirmCardLanded` sleeping out MangaDex's read cache**, against ~10s for everything before the commit.

## Why the fast path never fired

A re-card cannot take it, by construction:

- `echoedAPage` needs `before.pages === 0`, but a re-card starts at 1
- `echoedAWrite` needs a bumped version, and the commit echo reports a **stale** one — it said `7` for the chapter that had actually reached `13`

So both cheap checks fail every time and every re-card fell through to the expensive read.

## What changes

Re-cards keep the free echo check and skip the read loop. First cards keep full confirmation.

The asymmetry is the point. A re-card replaces an image on a chapter that is *already carded*, so a silent failure leaves the **old card** up — not a live chapter looking dead. The dangerous direction is a first card that never lands, and that case is settled by the echoed page count without waiting for anything.

The catalogue-wide check added earlier already audits this class after the fact, which is a better layer for it than a synchronous read per chapter.

## Tests

913/913 unit, 45/45 on the chapters integration file — that stub cards from `pages: 0`, so it exercises the first-card path that still confirms.

Expected effect: ~30s per card down to ~10s, so the remaining ~700 finish in roughly two hours instead of six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1z9pyVdxzrW7NuqQbdnz6