### PR TITLE
Spread a run's uploads across days instead of queueing them all due now

### DIFF
--- a/src/core/api/dashboard/app.js
+++ b/src/core/api/dashboard/app.js
@@ -6684,6 +6684,9 @@ VIEWS.extensions = (route) => {
   const throttle = new Resource("fetch-throttle", () =>
     can("settings:read") ? api("/fetch-throttle", { quiet: true }) : Promise.resolve(null),
   );
+  const uploadSchedule = new Resource("upload-schedule", () =>
+    can("settings:read") ? api("/upload-schedule", { quiet: true }) : Promise.resolve(null),
+  );
 
   return el(
     "div",
@@ -6712,6 +6715,27 @@ VIEWS.extensions = (route) => {
             reserve: 40,
             skeleton: () => el("div", { class: "skeleton skeleton-line", style: { height: "34px" } }),
           }),
+        )
+      : null,
+    can("settings:read")
+      ? card(
+          "Release pacing",
+          el("p", {
+            class: "dim small",
+            text:
+              "How many chapters may go up per day. A run still queues everything it decided in " +
+              "one pass; whatever is over a day's budget is dated forward instead of going up at " +
+              "once, so this changes when a chapter is released, never whether it is. 0 is no " +
+              "limit, not a stop. Extensions can override this individually on their own Config tab.",
+          }),
+          live(
+            [uploadSchedule],
+            (data) => (data ? uploadScheduleControls(data, uploadSchedule) : el("span", {})),
+            {
+              reserve: 40,
+              skeleton: () => el("div", { class: "skeleton skeleton-line", style: { height: "34px" } }),
+            },
+          ),
         )
       : null,
     can("bundles:write") ? publishCard(extensions) : null,
@@ -6912,6 +6936,167 @@ function extensionThrottleControls(name, data, resource) {
               minIntervalMs: Number(interval.value),
               jitter: jitter.checked,
               jitterRatio: Number(ratio.value),
+            },
+            event,
+          ),
+      }),
+      // An empty body clears, which is NOT the same as saving the current
+      // global into the override: a cleared extension tracks the global later.
+      overridden
+        ? gatedButton("settings:write", {
+            text: "Follow global",
+            onclick: (event) => post({}, event),
+          })
+        : el("span", {}),
+    ),
+    el("p", {
+      class: overridden ? "warn-text small" : "dim small",
+      text: overridden
+        ? `Overridden for ${name}: ${Object.keys(override).join(", ")}. Changes to the global will not reach it.`
+        : `Following the global. Saving an override pins ${name} to these values.`,
+    }),
+  ]);
+}
+
+/**
+ * The global release-spreading controls.
+ *
+ * Bounds mirror the server's, which enforces them again: this stops a typo at
+ * the keyboard, not a bad request. The 0 floor on the two caps is the one that
+ * needs saying out loud, and the card above says it: 0 is no limit, so the
+ * whole run goes up the moment it is decided. Read the other way round — as a
+ * cap of nothing — it would look like the field that stops uploads, which is
+ * not a thing this setting can do.
+ */
+function uploadScheduleControls(data, resource) {
+  const values = data.global ?? data.defaults ?? {};
+  const perDay = el("input", {
+    id: "schedule-per-day",
+    type: "number",
+    min: "0",
+    max: "100000",
+    step: "1",
+    value: String(values.perDay ?? 50),
+    "aria-label": "Chapters released per day, 0 for no limit",
+  });
+  const perManga = el("input", {
+    id: "schedule-per-manga",
+    type: "number",
+    min: "0",
+    max: "100000",
+    step: "1",
+    value: String(values.perMangaPerDay ?? 3),
+    "aria-label": "Chapters released per day for one series, 0 for no limit",
+  });
+  const interval = el("input", {
+    id: "schedule-interval",
+    type: "number",
+    min: "1",
+    max: "720",
+    step: "1",
+    value: String(values.intervalHours ?? 24),
+    "aria-label": "Hours between release days",
+  });
+
+  const overrides = Object.keys(data.overrides ?? {});
+  return el("div", {}, [
+    row(
+      el("label", { class: "inline", for: "schedule-per-day", text: "Per day" }),
+      perDay,
+      el("label", { class: "inline", for: "schedule-per-manga", text: "Per series per day" }),
+      perManga,
+      el("label", { class: "inline", for: "schedule-interval", text: "Gap between days (h)" }),
+      interval,
+      gatedButton("settings:write", {
+        text: "Save",
+        onclick: (event) =>
+          act(
+            "upload-schedule.set",
+            () =>
+              api("/upload-schedule", {
+                method: "POST",
+                body: {
+                  perDay: Number(perDay.value),
+                  perMangaPerDay: Number(perManga.value),
+                  intervalHours: Number(interval.value),
+                },
+              }),
+            { button: event.currentTarget, refresh: [resource] },
+          ),
+      }),
+    ),
+    // Named rather than counted, for the reason the pacing card above names
+    // them: a number does not tell an operator whether the global they are
+    // editing reaches the extension whose backlog they are worried about.
+    overrides.length
+      ? el("p", {
+          class: "dim small",
+          text: `Overridden for: ${overrides.join(", ")}. Those extensions ignore the fields they set here.`,
+        })
+      : el("p", { class: "dim small", text: "No extension overrides; every extension follows this." }),
+  ]);
+}
+
+/**
+ * One extension's release-spreading override.
+ *
+ * Seeded from the EFFECTIVE values and labelled in words for the same reasons
+ * as the fetch pacing override above: a filled-in field looks identical
+ * whether it came from the global or from an override, and only one of the two
+ * follows the global when it changes.
+ */
+function extensionUploadScheduleControls(name, data, resource) {
+  const override = (data.overrides ?? {})[name] ?? {};
+  const overridden = Object.keys(override).length > 0;
+  const effective = { ...(data.defaults ?? {}), ...(data.global ?? {}), ...override };
+
+  const perDay = el("input", {
+    type: "number",
+    min: "0",
+    max: "100000",
+    step: "1",
+    value: String(effective.perDay ?? 50),
+    "aria-label": `Chapters released per day for ${name}, 0 for no limit`,
+  });
+  const perManga = el("input", {
+    type: "number",
+    min: "0",
+    max: "100000",
+    step: "1",
+    value: String(effective.perMangaPerDay ?? 3),
+    "aria-label": `Chapters released per day for one ${name} series, 0 for no limit`,
+  });
+  const interval = el("input", {
+    type: "number",
+    min: "1",
+    max: "720",
+    step: "1",
+    value: String(effective.intervalHours ?? 24),
+    "aria-label": `Hours between release days for ${name}`,
+  });
+
+  const post = (body, event) =>
+    act("upload-schedule.set", () => api(`/upload-schedule/${encodeURIComponent(name)}`, { method: "POST", body }), {
+      button: event.currentTarget,
+      refresh: [resource],
+    });
+
+  return el("div", {}, [
+    row(
+      el("span", { class: "inline", text: "Per day" }),
+      perDay,
+      el("span", { class: "inline", text: "Per series per day" }),
+      perManga,
+      el("span", { class: "inline", text: "Gap between days (h)" }),
+      interval,
+      gatedButton("settings:write", {
+        text: "Override",
+        onclick: (event) =>
+          post(
+            {
+              perDay: Number(perDay.value),
+              perMangaPerDay: Number(perManga.value),
+              intervalHours: Number(interval.value),
             },
             event,
           ),
@@ -7743,6 +7928,9 @@ function configPanel(name) {
   const throttle = new Resource(`throttle:${name}`, () =>
     can("settings:read") ? api("/fetch-throttle", { quiet: true }) : Promise.resolve(null),
   );
+  const schedule = new Resource(`upload-schedule:${name}`, () =>
+    can("settings:read") ? api("/upload-schedule", { quiet: true }) : Promise.resolve(null),
+  );
   const writable = can("extensions:write");
 
   return el(
@@ -7761,6 +7949,27 @@ function configPanel(name) {
           live(
             [throttle],
             (data) => (data ? extensionThrottleControls(name, data, throttle) : el("span", {})),
+            {
+              reserve: 40,
+              skeleton: () => el("div", { class: "skeleton skeleton-line", style: { height: "34px" } }),
+            },
+          ),
+        )
+      : null,
+    can("settings:read")
+      ? card(
+          "Release pacing",
+          el("p", {
+            class: "dim small",
+            text:
+              "How many of this extension's chapters may go up per day. A run still queues " +
+              "everything it decided; whatever is over the day's budget is dated forward rather " +
+              "than released at once, and 0 is no limit. Set here it overrides the global on " +
+              "System, field by field; cleared, this extension follows the global as it changes.",
+          }),
+          live(
+            [schedule],
+            (data) => (data ? extensionUploadScheduleControls(name, data, schedule) : el("span", {})),
             {
               reserve: 40,
               skeleton: () => el("div", { class: "skeleton skeleton-line", style: { height: "34px" } }),

--- a/src/core/api/routes/admin.ts
+++ b/src/core/api/routes/admin.ts
@@ -34,7 +34,11 @@ import { countOutstandingErrors } from "../../observability/errorFeed.js";
  * reads was never passed to core-api at all.
  */
 const WORKER_IMAGE = process.env["PUBLOADER_WORKER_IMAGE"] ?? "ardax/publoader-worker:latest";
-import { DEFAULT_FETCH_THROTTLE, VALID_REMOVAL_MODES } from "../../store/settings.js";
+import {
+  DEFAULT_FETCH_THROTTLE,
+  DEFAULT_UPLOAD_SCHEDULE,
+  VALID_REMOVAL_MODES,
+} from "../../store/settings.js";
 import { BundleRejectedError } from "../../store/bundles.js";
 import { MapSyncService } from "../../mapsync/service.js";
 import AdmZip from "adm-zip";
@@ -646,6 +650,66 @@ export function registerAdminRoutes(app: FastifyInstance, ctx: AppContext): void
         await ctx.settings.setFetchThrottleOverride(name, clearing ? null : body);
         const applied = await ctx.settings.getFetchThrottle(name);
         await ctx.audit.record(actor(req), "fetch_throttle.set", name, {
+          cleared: clearing,
+          ...applied,
+        });
+        return { ok: true, extension: name, cleared: clearing, effective: applied };
+      },
+    );
+
+    // ---- upload release spreading ----
+
+    /**
+     * How many chapters a run may put on MangaDex per day.
+     *
+     * Operator infrastructure for the same reason the fetch throttle is: the
+     * extension decides what is publishable, the operator decides how fast that
+     * reaches readers. Spreading only changes a task's `not_before`, so nothing
+     * is dropped and a routine run — well under the caps — is unaffected.
+     */
+    scope.get(
+      "/api/v1/admin/upload-schedule",
+      { preHandler: requireScope("settings:read") },
+      async () => ({
+        global: await ctx.settings.getUploadSchedule(),
+        overrides: await ctx.settings.getUploadScheduleOverrides(),
+        defaults: DEFAULT_UPLOAD_SCHEDULE,
+      }),
+    );
+
+    // 0 is allowed and means "no limit"; the store clamps the rest.
+    const uploadScheduleBody = z
+      .object({
+        perDay: z.coerce.number().int().min(0).max(100_000).optional(),
+        perMangaPerDay: z.coerce.number().int().min(0).max(100_000).optional(),
+        intervalHours: z.coerce.number().int().min(1).max(24 * 30).optional(),
+      })
+      .strict();
+
+    scope.post(
+      "/api/v1/admin/upload-schedule",
+      { preHandler: requireScope("settings:write") },
+      async (req) => {
+        const body = uploadScheduleBody.parse(req.body);
+        await ctx.settings.setUploadSchedule(body);
+        const applied = await ctx.settings.getUploadSchedule();
+        await ctx.audit.record(actor(req), "upload_schedule.set", "global", applied);
+        return { ok: true, global: applied };
+      },
+    );
+
+    /** One extension's override; an empty body clears it, as above. */
+    scope.post(
+      "/api/v1/admin/upload-schedule/:name",
+      { preHandler: requireScope("settings:write") },
+      async (req, reply) => {
+        const { name } = req.params as { name: string };
+        if (!EXTENSION_NAME_RE.test(name)) return reply.code(400).send({ error: "bad name" });
+        const body = uploadScheduleBody.parse(req.body ?? {});
+        const clearing = Object.keys(body).length === 0;
+        await ctx.settings.setUploadScheduleOverride(name, clearing ? null : body);
+        const applied = await ctx.settings.getUploadSchedule(name);
+        await ctx.audit.record(actor(req), "upload_schedule.set", name, {
           cleared: clearing,
           ...applied,
         });

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -18,6 +18,7 @@ import { ExtensionConfigStore } from "../store/extensionConfig.js";
 import { ResultStore } from "../store/results.js";
 import { AuditLog, SettingsStore, type RemovalMode } from "../store/settings.js";
 import { UploadTaskStore, uploadDedupeKey } from "../store/uploadTasks.js";
+import { planUploadSchedule, summariseSchedule } from "./uploadSchedule.js";
 import {
   aggregateChapterIds,
   backfillVolumes,
@@ -493,6 +494,8 @@ export class RunProcessor {
     // catalogue, or just at the handful of series with new chapters?" — a
     // question the per-manga lines below cannot answer once they are quiet.
     const totals = { visited: 0, upload: 0, edit: 0, skip: 0, remove: 0, unfetchable: 0 };
+    /** Every chapter this run decided to upload, queued after the loop. */
+    const pendingUploads: Chapter[] = [];
 
     for (const [mangaId, updatedChapters] of visiting) {
       const chaptersOnMd = await this.md.chaptersForManga(mangaId, groupId);
@@ -529,9 +532,10 @@ export class RunProcessor {
         botUserId: this.botUserId,
       });
 
-      for (const chapter of decision.toUpload) {
-        await this.tasks.enqueue("UPLOAD", uploadDedupeKey(chapter), chapter);
-      }
+      // Held rather than queued here: the release schedule caps how many
+      // chapters a day takes across every series, which cannot be decided one
+      // series at a time. Queued together once the loop has seen them all.
+      pendingUploads.push(...decision.toUpload);
       for (const edit of decision.toEdit) {
         await this.tasks.enqueue("EDIT", edit.mdChapterId, {
           ...edit.chapter,
@@ -602,6 +606,39 @@ export class RunProcessor {
         },
         "manga processed",
       );
+    }
+
+    // Queue the run's uploads, spread across days when there are enough of them
+    // to matter. A routine run is well under the caps and every chapter comes
+    // out due now, exactly as before; a backlog is dated forward instead of
+    // landing on MangaDex all at once. Either way every chapter is queued here
+    // and none is recomputed later: a future-dated row is an ordinary PENDING
+    // task waiting for its date.
+    if (pendingUploads.length > 0) {
+      const schedule = await this.settings.getUploadSchedule(run.extension);
+      const scheduled = planUploadSchedule(pendingUploads, schedule);
+      const shape = summariseSchedule(scheduled);
+
+      for (const { chapter, notBefore } of scheduled) {
+        await this.tasks.enqueue("UPLOAD", uploadDedupeKey(chapter), chapter, { notBefore });
+      }
+
+      if (shape.deferred > 0) {
+        log.info(
+          {
+            queued: scheduled.length,
+            immediate: shape.immediate,
+            deferred: shape.deferred,
+            days: shape.days,
+            lastRelease: shape.lastDate,
+            perDay: schedule.perDay,
+            perMangaPerDay: schedule.perMangaPerDay,
+          },
+          "spreading this run's uploads over several days",
+        );
+      } else {
+        log.debug({ queued: scheduled.length }, "queued this run's uploads, all due now");
+      }
     }
 
     // "Untracked" is derived from the union of every segment's tracked ids, so

--- a/src/core/processor/uploadSchedule.ts
+++ b/src/core/processor/uploadSchedule.ts
@@ -1,0 +1,209 @@
+/**
+ * Deciding which day each newly-decided chapter is due on.
+ *
+ * The queue already had everything needed to run work later: `upload_tasks`
+ * carries `not_before`, the claim query reads
+ * `WHERE state = 'PENDING' AND not_before <= now() ORDER BY not_before ASC`,
+ * and `enqueue` is `ON CONFLICT DO NOTHING`. What was missing is that nothing
+ * ever set `not_before` to anything but `now()`, so every chapter a run decided
+ * became due the instant it was decided.
+ *
+ * That is right for a routine day — a couple of dozen chapters, all immediate —
+ * and wrong for the two cases that produce hundreds at once: an operator
+ * tracking a batch of new series, and the first run after an outage. Those
+ * flood MangaDex's latest-updates feed and sit in the upload queue in front of
+ * every ordinary update behind them.
+ *
+ * So this spreads the overflow across days instead. Nothing is dropped or
+ * withheld: every chapter is queued in the same pass, and a future-dated row is
+ * an ordinary PENDING task the claim query ignores until its date arrives.
+ * Because `enqueue` does nothing on conflict, a later run re-deciding the same
+ * chapter leaves the date it already has — the schedule is set once and stands.
+ */
+
+import type { UploadSchedule } from "../store/settings.js";
+
+/** The little a chapter must expose to be scheduled. */
+export interface SchedulableChapter {
+  /** Grouping key: the MangaDex title, falling back to the publisher's id. */
+  mdMangaId?: string | null;
+  mangaId?: string | null;
+  chapterNumber?: string | null;
+  chapterTimestamp?: string | Date | null;
+  chapterId?: string | null;
+}
+
+export interface ScheduledChapter<T> {
+  chapter: T;
+  /** When the task becomes claimable. Day 0 is `now`, i.e. immediately. */
+  notBefore: Date;
+  /** 0 for "today"; mostly here so a run can log the shape of what it queued. */
+  day: number;
+}
+
+/** Series with no id of any kind share one bucket rather than each being alone. */
+function mangaKey(chapter: SchedulableChapter): string {
+  return chapter.mdMangaId ?? chapter.mangaId ?? "";
+}
+
+function timestampOf(chapter: SchedulableChapter): number {
+  const raw = chapter.chapterTimestamp;
+  if (raw === null || raw === undefined) return Number.POSITIVE_INFINITY;
+  const parsed = raw instanceof Date ? raw.getTime() : Date.parse(raw);
+  return Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed;
+}
+
+/**
+ * Oldest first, then by chapter number, so a spread backlog is released in
+ * reading order rather than scattered.
+ */
+function compareChapters(a: SchedulableChapter, b: SchedulableChapter): number {
+  const at = timestampOf(a);
+  const bt = timestampOf(b);
+  if (at !== bt) return at - bt;
+
+  const an = Number(a.chapterNumber);
+  const bn = Number(b.chapterNumber);
+  const aValid = a.chapterNumber !== null && a.chapterNumber !== undefined && !Number.isNaN(an);
+  const bValid = b.chapterNumber !== null && b.chapterNumber !== undefined && !Number.isNaN(bn);
+  if (aValid && bValid && an !== bn) return an - bn;
+  if (aValid !== bValid) return aValid ? -1 : 1;
+
+  return (a.chapterId ?? "").localeCompare(b.chapterId ?? "");
+}
+
+/** 0 means "no limit" for both caps, matching `UploadSchedule`'s documented 0. */
+function limitOf(value: number): number {
+  return value > 0 ? value : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Assign every chapter a release day.
+ *
+ * Filling is round-robin over series, oldest chapter first, advancing a day
+ * when either cap is reached. Round-robin is the part that matters: filling one
+ * series at a time would put a single 300-chapter backlog in front of every
+ * other series for a week, so a title that published one new chapter today
+ * would wait behind it. Going a slice at a time per series keeps today's
+ * chapter on today.
+ *
+ * Ordering is stable — series sorted by key, chapters oldest-first — so the same
+ * input always produces the same schedule.
+ */
+export function planUploadSchedule<T extends SchedulableChapter>(
+  chapters: readonly T[],
+  schedule: UploadSchedule,
+  now: Date = new Date(),
+): ScheduledChapter<T>[] {
+  if (chapters.length === 0) return [];
+
+  const perDay = limitOf(schedule.perDay);
+  const perMangaPerDay = limitOf(schedule.perMangaPerDay);
+  const intervalMs = Math.max(1, schedule.intervalHours) * 60 * 60 * 1000;
+
+  // No caps: everything is due now, which is exactly the old behaviour.
+  if (perDay === Number.POSITIVE_INFINITY && perMangaPerDay === Number.POSITIVE_INFINITY) {
+    return chapters.map((chapter) => ({ chapter, notBefore: new Date(now), day: 0 }));
+  }
+
+  const queues = new Map<string, T[]>();
+  for (const chapter of chapters) {
+    const key = mangaKey(chapter);
+    const queue = queues.get(key);
+    if (queue) queue.push(chapter);
+    else queues.set(key, [chapter]);
+  }
+
+  const keys = [...queues.keys()].sort();
+  for (const key of keys) queues.get(key)!.sort(compareChapters);
+
+  const cursors = new Map<string, number>(keys.map((key) => [key, 0]));
+  const out: ScheduledChapter<T>[] = [];
+
+  let day = 0;
+  let remaining = chapters.length;
+
+  while (remaining > 0) {
+    let placedToday = 0;
+    const placedPerManga = new Map<string, number>();
+
+    // One pass per round so series interleave; repeated until the day is full
+    // or nothing more fits in it.
+    let progressed = true;
+    while (progressed && placedToday < perDay) {
+      progressed = false;
+
+      for (const key of keys) {
+        if (placedToday >= perDay) break;
+
+        const queue = queues.get(key)!;
+        const cursor = cursors.get(key)!;
+        if ((placedPerManga.get(key) ?? 0) >= perMangaPerDay) continue;
+
+        const next = queue[cursor];
+        if (next === undefined) continue;
+
+        out.push({
+          chapter: next,
+          notBefore: new Date(now.getTime() + day * intervalMs),
+          day,
+        });
+        cursors.set(key, cursor + 1);
+        placedPerManga.set(key, (placedPerManga.get(key) ?? 0) + 1);
+        placedToday++;
+        remaining--;
+        progressed = true;
+      }
+    }
+
+    // Nothing fitted in a whole day: only reachable if both caps are zero-ish,
+    // which `limitOf` already rules out. Guard anyway so this cannot spin.
+    if (placedToday === 0) {
+      for (const key of keys) {
+        const queue = queues.get(key)!;
+        for (let i = cursors.get(key)!; i < queue.length; i++) {
+          const chapter = queue[i];
+          if (chapter === undefined) continue;
+          out.push({
+            chapter,
+            notBefore: new Date(now.getTime() + day * intervalMs),
+            day,
+          });
+        }
+        cursors.set(key, queue.length);
+      }
+      break;
+    }
+
+    day++;
+  }
+
+  return out;
+}
+
+/** How many chapters land on each day, for the run log. */
+export function summariseSchedule<T>(scheduled: readonly ScheduledChapter<T>[]): {
+  immediate: number;
+  deferred: number;
+  days: number;
+  lastDate: string | null;
+} {
+  let immediate = 0;
+  let maxDay = 0;
+  let lastDate: string | null = null;
+
+  for (const entry of scheduled) {
+    if (entry.day === 0) immediate++;
+    if (entry.day >= maxDay) {
+      maxDay = entry.day;
+      lastDate = entry.notBefore.toISOString();
+    }
+  }
+
+  return {
+    immediate,
+    deferred: scheduled.length - immediate,
+    days: scheduled.length === 0 ? 0 : maxDay + 1,
+    lastDate,
+  };
+}

--- a/src/core/store/settings.ts
+++ b/src/core/store/settings.ts
@@ -46,8 +46,81 @@ const REMOVAL_MODE_KEY = "chapter_removal_mode";
 const SIGNUPS_KEY = "dash_signups_enabled";
 const WEBHOOK_SUCCESSES_KEY = "webhook_upload_successes";
 const GITHUB_AUTO_SYNC_KEY = "github_auto_sync";
+const UPLOAD_SCHEDULE_KEY = "upload_schedule";
+const UPLOAD_SCHEDULE_OVERRIDES_KEY = "upload_schedule_overrides";
+
 const FETCH_THROTTLE_KEY = "fetch_throttle";
 const FETCH_THROTTLE_OVERRIDES_KEY = "fetch_throttle_overrides";
+
+/**
+ * How many chapters a run may put on MangaDex *today*, and how the rest are
+ * dated.
+ *
+ * This is spread, not suppression: every decided chapter is queued in the same
+ * pass either way, and `perDay` only decides which of them are due now and
+ * which carry a future `not_before`. A future-dated task is an ordinary PENDING
+ * row the claim query ignores until its date arrives, so nothing is dropped,
+ * retried, or recomputed to make it happen.
+ *
+ * The reason to want it: a routine day is a couple of dozen chapters and lands
+ * immediately, but tracking a batch of new series, or the first run after an
+ * outage, decides hundreds at once. Those flood MangaDex's latest-updates feed
+ * and sit in front of every ordinary update in the upload queue.
+ */
+export interface UploadSchedule {
+  /** Chapters dated to a given day, across every series. 0 disables spreading. */
+  perDay: number;
+  /**
+   * Chapters dated to a given day for one series.
+   *
+   * Separate from `perDay` because the two failure modes differ: `perDay`
+   * protects the feed and the queue, `perMangaPerDay` stops one series' backlog
+   * from being the only thing anyone sees for a week.
+   */
+  perMangaPerDay: number;
+  /** Gap between successive release days. */
+  intervalHours: number;
+}
+
+export const DEFAULT_UPLOAD_SCHEDULE: UploadSchedule = {
+  perDay: 50,
+  perMangaPerDay: 3,
+  intervalHours: 24,
+};
+
+/**
+ * Bounds, not preferences. `perDay: 0` is meaningful (spread nothing, the
+ * behaviour before this existed) so the floor is 0, not 1.
+ */
+function clampUploadSchedule(value: UploadSchedule): UploadSchedule {
+  const num = (raw: number, fallback: number, min: number, max: number): number =>
+    Number.isFinite(raw) ? Math.min(max, Math.max(min, Math.floor(raw))) : fallback;
+  return {
+    perDay: num(value.perDay, DEFAULT_UPLOAD_SCHEDULE.perDay, 0, 100_000),
+    perMangaPerDay: num(value.perMangaPerDay, DEFAULT_UPLOAD_SCHEDULE.perMangaPerDay, 0, 100_000),
+    intervalHours: num(value.intervalHours, DEFAULT_UPLOAD_SCHEDULE.intervalHours, 1, 24 * 30),
+  };
+}
+
+/** Reads whatever was stored without trusting any of it. */
+function parseUploadSchedule(raw: unknown): Partial<UploadSchedule> {
+  let value = raw;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  if (typeof value !== "object" || value === null) return {};
+  const record = value as Record<string, unknown>;
+  const out: Partial<UploadSchedule> = {};
+  for (const key of ["perDay", "perMangaPerDay", "intervalHours"] as const) {
+    const field = record[key];
+    if (typeof field === "number") out[key] = field;
+  }
+  return out;
+}
 
 /** How a worker paces itself against one publisher. */
 export interface FetchThrottle {
@@ -217,6 +290,48 @@ export class SettingsStore {
     if (values === null) delete overrides[extension];
     else overrides[extension] = values;
     await this.setSetting(FETCH_THROTTLE_OVERRIDES_KEY, JSON.stringify(overrides));
+  }
+
+  // -- upload release spreading --
+
+  /**
+   * Resolved global-then-override, field by field, exactly like the fetch
+   * throttle: an extension can slow its own releases without restating the
+   * limits it was already happy with.
+   */
+  async getUploadSchedule(extension?: string): Promise<UploadSchedule> {
+    const [globalRaw, overridesRaw] = await Promise.all([
+      this.getSetting(UPLOAD_SCHEDULE_KEY),
+      extension ? this.getSetting(UPLOAD_SCHEDULE_OVERRIDES_KEY) : Promise.resolve(null),
+    ]);
+    const base = { ...DEFAULT_UPLOAD_SCHEDULE, ...parseUploadSchedule(globalRaw) };
+    if (!extension) return clampUploadSchedule(base);
+    const overrides = parseRecord(overridesRaw);
+    return clampUploadSchedule({ ...base, ...parseUploadSchedule(overrides[extension]) });
+  }
+
+  async setUploadSchedule(values: Partial<UploadSchedule>): Promise<void> {
+    const next = clampUploadSchedule({ ...(await this.getUploadSchedule()), ...values });
+    await this.setSetting(UPLOAD_SCHEDULE_KEY, JSON.stringify(next));
+  }
+
+  /** Every per-extension override, for the editor to render. */
+  async getUploadScheduleOverrides(): Promise<Record<string, Partial<UploadSchedule>>> {
+    const parsed = parseRecord(await this.getSetting(UPLOAD_SCHEDULE_OVERRIDES_KEY));
+    const out: Record<string, Partial<UploadSchedule>> = {};
+    for (const [name, value] of Object.entries(parsed)) out[name] = parseUploadSchedule(value);
+    return out;
+  }
+
+  /** `null` removes the override, so the extension follows the global again. */
+  async setUploadScheduleOverride(
+    extension: string,
+    values: Partial<UploadSchedule> | null,
+  ): Promise<void> {
+    const overrides = await this.getUploadScheduleOverrides();
+    if (values === null) delete overrides[extension];
+    else overrides[extension] = values;
+    await this.setSetting(UPLOAD_SCHEDULE_OVERRIDES_KEY, JSON.stringify(overrides));
   }
 
   // -- dashboard self-signup gate --

--- a/src/core/store/uploadTasks.ts
+++ b/src/core/store/uploadTasks.ts
@@ -241,11 +241,28 @@ export class UploadTaskStore {
   constructor(private readonly prisma: PrismaClient) {}
 
   /** Enqueue if absent. Returns true when a new task row was created. */
-  async enqueue(kind: UploadTaskKind, dedupeKey: string, chapter: unknown): Promise<boolean> {
+  /**
+   * `opts.notBefore` dates the row into the future, which is how a run spreads
+   * a backlog instead of making every chapter due at once (see
+   * processor/uploadSchedule.ts). Omitted, the column default `now()` applies
+   * and the task is claimable immediately, as it always was.
+   *
+   * DO NOTHING is what makes a future date stick: a later run that decides the
+   * same chapter again leaves the existing row, and its date, alone. Nothing
+   * here can pull a scheduled task forward — `requeueForChapter` and `reorder`
+   * are the deliberate ways to do that.
+   */
+  async enqueue(
+    kind: UploadTaskKind,
+    dedupeKey: string,
+    chapter: unknown,
+    opts: { notBefore?: Date } = {},
+  ): Promise<boolean> {
     const res = await this.prisma.$executeRaw(Prisma.sql`
-      INSERT INTO upload_tasks (id, kind, dedupe_key, chapter, state, created_at, updated_at)
+      INSERT INTO upload_tasks (id, kind, dedupe_key, chapter, state, not_before, created_at, updated_at)
       VALUES (${randomUUID()}, ${kind}::"UploadTaskKind", ${dedupeKey},
-              ${JSON.stringify(chapter)}::jsonb, 'PENDING', now(), now())
+              ${JSON.stringify(chapter)}::jsonb, 'PENDING',
+              coalesce(${opts.notBefore ?? null}::timestamptz, now()), now(), now())
       ON CONFLICT (kind, dedupe_key) DO NOTHING
     `);
     return res === 1;

--- a/test/unit/dashboardUploadSchedule.test.ts
+++ b/test/unit/dashboardUploadSchedule.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The release pacing controls, global and per extension.
+ *
+ * Spreading a run's uploads across days is a setting an operator can read
+ * backwards: every field is a cap, and a cap of 0 reads as "release nothing"
+ * when it actually means "no limit". Getting that wrong on the global field is
+ * not a mistake anyone notices from the queue — a run still queues everything
+ * it decided either way, so the difference only shows up days later in what
+ * MangaDex has. So the copy is pinned here alongside the wiring.
+ *
+ * The per-extension half has its own trap: the inputs are seeded from the
+ * EFFECTIVE values, so an extension following the global shows the global's
+ * numbers, and saving that form would pin them. Hence a test that an override
+ * really does merge over the global, and one that "Follow global" clears with
+ * an empty body rather than writing the numbers on screen back.
+ *
+ * Driven the same way as dashboardMapSync.test.ts: the real app.js evaluated
+ * under jsdom against a stubbed API. See dashboardChapters.test.ts's header for
+ * why app.js is a classic script and how it is mounted.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any --
+   The DOM lib is deliberately kept out of this program (see the same note in
+   dashboardModules.test.ts), so the jsdom globals, and every node read back out
+   of them below, are loosely typed in this file only. */
+const doc: any = (globalThis as any).document;
+const win: any = globalThis;
+
+const DASHBOARD = resolve(process.cwd(), "src/core/api/dashboard");
+const APP_JS = join(DASHBOARD, "app.js");
+const INDEX_HTML = join(DASHBOARD, "index.html");
+
+/**
+ * A global that is not the defaults, and one extension pinned to its own
+ * `perDay`. Every number differs from every other so a field read out of the
+ * wrong one is visible rather than accidentally correct.
+ */
+const SCHEDULE = {
+  global: { perDay: 60, perMangaPerDay: 2, intervalHours: 12 },
+  overrides: { viz: { perDay: 10 } },
+  defaults: { perDay: 50, perMangaPerDay: 3, intervalHours: 24 },
+};
+
+/** Swapped per test so the scope gate can be exercised. */
+let scopes: string[] = ["*"];
+/** Every request app.js made, in order, with the body it sent. */
+let calls: { path: string; method: string; body: any }[] = [];
+
+function apiRoutes(): { match: RegExp; body: unknown }[] {
+  return [
+    { match: /\/session$/, body: { actor: "ardax", role: "OWNER", userId: "u1", email: "a@b.c" } },
+    {
+      match: /\/whoami$/,
+      body: {
+        kind: "session",
+        name: "ardax",
+        role: "OWNER",
+        scopes,
+        csrfHeader: "x-requested-with",
+        csrfValue: "publoader-dash",
+      },
+    },
+    {
+      match: /\/stats$/,
+      body: { paused: false, workers: {}, jobs: {}, uploadTasks: [], quarantined: 0 },
+    },
+    { match: /\/runs\?limit=1/, body: { runs: [] } },
+    { match: /\/removal-mode$/, body: { mode: "DELETE", validModes: ["DELETE", "IGNORE"] } },
+    {
+      match: /\/fetch-throttle/,
+      body: {
+        global: { minIntervalMs: 500, jitter: true, jitterRatio: 0.5 },
+        overrides: {},
+        defaults: { minIntervalMs: 500, jitter: true, jitterRatio: 0.5 },
+      },
+    },
+    { match: /\/upload-schedule/, body: SCHEDULE },
+    { match: /\/extensions\/[^/]+\/config$/, body: { mangadexLanguages: ["en"], passthrough: {} } },
+    { match: /\/extensions$/, body: { extensions: [{ name: "mangaplus" }, { name: "viz" }] } },
+  ];
+}
+
+function installFetch(): void {
+  const routes = apiRoutes();
+  win.fetch = vi.fn(async (url: string, init: any = {}) => {
+    const path = String(url);
+    let body: any = null;
+    try {
+      body = init.body ? JSON.parse(init.body) : null;
+    } catch {
+      body = init.body;
+    }
+    calls.push({ path, method: init.method ?? "GET", body });
+    const route = routes.find((r) => r.match.test(path));
+    return {
+      ok: Boolean(route),
+      status: route ? 200 : 404,
+      statusText: route ? "OK" : "Not Found",
+      text: async () => JSON.stringify(route ? route.body : {}),
+    };
+  });
+}
+
+async function settle(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+async function goto(hash: string): Promise<void> {
+  win.location.hash = hash;
+  await settle();
+}
+
+function mount(): void {
+  const html = readFileSync(INDEX_HTML, "utf8");
+  const body = html.split("<body>")[1]?.split("</body>")[0];
+  if (!body) throw new Error("index.html has no <body>: the dashboard shell cannot be mounted");
+  doc.body.innerHTML = body;
+  win.location.hash = "";
+  installFetch();
+  // Evaluated rather than imported: app.js is deliberately a classic script
+  // ending in `void boot()`, so this is how a browser runs it. The source is
+  // this repo's own file read from disk; nothing is interpolated into it.
+  new Function(readFileSync(APP_JS, "utf8")).call(win);
+}
+
+/**
+ * The most recently rendered card whose heading is `title`.
+ *
+ * Last, not first: every test in this file evaluates app.js again on the one
+ * jsdom window, so earlier instances can leave their own nodes behind.
+ */
+function cardByTitle(title: string): any {
+  const cards = [...doc.querySelectorAll("section.card")].filter(
+    (c: any) => c.querySelector("h2")?.textContent === title,
+  );
+  return cards[cards.length - 1];
+}
+
+const buttonLabelled = (root: any, text: string): any =>
+  [...root.querySelectorAll("button")].find((b: any) => b.textContent === text);
+
+/** The card's three number inputs, in the order they are drawn. */
+const numbers = (card: any): string[] =>
+  [...card.querySelectorAll('input[type="number"]')].map((i: any) => i.value);
+
+const scheduleWrites = (): { path: string; method: string; body: any }[] =>
+  calls.filter((c) => c.method === "POST" && c.path.includes("/upload-schedule"));
+
+describe("release pacing is editable from the dashboard", () => {
+  beforeEach(async () => {
+    calls = [];
+    scopes = ["*"];
+    mount();
+    await settle(10);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  it("shows the global schedule beside the fetch pacing it is not", async () => {
+    await goto("#/extensions");
+    const card = cardByTitle("Release pacing");
+    expect(card).toBeTruthy();
+    expect(numbers(card)).toEqual(["60", "2", "12"]);
+    // An addition, not a replacement: the two pacing settings are different
+    // things and the operator needs both on the page.
+    expect(cardByTitle("Publisher fetch pacing")).toBeTruthy();
+  });
+
+  it("says what 0 does and that spreading never drops a chapter", async () => {
+    await goto("#/extensions");
+    const text = cardByTitle("Release pacing").textContent;
+    // The two readings that would cost an operator real chapters if they took
+    // the opposite one.
+    expect(text).toContain("0 is no limit");
+    expect(text).toContain("never whether it is");
+  });
+
+  it("names the extensions that will ignore the global", async () => {
+    await goto("#/extensions");
+    expect(cardByTitle("Release pacing").textContent).toContain("Overridden for: viz");
+  });
+
+  it("saves all three fields together", async () => {
+    await goto("#/extensions");
+    const card = cardByTitle("Release pacing");
+    const [perDay, perManga, interval] = [...card.querySelectorAll('input[type="number"]')];
+    perDay.value = "80";
+    perManga.value = "0";
+    interval.value = "6";
+
+    calls = [];
+    buttonLabelled(card, "Save").click();
+    await settle();
+
+    expect(scheduleWrites()).toHaveLength(1);
+    const [write] = scheduleWrites();
+    expect(write?.path).toContain("/upload-schedule");
+    // 0 is sent as 0, not dropped as falsy: it is a value the endpoint accepts
+    // and means something different from leaving the field alone.
+    expect(write?.body).toEqual({ perDay: 80, perMangaPerDay: 0, intervalHours: 6 });
+  });
+
+  it("seeds an extension's form with what that extension actually uses", async () => {
+    await goto("#/extensions/viz/config");
+    const card = cardByTitle("Release pacing");
+    expect(card).toBeTruthy();
+    // perDay from the override, the other two from the global it merges over.
+    expect(numbers(card)).toEqual(["10", "2", "12"]);
+    expect(card.textContent).toContain("Overridden for viz");
+  });
+
+  it("clears an override with an empty body rather than the numbers on screen", async () => {
+    await goto("#/extensions/viz/config");
+    const card = cardByTitle("Release pacing");
+
+    calls = [];
+    buttonLabelled(card, "Follow global").click();
+    await settle();
+
+    expect(scheduleWrites()).toHaveLength(1);
+    expect(scheduleWrites()[0]?.path).toContain("/upload-schedule/viz");
+    // Not `{ perDay: 10, ... }`: writing the effective values back would pin
+    // viz to today's global instead of letting it track tomorrow's.
+    expect(scheduleWrites()[0]?.body).toEqual({});
+  });
+
+  it("offers no way to unfollow a global an extension is already following", async () => {
+    await goto("#/extensions/mangaplus/config");
+    const card = cardByTitle("Release pacing");
+    expect(numbers(card)).toEqual(["60", "2", "12"]);
+    expect(card.textContent).toContain("Following the global");
+    expect(buttonLabelled(card, "Follow global")).toBeUndefined();
+    expect(buttonLabelled(card, "Override")).toBeTruthy();
+  });
+
+  it("hides the card from a credential that cannot read settings", async () => {
+    scopes = ["extensions:read", "runs:read"];
+    mount();
+    await settle(10);
+    await goto("#/extensions");
+    expect(cardByTitle("Release pacing")).toBeUndefined();
+  });
+});

--- a/test/unit/uploadSchedule.test.ts
+++ b/test/unit/uploadSchedule.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  planUploadSchedule,
+  summariseSchedule,
+  type SchedulableChapter,
+} from "../../src/core/processor/uploadSchedule.js";
+import {
+  DEFAULT_UPLOAD_SCHEDULE,
+  type UploadSchedule,
+} from "../../src/core/store/settings.js";
+
+const NOW = new Date("2026-08-30T00:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const chapter = (
+  mdMangaId: string,
+  chapterId: string,
+  chapterNumber: string,
+  dayPublished = 1,
+): SchedulableChapter => ({
+  mdMangaId,
+  chapterId,
+  chapterNumber,
+  chapterTimestamp: new Date(NOW.getTime() - dayPublished * DAY_MS).toISOString(),
+});
+
+const schedule = (over: Partial<UploadSchedule> = {}): UploadSchedule => ({
+  ...DEFAULT_UPLOAD_SCHEDULE,
+  ...over,
+});
+
+/** Day offsets keyed by chapter id, which is what most assertions care about. */
+const daysById = (
+  scheduled: readonly { chapter: SchedulableChapter; day: number }[],
+): Record<string, number> =>
+  Object.fromEntries(scheduled.map((entry) => [entry.chapter.chapterId!, entry.day]));
+
+describe("planUploadSchedule", () => {
+  it("makes a routine run entirely immediate", () => {
+    // The case that must not regress: a normal day is far under the caps, so
+    // every chapter comes out due now exactly as it did before scheduling.
+    const chapters = Array.from({ length: 20 }, (_, i) => chapter(`m${i}`, `c${i}`, "1"));
+    const scheduled = planUploadSchedule(chapters, schedule(), NOW);
+
+    expect(scheduled).toHaveLength(20);
+    expect(scheduled.every((entry) => entry.day === 0)).toBe(true);
+    expect(scheduled.every((entry) => entry.notBefore.getTime() === NOW.getTime())).toBe(true);
+  });
+
+  it("queues every chapter, deferred ones included", () => {
+    const chapters = Array.from({ length: 30 }, (_, i) => chapter("m1", `c${i}`, String(i + 1), 30 - i));
+    const scheduled = planUploadSchedule(chapters, schedule({ perMangaPerDay: 3 }), NOW);
+
+    // Nothing is dropped: spreading is about the date, never about the set.
+    expect(scheduled).toHaveLength(30);
+    expect(new Set(scheduled.map((e) => e.chapter.chapterId)).size).toBe(30);
+  });
+
+  it("spreads one series' backlog over days at its per-series cap", () => {
+    const chapters = Array.from({ length: 7 }, (_, i) => chapter("m1", `c${i}`, String(i + 1), 7 - i));
+    const scheduled = planUploadSchedule(chapters, schedule({ perMangaPerDay: 3 }), NOW);
+
+    const days = daysById(scheduled);
+    expect([days.c0, days.c1, days.c2]).toEqual([0, 0, 0]);
+    expect([days.c3, days.c4, days.c5]).toEqual([1, 1, 1]);
+    expect(days.c6).toBe(2);
+  });
+
+  it("releases a backlog oldest first, so it reads in order", () => {
+    const chapters = [
+      chapter("m1", "new", "3", 1),
+      chapter("m1", "old", "1", 10),
+      chapter("m1", "mid", "2", 5),
+    ];
+    const scheduled = planUploadSchedule(chapters, schedule({ perMangaPerDay: 1 }), NOW);
+    expect(scheduled.map((e) => e.chapter.chapterId)).toEqual(["old", "mid", "new"]);
+    expect(scheduled.map((e) => e.day)).toEqual([0, 1, 2]);
+  });
+
+  it("does not let one series' backlog delay another series' new chapter", () => {
+    // The reason filling is round-robin rather than series-at-a-time: "m1" has
+    // a 10-chapter backfill, "m2" published one chapter today. m2 must not wait
+    // behind the backfill.
+    const backlog = Array.from({ length: 10 }, (_, i) => chapter("m1", `b${i}`, String(i + 1), 20 - i));
+    const fresh = chapter("m2", "fresh", "42", 0);
+    const scheduled = planUploadSchedule([...backlog, fresh], schedule({ perMangaPerDay: 2 }), NOW);
+
+    expect(daysById(scheduled).fresh).toBe(0);
+  });
+
+  it("caps the whole day across series", () => {
+    const chapters = Array.from({ length: 10 }, (_, i) => chapter(`m${i}`, `c${i}`, "1"));
+    const scheduled = planUploadSchedule(chapters, schedule({ perDay: 4 }), NOW);
+
+    const perDay = new Map<number, number>();
+    for (const entry of scheduled) perDay.set(entry.day, (perDay.get(entry.day) ?? 0) + 1);
+    expect(perDay.get(0)).toBe(4);
+    expect(perDay.get(1)).toBe(4);
+    expect(perDay.get(2)).toBe(2);
+  });
+
+  it("dates deferred chapters by the configured interval", () => {
+    const chapters = [chapter("m1", "a", "1", 2), chapter("m1", "b", "2", 1)];
+    const scheduled = planUploadSchedule(
+      chapters,
+      schedule({ perMangaPerDay: 1, intervalHours: 6 }),
+      NOW,
+    );
+
+    expect(scheduled[0]!.notBefore.getTime()).toBe(NOW.getTime());
+    expect(scheduled[1]!.notBefore.getTime()).toBe(NOW.getTime() + 6 * 60 * 60 * 1000);
+  });
+
+  it("treats a zero cap as no limit, not as a stop switch", () => {
+    // A zero that meant "release nothing" would silently halt all uploads.
+    const chapters = Array.from({ length: 200 }, (_, i) => chapter("m1", `c${i}`, String(i + 1)));
+    const scheduled = planUploadSchedule(
+      chapters,
+      schedule({ perDay: 0, perMangaPerDay: 0 }),
+      NOW,
+    );
+
+    expect(scheduled).toHaveLength(200);
+    expect(scheduled.every((entry) => entry.day === 0)).toBe(true);
+  });
+
+  it("is stable: the same input yields the same schedule", () => {
+    const chapters = Array.from({ length: 12 }, (_, i) =>
+      chapter(`m${i % 3}`, `c${i}`, String(i + 1), 12 - i),
+    );
+    const opts = schedule({ perDay: 5, perMangaPerDay: 2 });
+    const first = planUploadSchedule(chapters, opts, NOW);
+    const second = planUploadSchedule(chapters, opts, NOW);
+    expect(daysById(second)).toEqual(daysById(first));
+  });
+
+  it("groups by publisher id when there is no MangaDex id yet", () => {
+    const chapters = [
+      { mangaId: "p1", chapterId: "a", chapterNumber: "1", chapterTimestamp: null },
+      { mangaId: "p1", chapterId: "b", chapterNumber: "2", chapterTimestamp: null },
+    ];
+    const scheduled = planUploadSchedule(chapters, schedule({ perMangaPerDay: 1 }), NOW);
+    expect(scheduled.map((e) => e.day)).toEqual([0, 1]);
+  });
+
+  it("handles an empty run", () => {
+    expect(planUploadSchedule([], schedule(), NOW)).toEqual([]);
+  });
+});
+
+describe("summariseSchedule", () => {
+  it("counts immediate against deferred", () => {
+    const chapters = Array.from({ length: 5 }, (_, i) => chapter("m1", `c${i}`, String(i + 1), 5 - i));
+    const scheduled = planUploadSchedule(chapters, schedule({ perMangaPerDay: 2 }), NOW);
+    const shape = summariseSchedule(scheduled);
+
+    expect(shape.immediate).toBe(2);
+    expect(shape.deferred).toBe(3);
+    expect(shape.days).toBe(3);
+    expect(shape.lastDate).toBe(new Date(NOW.getTime() + 2 * DAY_MS).toISOString());
+  });
+
+  it("reports nothing deferred for a routine run", () => {
+    const scheduled = planUploadSchedule([chapter("m1", "a", "1")], schedule(), NOW);
+    expect(summariseSchedule(scheduled)).toMatchObject({ immediate: 1, deferred: 0, days: 1 });
+  });
+
+  it("is empty for an empty run", () => {
+    expect(summariseSchedule([])).toEqual({
+      immediate: 0,
+      deferred: 0,
+      days: 0,
+      lastDate: null,
+    });
+  });
+});


### PR DESCRIPTION
The queue could already run work later and never did. upload_tasks carries not_before, the claim query is `state = 'PENDING' AND not_before <= now() ORDER BY not_before ASC`, and enqueue is ON CONFLICT DO NOTHING -- but nothing ever set not_before to anything but now(), so every chapter a run decided became claimable the instant it was decided.

That is right for a routine day and wrong for the two cases that decide hundreds at once: tracking a batch of new series, and the first run after an outage. Those flood MangaDex's latest-updates feed and sit in the upload queue in front of every ordinary update behind them.

So a run now dates its overflow forward. This is spread, not suppression: every decided chapter is queued in the same pass either way, and a future-dated row is an ordinary PENDING task the claim query ignores until its date arrives. Nothing is dropped, retried, or recomputed to make it happen, and because enqueue does nothing on conflict, a later run deciding the same chapter again leaves the date it already has -- the schedule is set once and stands.

planUploadSchedule fills round-robin over series, oldest chapter first, advancing a day when either cap is hit. Round-robin is the part that matters: filling one series at a time would put a 300-chapter backfill in front of every other series for a week, so a title that published one chapter today would wait behind it. Oldest-first means a spread backlog is released in reading order.

Defaults (50/day overall, 3/day per series) sit well above steady state, so a routine run comes out entirely immediate exactly as before; a zero cap means "no limit" rather than "release nothing", which would silently halt uploads. Resolved global-then-override per extension, and exposed on /api/v1/admin/upload-schedule, both mirroring the fetch throttle.

The processor now collects the run's uploads and queues them after the manga loop, because a per-day cap across every series cannot be decided one series at a time. Edits and removals are untouched and stay immediate.

No migration: not_before and its index already existed.

927 unit tests pass, typecheck and lint clean.


Claude-Session: https://claude.ai/code/session_012158jYiScGkEMpeszNdHi8